### PR TITLE
Handle missing properties with 404 response

### DIFF
--- a/server/src/__tests__/property.test.ts
+++ b/server/src/__tests__/property.test.ts
@@ -1,0 +1,25 @@
+import request from "supertest";
+import express from "express";
+import propertyRoutes from "../routes/propertyRoutes";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+const app = express();
+app.use(express.json());
+app.use("/properties", propertyRoutes);
+
+describe("Property API", () => {
+  beforeEach(async () => {
+    await prisma.property.deleteMany();
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("returns 404 for missing property", async () => {
+    const res = await request(app).get("/properties/9999");
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ message: "Property not found" });
+  });
+});

--- a/server/src/controllers/propertyControllers.ts
+++ b/server/src/controllers/propertyControllers.ts
@@ -167,9 +167,9 @@ export const getProperty = async (
       const coordinates: { coordinates: string }[] =
         await prisma.$queryRaw`SELECT ST_asText(coordinates) as coordinates from "Location" where id = ${property.location.id}`;
 
-      const geoJSON: any = wktToGeoJSON(coordinates[0]?.coordinates || "");
-      const longitude = geoJSON.coordinates[0];
-      const latitude = geoJSON.coordinates[1];
+    const geoJSON: any = wktToGeoJSON(coordinates[0]?.coordinates || "");
+    const longitude = geoJSON.coordinates[0];
+    const latitude = geoJSON.coordinates[1];
 
       const propertyWithCoordinates = {
         ...property,
@@ -182,6 +182,8 @@ export const getProperty = async (
         },
       };
       res.json(propertyWithCoordinates);
+    } else {
+      res.status(404).json({ message: "Property not found" });
     }
   } catch (err: any) {
     res


### PR DESCRIPTION
## Summary
- Return a 404 error when a requested property ID does not exist
- Add Jest test to verify 404 is returned for nonexistent property

## Testing
- `npx jest` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_6898d61d20048328b03deb46ae1537aa