### PR TITLE
feat: unify property listing model

### DIFF
--- a/client/components/ListingCard.tsx
+++ b/client/components/ListingCard.tsx
@@ -3,30 +3,30 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 export interface Listing {
   id: number | string;
-  title: string;
+  name: string;
   description: string;
-  price: number;
-  imageUrl?: string;
+  pricePerMonth: number;
+  photoUrls?: string[];
 }
 
 const ListingCard = ({ listing }: { listing: Listing }) => {
   return (
     <Card className="overflow-hidden">
-      {listing.imageUrl && (
+      {listing.photoUrls?.[0] && (
         <Image
-          src={listing.imageUrl}
-          alt={listing.title}
+          src={listing.photoUrls[0]}
+          alt={listing.name}
           width={400}
           height={200}
           className="h-48 w-full object-cover"
         />
       )}
       <CardHeader>
-        <CardTitle className="text-lg font-bold">{listing.title}</CardTitle>
+        <CardTitle className="text-lg font-bold">{listing.name}</CardTitle>
       </CardHeader>
       <CardContent>
         <p className="mb-2 text-sm text-gray-600">{listing.description}</p>
-        <p className="font-semibold">${listing.price}</p>
+        <p className="font-semibold">${listing.pricePerMonth}</p>
       </CardContent>
     </Card>
   );

--- a/client/components/forms/ListingForm.tsx
+++ b/client/components/forms/ListingForm.tsx
@@ -7,9 +7,9 @@ import { CustomFormField } from "../FormField";
 import { createListing } from "@/lib/api";
 
 const listingSchema = z.object({
-  title: z.string().min(1, "Title is required"),
+  name: z.string().min(1, "Name is required"),
   description: z.string().min(1, "Description is required"),
-  price: z.coerce.number().positive("Price must be positive"),
+  pricePerMonth: z.coerce.number().positive("Price must be positive"),
 });
 
 export type ListingFormData = z.infer<typeof listingSchema>;
@@ -28,9 +28,9 @@ const ListingForm = ({ onSuccess }: { onSuccess?: () => void }) => {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-        <CustomFormField name="title" label="Title" />
+        <CustomFormField name="name" label="Property Name" />
         <CustomFormField name="description" label="Description" type="textarea" />
-        <CustomFormField name="price" label="Price" type="number" />
+        <CustomFormField name="pricePerMonth" label="Price per Month" type="number" />
         <Button type="submit">Submit</Button>
       </form>
     </Form>

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { mapPropertyToListing } from "./utils";
 
 const api = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:3002",
@@ -6,7 +7,7 @@ const api = axios.create({
 
 export const fetchListings = async (search?: string) => {
   const response = await api.get("/properties", { params: { q: search } });
-  return response.data;
+  return response.data.map(mapPropertyToListing);
 };
 
 export const createListing = async (data: any) => {

--- a/client/lib/utils.ts
+++ b/client/lib/utils.ts
@@ -1,6 +1,8 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { toast } from "sonner";
+import { Property } from "@/types/prismaTypes";
+import { Listing } from "@/components/ListingCard";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -34,6 +36,14 @@ export function cleanParams(params: Record<string, any>): Record<string, any> {
     )
   );
 }
+
+export const mapPropertyToListing = (property: Property): Listing => ({
+  id: property.id,
+  name: property.name,
+  description: property.description,
+  pricePerMonth: property.pricePerMonth,
+  photoUrls: property.photoUrls,
+});
 
 type MutationMessages = {
   success?: string;

--- a/client/src/components/ListingCard.tsx
+++ b/client/src/components/ListingCard.tsx
@@ -3,30 +3,30 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 export interface Listing {
   id: number | string;
-  title: string;
+  name: string;
   description: string;
-  price: number;
-  imageUrl?: string;
+  pricePerMonth: number;
+  photoUrls?: string[];
 }
 
 const ListingCard = ({ listing }: { listing: Listing }) => {
   return (
     <Card className="overflow-hidden">
-      {listing.imageUrl && (
+      {listing.photoUrls?.[0] && (
         <Image
-          src={listing.imageUrl}
-          alt={listing.title}
+          src={listing.photoUrls[0]}
+          alt={listing.name}
           width={400}
           height={200}
           className="h-48 w-full object-cover"
         />
       )}
       <CardHeader>
-        <CardTitle className="text-lg font-bold">{listing.title}</CardTitle>
+        <CardTitle className="text-lg font-bold">{listing.name}</CardTitle>
       </CardHeader>
       <CardContent>
         <p className="mb-2 text-sm text-gray-600">{listing.description}</p>
-        <p className="font-semibold">${listing.price}</p>
+        <p className="font-semibold">${listing.pricePerMonth}</p>
       </CardContent>
     </Card>
   );

--- a/client/src/components/forms/ListingForm.tsx
+++ b/client/src/components/forms/ListingForm.tsx
@@ -7,9 +7,9 @@ import { CustomFormField } from "../FormField";
 import { createListing } from "@/lib/api";
 
 const listingSchema = z.object({
-  title: z.string().min(1, "Title is required"),
+  name: z.string().min(1, "Name is required"),
   description: z.string().min(1, "Description is required"),
-  price: z.coerce.number().positive("Price must be positive"),
+  pricePerMonth: z.coerce.number().positive("Price must be positive"),
 });
 
 export type ListingFormData = z.infer<typeof listingSchema>;
@@ -28,9 +28,9 @@ const ListingForm = ({ onSuccess }: { onSuccess?: () => void }) => {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-        <CustomFormField name="title" label="Title" />
+        <CustomFormField name="name" label="Property Name" />
         <CustomFormField name="description" label="Description" type="textarea" />
-        <CustomFormField name="price" label="Price" type="number" />
+        <CustomFormField name="pricePerMonth" label="Price per Month" type="number" />
         <Button type="submit">Submit</Button>
       </form>
     </Form>

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { mapPropertyToListing } from "./utils";
 
 const api = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:3002",
@@ -6,7 +7,7 @@ const api = axios.create({
 
 export const fetchListings = async (search?: string) => {
   const response = await api.get("/properties", { params: { q: search } });
-  return response.data;
+  return response.data.map(mapPropertyToListing);
 };
 
 export const createListing = async (data: any) => {

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -1,6 +1,16 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
+import { Property } from "@/types/prismaTypes"
+import { Listing } from "@/components/ListingCard"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export const mapPropertyToListing = (property: Property): Listing => ({
+  id: property.id,
+  name: property.name,
+  description: property.description,
+  pricePerMonth: property.pricePerMonth,
+  photoUrls: property.photoUrls,
+})

--- a/client/tests/e2e/specs/listing-browsing.spec.ts
+++ b/client/tests/e2e/specs/listing-browsing.spec.ts
@@ -12,7 +12,7 @@ test.describe('Listing browsing flow', () => {
           <script>
             fetch('/properties').then(r=>r.json()).then(data=>{
               const div=document.getElementById('list');
-              div.innerHTML = '<div>' + data[0].name + '</div>';
+              div.innerHTML = '<div>' + data[0].name + ' - $' + data[0].pricePerMonth + '</div>';
             });
           </script>
         </body></html>`
@@ -26,13 +26,14 @@ test.describe('Listing browsing flow', () => {
         body: JSON.stringify([
           {
             id: 1,
-            name: 'Sample Property'
+            name: 'Sample Property',
+            pricePerMonth: 1500
           }
         ])
       });
     });
 
     await page.goto('http://localhost:3000/search');
-    await expect(page.getByText('Sample Property')).toBeVisible();
+    await expect(page.getByText('Sample Property - $1500')).toBeVisible();
   });
 });

--- a/client/tests/e2e/specs/listing-creation.spec.ts
+++ b/client/tests/e2e/specs/listing-creation.spec.ts
@@ -20,5 +20,6 @@ test.describe('Listing creation flow', () => {
     await page.getByLabel('Description').fill('Great place');
     await page.getByLabel('Price per Month').fill('1500');
     await expect(page.getByLabel('Property Name')).toHaveValue('Test Property');
+    await expect(page.getByLabel('Price per Month')).toHaveValue('1500');
   });
 });


### PR DESCRIPTION
## Summary
- map Property objects into UI-friendly Listing models
- render listings using property name, first photo, and monthly price
- align creation form and tests with unified model

## Testing
- `npm --prefix client run test:e2e` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_6898d62356148328ae833b898d7a07af