### PR TITLE
feat: add RTK Query listings API

### DIFF
--- a/client/app/listings/page.tsx
+++ b/client/app/listings/page.tsx
@@ -1,22 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
-import ListingCard, { Listing } from "@/components/ListingCard";
+import { useState } from "react";
+import ListingCard from "@/components/ListingCard";
 import ListingForm from "@/components/forms/ListingForm";
-import { fetchListings } from "@/lib/api";
+import { useFetchListingsQuery } from "@/state/api";
 
 const ListingsPage = () => {
-  const [listings, setListings] = useState<Listing[]>([]);
   const [query, setQuery] = useState("");
-
-  const loadListings = useCallback(async () => {
-    const data = await fetchListings(query);
-    setListings(data);
-  }, [query]);
-
-  useEffect(() => {
-    loadListings();
-  }, [loadListings]);
+  const { data: listings = [], error, refetch } = useFetchListingsQuery(query);
 
   return (
     <div className="space-y-6 p-6">
@@ -27,12 +18,15 @@ const ListingsPage = () => {
         placeholder="Search listings..."
         className="w-full rounded-md border p-2"
       />
+      {error && (
+        <p className="text-sm text-red-500">Failed to load listings.</p>
+      )}
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {listings.map((listing) => (
           <ListingCard key={listing.id} listing={listing} />
         ))}
       </div>
-      <ListingForm onSuccess={loadListings} />
+      <ListingForm onSuccess={refetch} />
     </div>
   );
 };

--- a/client/components/forms/ListingForm.tsx
+++ b/client/components/forms/ListingForm.tsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 import { Form } from "@/components/ui/form";
 import { Button } from "@/components/ui/button";
 import { CustomFormField } from "../FormField";
-import { createListing } from "@/lib/api";
+import { useCreateListingMutation } from "@/state/api";
 
 const listingSchema = z.object({
   title: z.string().min(1, "Title is required"),
@@ -19,10 +19,16 @@ const ListingForm = ({ onSuccess }: { onSuccess?: () => void }) => {
     resolver: zodResolver(listingSchema),
   });
 
+  const [createListing] = useCreateListingMutation();
+
   const onSubmit = async (data: ListingFormData) => {
-    await createListing(data);
-    form.reset();
-    onSuccess?.();
+    try {
+      await createListing(data).unwrap();
+      form.reset();
+      onSuccess?.();
+    } catch (error) {
+      console.error("Failed to create listing", error);
+    }
   };
 
   return (

--- a/client/src/app/listings/page.tsx
+++ b/client/src/app/listings/page.tsx
@@ -1,22 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
-import ListingCard, { Listing } from "@/components/ListingCard";
+import { useState } from "react";
+import ListingCard from "@/components/ListingCard";
 import ListingForm from "@/components/forms/ListingForm";
-import { fetchListings } from "@/lib/api";
+import { useFetchListingsQuery } from "@/state/api";
 
 const ListingsPage = () => {
-  const [listings, setListings] = useState<Listing[]>([]);
   const [query, setQuery] = useState("");
-
-  const loadListings = useCallback(async () => {
-    const data = await fetchListings(query);
-    setListings(data);
-  }, [query]);
-
-  useEffect(() => {
-    loadListings();
-  }, [loadListings]);
+  const { data: listings = [], error, refetch } = useFetchListingsQuery(query);
 
   return (
     <div className="space-y-6 p-6">
@@ -27,12 +18,15 @@ const ListingsPage = () => {
         placeholder="Search listings..."
         className="w-full rounded-md border p-2"
       />
+      {error && (
+        <p className="text-sm text-red-500">Failed to load listings.</p>
+      )}
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {listings.map((listing) => (
           <ListingCard key={listing.id} listing={listing} />
         ))}
       </div>
-      <ListingForm onSuccess={loadListings} />
+      <ListingForm onSuccess={refetch} />
     </div>
   );
 };

--- a/client/src/components/forms/ListingForm.tsx
+++ b/client/src/components/forms/ListingForm.tsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 import { Form } from "@/components/ui/form";
 import { Button } from "@/components/ui/button";
 import { CustomFormField } from "../FormField";
-import { createListing } from "@/lib/api";
+import { useCreateListingMutation } from "@/state/api";
 
 const listingSchema = z.object({
   title: z.string().min(1, "Title is required"),
@@ -19,10 +19,16 @@ const ListingForm = ({ onSuccess }: { onSuccess?: () => void }) => {
     resolver: zodResolver(listingSchema),
   });
 
+  const [createListing] = useCreateListingMutation();
+
   const onSubmit = async (data: ListingFormData) => {
-    await createListing(data);
-    form.reset();
-    onSuccess?.();
+    try {
+      await createListing(data).unwrap();
+      form.reset();
+      onSuccess?.();
+    } catch (error) {
+      console.error("Failed to create listing", error);
+    }
   };
 
   return (

--- a/client/src/state/api.ts
+++ b/client/src/state/api.ts
@@ -11,6 +11,14 @@ import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import { fetchAuthSession, getCurrentUser } from "aws-amplify/auth";
 import { FiltersState } from ".";
 
+export interface Listing {
+  id: number | string;
+  title: string;
+  description: string;
+  price: number;
+  imageUrl?: string;
+}
+
 export const api = createApi({
   baseQuery: fetchBaseQuery({
     baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL,
@@ -32,6 +40,7 @@ export const api = createApi({
     "Leases",
     "Payments",
     "Applications",
+    "Listings",
   ],
   endpoints: (build) => ({
     getAuthUser: build.query<User, void>({
@@ -71,6 +80,43 @@ export const api = createApi({
           };
         } catch (error: any) {
           return { error: error.message || "Could not fetch user data" };
+        }
+      },
+    }),
+
+    fetchListings: build.query<Listing[], string | void>({
+      query: (search = "") => ({
+        url: "properties",
+        params: search ? { q: search } : undefined,
+      }),
+      providesTags: (result) =>
+        result
+          ? [
+              ...result.map(({ id }) => ({ type: "Listings" as const, id })),
+              { type: "Listings", id: "LIST" },
+            ]
+          : [{ type: "Listings", id: "LIST" }],
+      async onQueryStarted(_, { queryFulfilled }) {
+        try {
+          await queryFulfilled;
+        } catch (error) {
+          console.error("Failed to fetch listings", error);
+        }
+      },
+    }),
+
+    createListing: build.mutation<Listing, Partial<Listing>>({
+      query: (body) => ({
+        url: "properties",
+        method: "POST",
+        body,
+      }),
+      invalidatesTags: [{ type: "Listings", id: "LIST" }],
+      async onQueryStarted(_, { queryFulfilled }) {
+        try {
+          await queryFulfilled;
+        } catch (error) {
+          console.error("Failed to create listing", error);
         }
       },
     }),
@@ -355,6 +401,8 @@ export const {
   useGetAuthUserQuery,
   useUpdateTenantSettingsMutation,
   useUpdateManagerSettingsMutation,
+  useFetchListingsQuery,
+  useCreateListingMutation,
   useGetPropertiesQuery,
   useGetPropertyQuery,
   useGetCurrentResidencesQuery,

--- a/client/state/api.ts
+++ b/client/state/api.ts
@@ -1,12 +1,56 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
+export interface Listing {
+  id: number | string;
+  title: string;
+  description: string;
+  price: number;
+  imageUrl?: string;
+}
+
 export const api = createApi({
   baseQuery: fetchBaseQuery({
     baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL,
   }),
   reducerPath: "api",
-  tagTypes: [],
-  endpoints: (build) => ({}),
+  tagTypes: ["Listings"],
+  endpoints: (build) => ({
+    fetchListings: build.query<Listing[], string | void>({
+      query: (search = "") => ({
+        url: "properties",
+        params: search ? { q: search } : undefined,
+      }),
+      providesTags: (result) =>
+        result
+          ? [
+              ...result.map(({ id }) => ({ type: "Listings" as const, id })),
+              { type: "Listings", id: "LIST" },
+            ]
+          : [{ type: "Listings", id: "LIST" }],
+      async onQueryStarted(_, { queryFulfilled }) {
+        try {
+          await queryFulfilled;
+        } catch (error) {
+          console.error("Failed to fetch listings", error);
+        }
+      },
+    }),
+    createListing: build.mutation<Listing, Partial<Listing>>({
+      query: (body) => ({
+        url: "properties",
+        method: "POST",
+        body,
+      }),
+      invalidatesTags: [{ type: "Listings", id: "LIST" }],
+      async onQueryStarted(_, { queryFulfilled }) {
+        try {
+          await queryFulfilled;
+        } catch (error) {
+          console.error("Failed to create listing", error);
+        }
+      },
+    }),
+  }),
 });
 
-export const {} = api;
+export const { useFetchListingsQuery, useCreateListingMutation } = api;


### PR DESCRIPTION
## Summary
- add Listing interfaces and endpoints to RTK Query API
- switch listings page to use `useFetchListingsQuery`
- replace axios calls in listing form with RTK Query mutation hooks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898d613c868832895f59cc5b0af91d7