### PR TITLE
feat: add request validation middleware

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -23,7 +23,8 @@
         "morgan": "^1.10.1",
         "multer": "^1.4.5-lts.1",
         "prisma": "^6.13.0",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
@@ -5283,6 +5284,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/server/package.json
+++ b/server/package.json
@@ -29,7 +29,8 @@
     "morgan": "^1.10.1",
     "multer": "^1.4.5-lts.1",
     "prisma": "^6.13.0",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",

--- a/server/src/middleware/validationMiddleware.ts
+++ b/server/src/middleware/validationMiddleware.ts
@@ -1,0 +1,20 @@
+import { AnyZodObject } from "zod";
+import { Request, Response, NextFunction } from "express";
+
+export const validate = (
+  schema: AnyZodObject,
+  property: "body" | "query" = "body"
+) =>
+  (req: Request, res: Response, next: NextFunction): void => {
+    const result = schema.safeParse(req[property]);
+    if (!result.success) {
+      res.status(400).json({ errors: result.error.flatten() });
+      return;
+    }
+    // replace property with parsed data for downstream handlers
+    (req as any)[property] = result.data;
+    next();
+  };
+
+export const validateBody = (schema: AnyZodObject) => validate(schema, "body");
+export const validateQuery = (schema: AnyZodObject) => validate(schema, "query");

--- a/server/src/routes/applicationRoutes.ts
+++ b/server/src/routes/applicationRoutes.ts
@@ -5,11 +5,32 @@ import {
   listApplications,
   updateApplicationStatus,
 } from "../controllers/applicationControllers";
+import { validateBody, validateQuery } from "../middleware/validationMiddleware";
+import {
+  applicationSchema,
+  applicationStatusSchema,
+  applicationListQuerySchema,
+} from "../validation/applicationSchema";
 
 const router = express.Router();
 
-router.post("/", authMiddleware(["tenant"]), createApplication);
-router.put("/:id/status", authMiddleware(["manager"]), updateApplicationStatus);
-router.get("/", authMiddleware(["manager", "tenant"]), listApplications);
+router.post(
+  "/",
+  authMiddleware(["tenant"]),
+  validateBody(applicationSchema),
+  createApplication
+);
+router.put(
+  "/:id/status",
+  authMiddleware(["manager"]),
+  validateBody(applicationStatusSchema),
+  updateApplicationStatus
+);
+router.get(
+  "/",
+  authMiddleware(["manager", "tenant"]),
+  validateQuery(applicationListQuerySchema),
+  listApplications
+);
 
 export default router;

--- a/server/src/routes/listings.ts
+++ b/server/src/routes/listings.ts
@@ -6,13 +6,15 @@ import {
   updateListing,
   deleteListing,
 } from "../controllers/listings";
+import { validateBody } from "../middleware/validationMiddleware";
+import { listingSchema } from "../validation/listingSchema";
 
 const router = express.Router();
 
 router.get("/", getListings);
 router.get("/:id", getListing);
-router.post("/", createListing);
-router.put("/:id", updateListing);
+router.post("/", validateBody(listingSchema), createListing);
+router.put("/:id", validateBody(listingSchema), updateListing);
 router.delete("/:id", deleteListing);
 
 export default router;

--- a/server/src/routes/propertyRoutes.ts
+++ b/server/src/routes/propertyRoutes.ts
@@ -6,18 +6,24 @@ import {
 } from "../controllers/propertyControllers";
 import multer from "multer";
 import { authMiddleware } from "../middleware/authMiddleware";
+import { validateBody, validateQuery } from "../middleware/validationMiddleware";
+import {
+  propertyCreateSchema,
+  propertyQuerySchema,
+} from "../validation/propertySchema";
 
 const storage = multer.memoryStorage();
 const upload = multer({ storage: storage });
 
 const router = express.Router();
 
-router.get("/", getProperties);
+router.get("/", validateQuery(propertyQuerySchema), getProperties);
 router.get("/:id", getProperty);
 router.post(
   "/",
   authMiddleware(["manager"]),
   upload.array("photos"),
+  validateBody(propertyCreateSchema),
   createProperty
 );
 

--- a/server/src/validation/applicationSchema.ts
+++ b/server/src/validation/applicationSchema.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+const statusEnum = z.enum(["Pending", "Denied", "Approved"]);
+
+export const applicationSchema = z.object({
+  applicationDate: z.string(),
+  status: statusEnum,
+  propertyId: z.coerce.number().int(),
+  tenantCognitoId: z.string(),
+  name: z.string(),
+  email: z.string().email(),
+  phoneNumber: z.string(),
+  message: z.string().optional(),
+});
+
+export const applicationStatusSchema = z.object({
+  status: statusEnum,
+});
+
+export const applicationListQuerySchema = z.object({
+  userId: z.string().optional(),
+  userType: z.enum(["tenant", "manager"]).optional(),
+});
+
+export type ApplicationInput = z.infer<typeof applicationSchema>;

--- a/server/src/validation/leaseSchema.ts
+++ b/server/src/validation/leaseSchema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const leaseSchema = z.object({
+  startDate: z.string(),
+  endDate: z.string(),
+  rent: z.coerce.number(),
+  deposit: z.coerce.number(),
+  propertyId: z.coerce.number().int(),
+  tenantCognitoId: z.string(),
+});
+
+export type LeaseInput = z.infer<typeof leaseSchema>;

--- a/server/src/validation/listingSchema.ts
+++ b/server/src/validation/listingSchema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const listingSchema = z.object({
+  title: z.string(),
+  description: z.string(),
+  price: z.coerce.number().positive(),
+});
+
+export type ListingInput = z.infer<typeof listingSchema>;

--- a/server/src/validation/propertySchema.ts
+++ b/server/src/validation/propertySchema.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+const propertyTypeEnum = z.enum([
+  "Rooms",
+  "Tinyhouse",
+  "Apartment",
+  "Villa",
+  "Townhouse",
+  "Cottage",
+]);
+
+export const propertyQuerySchema = z.object({
+  favoriteIds: z.string().optional(),
+  priceMin: z.coerce.number().optional(),
+  priceMax: z.coerce.number().optional(),
+  beds: z.coerce.number().int().optional(),
+  baths: z.coerce.number().optional(),
+  propertyType: propertyTypeEnum.optional(),
+  squareFeetMin: z.coerce.number().int().optional(),
+  squareFeetMax: z.coerce.number().int().optional(),
+  amenities: z.string().optional(),
+  availableFrom: z.string().optional(),
+  latitude: z.coerce.number().optional(),
+  longitude: z.coerce.number().optional(),
+});
+
+export const propertyCreateSchema = z.object({
+  address: z.string(),
+  city: z.string(),
+  state: z.string(),
+  country: z.string(),
+  postalCode: z.string(),
+  managerCognitoId: z.string(),
+  name: z.string(),
+  description: z.string(),
+  pricePerMonth: z.coerce.number(),
+  securityDeposit: z.coerce.number(),
+  applicationFee: z.coerce.number(),
+  amenities: z.string().optional(),
+  highlights: z.string().optional(),
+  isPetsAllowed: z.enum(["true", "false"]).optional(),
+  isParkingIncluded: z.enum(["true", "false"]).optional(),
+  beds: z.coerce.number().int(),
+  baths: z.coerce.number(),
+  squareFeet: z.coerce.number().int(),
+  propertyType: propertyTypeEnum,
+});
+
+export type PropertyCreateInput = z.infer<typeof propertyCreateSchema>;
+export type PropertyQueryInput = z.infer<typeof propertyQuerySchema>;


### PR DESCRIPTION
## Summary
- add Zod validation schemas for listings, properties, leases, and applications
- create reusable validation middleware
- validate bodies and queries on property, listing, and application routes

## Testing
- `npm run build` *(fails: Cannot find module 'supertest' or type definitions for Jest)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898d6127e908328a0afd5123269eeab