### PR TITLE
Use owner-based image tags for CI containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
 
+env:
+  SERVER_IMAGE_LATEST: ghcr.io/${{ github.repository_owner }}/server:latest
+  CLIENT_IMAGE_LATEST: ghcr.io/${{ github.repository_owner }}/client:latest
+  SERVER_IMAGE_SHA: ghcr.io/${{ github.repository_owner }}/server:${{ github.sha }}
+  CLIENT_IMAGE_SHA: ghcr.io/${{ github.repository_owner }}/client:${{ github.sha }}
+
 jobs:
   e2e:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- declare container image references using `github.repository_owner`
- add commit SHA image tags for server and client

## Testing
- `npm run lint` *(fails: require() style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689726480334832883af6ce5d297fcd1