### PR TITLE
Add listing model and CRUD endpoints

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -173,3 +173,12 @@ model Payment {
 
   lease Lease @relation(fields: [leaseId], references: [id])
 }
+
+model Listing {
+  id          Int      @id @default(autoincrement())
+  title       String
+  description String
+  price       Float
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}

--- a/server/src/__tests__/listings.test.ts
+++ b/server/src/__tests__/listings.test.ts
@@ -1,0 +1,50 @@
+import request from "supertest";
+import express from "express";
+import listingsRouter from "../routes/listings";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+const app = express();
+app.use(express.json());
+app.use("/listings", listingsRouter);
+
+describe("Listings API", () => {
+  beforeEach(async () => {
+    await prisma.listing.deleteMany();
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("creates and retrieves a listing", async () => {
+    const createRes = await request(app)
+      .post("/listings")
+      .send({ title: "Bike", description: "Mountain bike", price: 100 });
+    expect(createRes.status).toBe(201);
+
+    const id = createRes.body.id;
+    const getRes = await request(app).get(`/listings/${id}`);
+    expect(getRes.status).toBe(200);
+    expect(getRes.body.title).toBe("Bike");
+  });
+
+  it("updates a listing", async () => {
+    const listing = await prisma.listing.create({
+      data: { title: "Old", description: "Old", price: 10 },
+    });
+    const res = await request(app)
+      .put(`/listings/${listing.id}`)
+      .send({ title: "New", description: "New", price: 20 });
+    expect(res.status).toBe(200);
+    expect(res.body.title).toBe("New");
+  });
+
+  it("deletes a listing", async () => {
+    const listing = await prisma.listing.create({
+      data: { title: "Trash", description: "To delete", price: 5 },
+    });
+    const res = await request(app).delete(`/listings/${listing.id}`);
+    expect(res.status).toBe(204);
+  });
+});

--- a/server/src/controllers/listings.ts
+++ b/server/src/controllers/listings.ts
@@ -1,0 +1,83 @@
+import { Request, Response } from "express";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+export const getListings = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const listings = await prisma.listing.findMany();
+    res.json(listings);
+  } catch (error: any) {
+    res
+      .status(500)
+      .json({ message: `Error retrieving listings: ${error.message}` });
+  }
+};
+
+export const getListing = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const listing = await prisma.listing.findUnique({
+      where: { id: Number(id) },
+    });
+    if (listing) {
+      res.json(listing);
+    } else {
+      res.status(404).json({ message: "Listing not found" });
+    }
+  } catch (error: any) {
+    res
+      .status(500)
+      .json({ message: `Error retrieving listing: ${error.message}` });
+  }
+};
+
+export const createListing = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { title, description, price } = req.body;
+    const listing = await prisma.listing.create({
+      data: {
+        title,
+        description,
+        price: Number(price),
+      },
+    });
+    res.status(201).json(listing);
+  } catch (error: any) {
+    res
+      .status(500)
+      .json({ message: `Error creating listing: ${error.message}` });
+  }
+};
+
+export const updateListing = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const { title, description, price } = req.body;
+    const listing = await prisma.listing.update({
+      where: { id: Number(id) },
+      data: {
+        title,
+        description,
+        price: Number(price),
+      },
+    });
+    res.json(listing);
+  } catch (error: any) {
+    res
+      .status(500)
+      .json({ message: `Error updating listing: ${error.message}` });
+  }
+};
+
+export const deleteListing = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { id } = req.params;
+    await prisma.listing.delete({ where: { id: Number(id) } });
+    res.status(204).send();
+  } catch (error: any) {
+    res
+      .status(500)
+      .json({ message: `Error deleting listing: ${error.message}` });
+  }
+};

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -11,6 +11,7 @@ import managerRoutes from "./routes/managerRoutes";
 import propertyRoutes from "./routes/propertyRoutes";
 import leaseRoutes from "./routes/leaseRoutes";
 import applicationRoutes from "./routes/applicationRoutes";
+import listingsRoutes from "./routes/listings";
 
 /* CONFIGURATIONS */
 dotenv.config();
@@ -31,6 +32,7 @@ app.get("/", (req, res) => {
 app.use("/applications", applicationRoutes);
 app.use("/properties", propertyRoutes);
 app.use("/leases", leaseRoutes);
+app.use("/listings", listingsRoutes);
 app.use("/tenants", authMiddleware(["tenant"]), tenantRoutes);
 app.use("/managers", authMiddleware(["manager"]), managerRoutes);
 

--- a/server/src/routes/listings.ts
+++ b/server/src/routes/listings.ts
@@ -1,0 +1,18 @@
+import express from "express";
+import {
+  getListings,
+  getListing,
+  createListing,
+  updateListing,
+  deleteListing,
+} from "../controllers/listings";
+
+const router = express.Router();
+
+router.get("/", getListings);
+router.get("/:id", getListing);
+router.post("/", createListing);
+router.put("/:id", updateListing);
+router.delete("/:id", deleteListing);
+
+export default router;


### PR DESCRIPTION
## Summary
- add `Listing` model to Prisma schema for simple listings
- implement CRUD controllers and routes for listings and register in server
- create basic Jest tests for listing API

## Testing
- `npm run build` *(fails: Cannot find module 'supertest'; missing Jest globals)*
- `npm test` *(fails: Missing script: "test")*
- `npx jest` *(fails: Need to install jest@30.0.5)*

------
https://chatgpt.com/codex/tasks/task_e_68970fb7b3d88328be70e57df2ac82d1