### PR TITLE
Add listing search page and components

### DIFF
--- a/client/app/listings/page.tsx
+++ b/client/app/listings/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import ListingCard, { Listing } from "@/components/ListingCard";
+import ListingForm from "@/components/forms/ListingForm";
+import { fetchListings } from "@/lib/api";
+
+const ListingsPage = () => {
+  const [listings, setListings] = useState<Listing[]>([]);
+  const [query, setQuery] = useState("");
+
+  const loadListings = useCallback(async () => {
+    const data = await fetchListings(query);
+    setListings(data);
+  }, [query]);
+
+  useEffect(() => {
+    loadListings();
+  }, [loadListings]);
+
+  return (
+    <div className="space-y-6 p-6">
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search listings..."
+        className="w-full rounded-md border p-2"
+      />
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {listings.map((listing) => (
+          <ListingCard key={listing.id} listing={listing} />
+        ))}
+      </div>
+      <ListingForm onSuccess={loadListings} />
+    </div>
+  );
+};
+
+export default ListingsPage;

--- a/client/components/ListingCard.tsx
+++ b/client/components/ListingCard.tsx
@@ -1,0 +1,35 @@
+import Image from "next/image";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+
+export interface Listing {
+  id: number | string;
+  title: string;
+  description: string;
+  price: number;
+  imageUrl?: string;
+}
+
+const ListingCard = ({ listing }: { listing: Listing }) => {
+  return (
+    <Card className="overflow-hidden">
+      {listing.imageUrl && (
+        <Image
+          src={listing.imageUrl}
+          alt={listing.title}
+          width={400}
+          height={200}
+          className="h-48 w-full object-cover"
+        />
+      )}
+      <CardHeader>
+        <CardTitle className="text-lg font-bold">{listing.title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="mb-2 text-sm text-gray-600">{listing.description}</p>
+        <p className="font-semibold">${listing.price}</p>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ListingCard;

--- a/client/components/forms/ListingForm.tsx
+++ b/client/components/forms/ListingForm.tsx
@@ -1,0 +1,40 @@
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { Form } from "@/components/ui/form";
+import { Button } from "@/components/ui/button";
+import { CustomFormField } from "../FormField";
+import { createListing } from "@/lib/api";
+
+const listingSchema = z.object({
+  title: z.string().min(1, "Title is required"),
+  description: z.string().min(1, "Description is required"),
+  price: z.coerce.number().positive("Price must be positive"),
+});
+
+export type ListingFormData = z.infer<typeof listingSchema>;
+
+const ListingForm = ({ onSuccess }: { onSuccess?: () => void }) => {
+  const form = useForm<ListingFormData>({
+    resolver: zodResolver(listingSchema),
+  });
+
+  const onSubmit = async (data: ListingFormData) => {
+    await createListing(data);
+    form.reset();
+    onSuccess?.();
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <CustomFormField name="title" label="Title" />
+        <CustomFormField name="description" label="Description" type="textarea" />
+        <CustomFormField name="price" label="Price" type="number" />
+        <Button type="submit">Submit</Button>
+      </form>
+    </Form>
+  );
+};
+
+export default ListingForm;

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -1,0 +1,17 @@
+import axios from "axios";
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:3002",
+});
+
+export const fetchListings = async (search?: string) => {
+  const response = await api.get("/properties", { params: { q: search } });
+  return response.data;
+};
+
+export const createListing = async (data: any) => {
+  const response = await api.post("/properties", data);
+  return response.data;
+};
+
+export default api;

--- a/client/src/app/listings/page.tsx
+++ b/client/src/app/listings/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import ListingCard, { Listing } from "@/components/ListingCard";
+import ListingForm from "@/components/forms/ListingForm";
+import { fetchListings } from "@/lib/api";
+
+const ListingsPage = () => {
+  const [listings, setListings] = useState<Listing[]>([]);
+  const [query, setQuery] = useState("");
+
+  const loadListings = useCallback(async () => {
+    const data = await fetchListings(query);
+    setListings(data);
+  }, [query]);
+
+  useEffect(() => {
+    loadListings();
+  }, [loadListings]);
+
+  return (
+    <div className="space-y-6 p-6">
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search listings..."
+        className="w-full rounded-md border p-2"
+      />
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {listings.map((listing) => (
+          <ListingCard key={listing.id} listing={listing} />
+        ))}
+      </div>
+      <ListingForm onSuccess={loadListings} />
+    </div>
+  );
+};
+
+export default ListingsPage;

--- a/client/src/components/ListingCard.tsx
+++ b/client/src/components/ListingCard.tsx
@@ -1,0 +1,35 @@
+import Image from "next/image";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+
+export interface Listing {
+  id: number | string;
+  title: string;
+  description: string;
+  price: number;
+  imageUrl?: string;
+}
+
+const ListingCard = ({ listing }: { listing: Listing }) => {
+  return (
+    <Card className="overflow-hidden">
+      {listing.imageUrl && (
+        <Image
+          src={listing.imageUrl}
+          alt={listing.title}
+          width={400}
+          height={200}
+          className="h-48 w-full object-cover"
+        />
+      )}
+      <CardHeader>
+        <CardTitle className="text-lg font-bold">{listing.title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="mb-2 text-sm text-gray-600">{listing.description}</p>
+        <p className="font-semibold">${listing.price}</p>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ListingCard;

--- a/client/src/components/forms/ListingForm.tsx
+++ b/client/src/components/forms/ListingForm.tsx
@@ -1,0 +1,40 @@
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { Form } from "@/components/ui/form";
+import { Button } from "@/components/ui/button";
+import { CustomFormField } from "../FormField";
+import { createListing } from "@/lib/api";
+
+const listingSchema = z.object({
+  title: z.string().min(1, "Title is required"),
+  description: z.string().min(1, "Description is required"),
+  price: z.coerce.number().positive("Price must be positive"),
+});
+
+export type ListingFormData = z.infer<typeof listingSchema>;
+
+const ListingForm = ({ onSuccess }: { onSuccess?: () => void }) => {
+  const form = useForm<ListingFormData>({
+    resolver: zodResolver(listingSchema),
+  });
+
+  const onSubmit = async (data: ListingFormData) => {
+    await createListing(data);
+    form.reset();
+    onSuccess?.();
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <CustomFormField name="title" label="Title" />
+        <CustomFormField name="description" label="Description" type="textarea" />
+        <CustomFormField name="price" label="Price" type="number" />
+        <Button type="submit">Submit</Button>
+      </form>
+    </Form>
+  );
+};
+
+export default ListingForm;

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,0 +1,17 @@
+import axios from "axios";
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:3002",
+});
+
+export const fetchListings = async (search?: string) => {
+  const response = await api.get("/properties", { params: { q: search } });
+  return response.data;
+};
+
+export const createListing = async (data: any) => {
+  const response = await api.post("/properties", data);
+  return response.data;
+};
+
+export default api;


### PR DESCRIPTION
## Summary
- add listing search page with form and results
- add reusable ListingCard and ListingForm components
- connect frontend to backend with axios API helper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: A `require()` style import is forbidden in app/tailwind.config.ts)*


------
https://chatgpt.com/codex/tasks/task_e_68970fb8d2b08328ae2af5bc6fdfa1a7