### PR TITLE
feat: centralize environment config

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -23,7 +23,8 @@
         "morgan": "^1.10.1",
         "multer": "^1.4.5-lts.1",
         "prisma": "^6.13.0",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
@@ -5283,6 +5284,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/server/package.json
+++ b/server/package.json
@@ -29,7 +29,8 @@
     "morgan": "^1.10.1",
     "multer": "^1.4.5-lts.1",
     "prisma": "^6.13.0",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,0 +1,20 @@
+import dotenv from "dotenv";
+import { z } from "zod";
+
+dotenv.config();
+
+const envSchema = z.object({
+  PORT: z.coerce.number().default(3002),
+  JWT_SECRET: z.string(),
+  AWS_REGION: z.string(),
+  S3_BUCKET_NAME: z.string(),
+});
+
+type Env = z.infer<typeof envSchema>;
+
+const env: Env = envSchema.parse(process.env);
+
+export const PORT = env.PORT;
+export const JWT_SECRET = env.JWT_SECRET;
+export const AWS_REGION = env.AWS_REGION;
+export const S3_BUCKET_NAME = env.S3_BUCKET_NAME;

--- a/server/src/controllers/propertyControllers.ts
+++ b/server/src/controllers/propertyControllers.ts
@@ -5,11 +5,12 @@ import { S3Client } from "@aws-sdk/client-s3";
 import { Location } from "@prisma/client";
 import { Upload } from "@aws-sdk/lib-storage";
 import axios from "axios";
+import { AWS_REGION, S3_BUCKET_NAME } from "../config";
 
 const prisma = new PrismaClient();
 
 const s3Client = new S3Client({
-  region: process.env.AWS_REGION,
+  region: AWS_REGION,
 });
 
 export const getProperties = async (
@@ -209,7 +210,7 @@ export const createProperty = async (
     const photoUrls = await Promise.all(
       files.map(async (file) => {
         const uploadParams = {
-          Bucket: process.env.S3_BUCKET_NAME!,
+          Bucket: S3_BUCKET_NAME,
           Key: `properties/${Date.now()}-${file.originalname}`,
           Body: file.buffer,
           ContentType: file.mimetype,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,10 +1,10 @@
 import express from "express";
-import dotenv from "dotenv";
 import bodyParser from "body-parser";
 import cors from "cors";
 import helmet from "helmet";
 import morgan from "morgan";
 import { authMiddleware } from "./middleware/authMiddleware";
+import { PORT } from "./config";
 /* ROUTE IMPORT */
 import tenantRoutes from "./routes/tenantRoutes";
 import managerRoutes from "./routes/managerRoutes";
@@ -14,7 +14,6 @@ import applicationRoutes from "./routes/applicationRoutes";
 import listingsRoutes from "./routes/listings";
 
 /* CONFIGURATIONS */
-dotenv.config();
 const app = express();
 app.use(express.json());
 app.use(helmet());
@@ -37,7 +36,6 @@ app.use("/tenants", authMiddleware(["tenant"]), tenantRoutes);
 app.use("/managers", authMiddleware(["manager"]), managerRoutes);
 
 /* SERVER */
-const port = Number(process.env.PORT) || 3002;
-app.listen(port, "0.0.0.0", () => {
-  console.log(`Server running on port ${port}`);
+app.listen(PORT, "0.0.0.0", () => {
+  console.log(`Server running on port ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- add Zod-based config module for validated env variables
- use config constants instead of `process.env` in controllers and server entry
- add `zod` dependency

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Cannot find module 'supertest' and missing test runner types)


------
https://chatgpt.com/codex/tasks/task_e_6898d611eb588328ac04305803aa3efa