### PR TITLE
ci: conditionally deploy on main push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,31 @@ jobs:
         run: |
           cd client
           npm run test:e2e
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: e2e
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker registry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and push server image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v5
+        with:
+          context: ./server
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/garage-sale-server:latest
+      - name: Build and push client image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v5
+        with:
+          context: ./client
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/garage-sale-client:latest


### PR DESCRIPTION
## Summary
- add `deploy` job with conditional execution only on `main` push
- ensure docker login and publish steps run only when pushing to `main`

## Testing
- `npm run lint` (failed: A `require()` style import is forbidden)
- `npm run build` (failed: Cannot find module 'supertest')

------
https://chatgpt.com/codex/tasks/task_e_689726470ba883288cee44293073970a