### PR TITLE
refactor: centralize Prisma client instance

### DIFF
--- a/server/src/__tests__/listings.test.ts
+++ b/server/src/__tests__/listings.test.ts
@@ -1,9 +1,8 @@
 import request from "supertest";
 import express from "express";
 import listingsRouter from "../routes/listings";
-import { PrismaClient } from "@prisma/client";
+import prisma from "../prisma";
 
-const prisma = new PrismaClient();
 const app = express();
 app.use(express.json());
 app.use("/listings", listingsRouter);

--- a/server/src/controllers/applicationControllers.ts
+++ b/server/src/controllers/applicationControllers.ts
@@ -1,7 +1,5 @@
 import { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import prisma from "../prisma";
 
 export const listApplications = async (
   req: Request,

--- a/server/src/controllers/leaseControllers.ts
+++ b/server/src/controllers/leaseControllers.ts
@@ -1,7 +1,5 @@
 import { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import prisma from "../prisma";
 
 export const getLeases = async (req: Request, res: Response): Promise<void> => {
   try {

--- a/server/src/controllers/listings.ts
+++ b/server/src/controllers/listings.ts
@@ -1,7 +1,5 @@
 import { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import prisma from "../prisma";
 
 export const getListings = async (req: Request, res: Response): Promise<void> => {
   try {

--- a/server/src/controllers/managerControllers.ts
+++ b/server/src/controllers/managerControllers.ts
@@ -1,8 +1,6 @@
 import { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
+import prisma from "../prisma";
 import { wktToGeoJSON } from "@terraformer/wkt";
-
-const prisma = new PrismaClient();
 
 export const getManager = async (
   req: Request,

--- a/server/src/controllers/propertyControllers.ts
+++ b/server/src/controllers/propertyControllers.ts
@@ -1,12 +1,11 @@
 import { Request, Response } from "express";
-import { PrismaClient, Prisma } from "@prisma/client";
+import prisma from "../prisma";
+import { Prisma, Location } from "@prisma/client";
 import { wktToGeoJSON } from "@terraformer/wkt";
 import { S3Client } from "@aws-sdk/client-s3";
-import { Location } from "@prisma/client";
 import { Upload } from "@aws-sdk/lib-storage";
 import axios from "axios";
 
-const prisma = new PrismaClient();
 
 const s3Client = new S3Client({
   region: process.env.AWS_REGION,

--- a/server/src/controllers/tenantControllers.ts
+++ b/server/src/controllers/tenantControllers.ts
@@ -1,8 +1,6 @@
 import { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
+import prisma from "../prisma";
 import { wktToGeoJSON } from "@terraformer/wkt";
-
-const prisma = new PrismaClient();
 
 export const getTenant = async (req: Request, res: Response): Promise<void> => {
   try {

--- a/server/src/prisma.ts
+++ b/server/src/prisma.ts
@@ -1,0 +1,6 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+export default prisma;
+


### PR DESCRIPTION
## Summary
- add shared Prisma client to avoid multiple connections
- update controllers and tests to use the shared client

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'supertest' or type definitions for test runner)*

------
https://chatgpt.com/codex/tasks/task_e_6898d61b156483289d89e5ffb804171d