### PR TITLE
feat: add property services and centralized error handling

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,7 @@ import cors from "cors";
 import helmet from "helmet";
 import morgan from "morgan";
 import { authMiddleware } from "./middleware/authMiddleware";
+import { errorHandler } from "./middleware/errorHandler";
 /* ROUTE IMPORT */
 import tenantRoutes from "./routes/tenantRoutes";
 import managerRoutes from "./routes/managerRoutes";
@@ -35,6 +36,8 @@ app.use("/leases", leaseRoutes);
 app.use("/listings", listingsRoutes);
 app.use("/tenants", authMiddleware(["tenant"]), tenantRoutes);
 app.use("/managers", authMiddleware(["manager"]), managerRoutes);
+
+app.use(errorHandler);
 
 /* SERVER */
 const port = Number(process.env.PORT) || 3002;

--- a/server/src/middleware/asyncHandler.ts
+++ b/server/src/middleware/asyncHandler.ts
@@ -1,0 +1,8 @@
+import { RequestHandler } from "express";
+
+export const asyncHandler = (fn: RequestHandler): RequestHandler => {
+  return (req, res, next) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+};
+

--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -1,0 +1,13 @@
+import { Request, Response, NextFunction } from "express";
+
+export const errorHandler = (
+  err: any,
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const status = err.status || 500;
+  const message = err.message || "Internal Server Error";
+  res.status(status).json({ message });
+};
+

--- a/server/src/routes/propertyRoutes.ts
+++ b/server/src/routes/propertyRoutes.ts
@@ -1,24 +1,45 @@
 import express from "express";
+import multer from "multer";
+import { authMiddleware } from "../middleware/authMiddleware";
+import { asyncHandler } from "../middleware/asyncHandler";
 import {
   getProperties,
   getProperty,
   createProperty,
-} from "../controllers/propertyControllers";
-import multer from "multer";
-import { authMiddleware } from "../middleware/authMiddleware";
+} from "../services/propertyService";
 
 const storage = multer.memoryStorage();
 const upload = multer({ storage: storage });
 
 const router = express.Router();
 
-router.get("/", getProperties);
-router.get("/:id", getProperty);
+router.get(
+  "/",
+  asyncHandler(async (req, res) => {
+    const properties = await getProperties(req.query);
+    res.json(properties);
+  })
+);
+
+router.get(
+  "/:id",
+  asyncHandler(async (req, res) => {
+    const property = await getProperty(Number(req.params.id));
+    res.json(property);
+  })
+);
+
 router.post(
   "/",
   authMiddleware(["manager"]),
   upload.array("photos"),
-  createProperty
+  asyncHandler(async (req, res) => {
+    const newProperty = await createProperty(
+      req.body,
+      req.files as Express.Multer.File[]
+    );
+    res.status(201).json(newProperty);
+  })
 );
 
 export default router;

--- a/server/src/services/propertyService.ts
+++ b/server/src/services/propertyService.ts
@@ -1,0 +1,276 @@
+import { PrismaClient, Prisma, Location } from "@prisma/client";
+import { wktToGeoJSON } from "@terraformer/wkt";
+import { S3Client } from "@aws-sdk/client-s3";
+import { Upload } from "@aws-sdk/lib-storage";
+import axios from "axios";
+import { Express } from "express";
+
+const prisma = new PrismaClient();
+
+const s3Client = new S3Client({
+  region: process.env.AWS_REGION,
+});
+
+export const getProperties = async (query: any) => {
+  try {
+    const {
+      favoriteIds,
+      priceMin,
+      priceMax,
+      beds,
+      baths,
+      propertyType,
+      squareFeetMin,
+      squareFeetMax,
+      amenities,
+      availableFrom,
+      latitude,
+      longitude,
+    } = query;
+
+    let whereConditions: Prisma.Sql[] = [];
+
+    if (favoriteIds) {
+      const favoriteIdsArray = (favoriteIds as string).split(",").map(Number);
+      whereConditions.push(
+        Prisma.sql`p.id IN (${Prisma.join(favoriteIdsArray)})`
+      );
+    }
+
+    if (priceMin) {
+      whereConditions.push(
+        Prisma.sql`p."pricePerMonth" >= ${Number(priceMin)}`
+      );
+    }
+
+    if (priceMax) {
+      whereConditions.push(
+        Prisma.sql`p."pricePerMonth" <= ${Number(priceMax)}`
+      );
+    }
+
+    if (beds && beds !== "any") {
+      whereConditions.push(Prisma.sql`p.beds >= ${Number(beds)}`);
+    }
+
+    if (baths && baths !== "any") {
+      whereConditions.push(Prisma.sql`p.baths >= ${Number(baths)}`);
+    }
+
+    if (squareFeetMin) {
+      whereConditions.push(
+        Prisma.sql`p."squareFeet" >= ${Number(squareFeetMin)}`
+      );
+    }
+
+    if (squareFeetMax) {
+      whereConditions.push(
+        Prisma.sql`p."squareFeet" <= ${Number(squareFeetMax)}`
+      );
+    }
+
+    if (propertyType && propertyType !== "any") {
+      whereConditions.push(
+        Prisma.sql`p."propertyType" = ${propertyType}::"PropertyType"`
+      );
+    }
+
+    if (amenities && amenities !== "any") {
+      const amenitiesArray = (amenities as string).split(",");
+      whereConditions.push(Prisma.sql`p.amenities @> ${amenitiesArray}`);
+    }
+
+    if (availableFrom && availableFrom !== "any") {
+      const availableFromDate =
+        typeof availableFrom === "string" ? availableFrom : null;
+      if (availableFromDate) {
+        const date = new Date(availableFromDate);
+        if (!isNaN(date.getTime())) {
+          whereConditions.push(
+            Prisma.sql`EXISTS (
+              SELECT 1 FROM "Lease" l
+              WHERE l."propertyId" = p.id
+              AND l."startDate" <= ${date.toISOString()}
+            )`
+          );
+        }
+      }
+    }
+
+    if (latitude && longitude) {
+      const lat = parseFloat(latitude as string);
+      const lng = parseFloat(longitude as string);
+      const radiusInKilometers = 1000;
+      const degrees = radiusInKilometers / 111; // Converts kilometers to degrees
+
+      whereConditions.push(
+        Prisma.sql`ST_DWithin(
+          l.coordinates::geometry,
+          ST_SetSRID(ST_MakePoint(${lng}, ${lat}), 4326),
+          ${degrees}
+        )`
+      );
+    }
+
+    const completeQuery = Prisma.sql`
+      SELECT
+        p.*,
+        json_build_object(
+          'id', l.id,
+          'address', l.address,
+          'city', l.city,
+          'state', l.state,
+          'country', l.country,
+          'postalCode', l."postalCode",
+          'coordinates', json_build_object(
+            'longitude', ST_X(l."coordinates"::geometry),
+            'latitude', ST_Y(l."coordinates"::geometry)
+          )
+        ) as location
+      FROM "Property" p
+      JOIN "Location" l ON p."locationId" = l.id
+      ${
+        whereConditions.length > 0
+          ? Prisma.sql`WHERE ${Prisma.join(whereConditions, " AND ")}`
+          : Prisma.empty
+      }
+    `;
+
+    return prisma.$queryRaw(completeQuery);
+  } catch (error: any) {
+    throw new Error(`Error retrieving properties: ${error.message}`);
+  }
+};
+
+export const getProperty = async (id: number) => {
+  try {
+    const property = await prisma.property.findUnique({
+      where: { id: Number(id) },
+      include: {
+        location: true,
+      },
+    });
+
+    if (!property) {
+      throw new Error("Property not found");
+    }
+
+    const coordinates: { coordinates: string }[] =
+      await prisma.$queryRaw`SELECT ST_asText(coordinates) as coordinates from "Location" where id = ${property.location.id}`;
+
+    const geoJSON: any = wktToGeoJSON(coordinates[0]?.coordinates || "");
+    const longitude = geoJSON.coordinates[0];
+    const latitude = geoJSON.coordinates[1];
+
+    return {
+      ...property,
+      location: {
+        ...property.location,
+        coordinates: {
+          longitude,
+          latitude,
+        },
+      },
+    };
+  } catch (err: any) {
+    throw new Error(`Error retrieving property: ${err.message}`);
+  }
+};
+
+export const createProperty = async (
+  data: any,
+  files: Express.Multer.File[]
+) => {
+  try {
+    const {
+      address,
+      city,
+      state,
+      country,
+      postalCode,
+      managerCognitoId,
+      ...propertyData
+    } = data;
+
+    const photoUrls = await Promise.all(
+      files.map(async (file) => {
+        const uploadParams = {
+          Bucket: process.env.S3_BUCKET_NAME!,
+          Key: `properties/${Date.now()}-${file.originalname}`,
+          Body: file.buffer,
+          ContentType: file.mimetype,
+        };
+
+        const uploadResult = await new Upload({
+          client: s3Client,
+          params: uploadParams,
+        }).done();
+
+        return uploadResult.Location as string;
+      })
+    );
+
+    const geocodingUrl = `https://nominatim.openstreetmap.org/search?${new URLSearchParams(
+      {
+        street: address,
+        city,
+        country,
+        postalcode: postalCode,
+        format: "json",
+        limit: "1",
+      }
+    ).toString()}`;
+    const geocodingResponse = await axios.get(geocodingUrl, {
+      headers: {
+        "User-Agent": "RealEstateApp (justsomedummyemail@gmail.com",
+      },
+    });
+    const [longitude, latitude] =
+      geocodingResponse.data[0]?.lon && geocodingResponse.data[0]?.lat
+        ? [
+            parseFloat(geocodingResponse.data[0]?.lon),
+            parseFloat(geocodingResponse.data[0]?.lat),
+          ]
+        : [0, 0];
+
+    const [location] = await prisma.$queryRaw<Location[]>`
+      INSERT INTO "Location" (address, city, state, country, "postalCode", coordinates)
+      VALUES (${address}, ${city}, ${state}, ${country}, ${postalCode}, ST_SetSRID(ST_MakePoint(${longitude}, ${latitude}), 4326))
+      RETURNING id, address, city, state, country, "postalCode", ST_AsText(coordinates) as coordinates;
+    `;
+
+    const newProperty = await prisma.property.create({
+      data: {
+        ...propertyData,
+        photoUrls,
+        locationId: location.id,
+        managerCognitoId,
+        amenities:
+          typeof propertyData.amenities === "string"
+            ? propertyData.amenities.split(",")
+            : [],
+        highlights:
+          typeof propertyData.highlights === "string"
+            ? propertyData.highlights.split(",")
+            : [],
+        isPetsAllowed: propertyData.isPetsAllowed === "true",
+        isParkingIncluded: propertyData.isParkingIncluded === "true",
+        pricePerMonth: parseFloat(propertyData.pricePerMonth),
+        securityDeposit: parseFloat(propertyData.securityDeposit),
+        applicationFee: parseFloat(propertyData.applicationFee),
+        beds: parseInt(propertyData.beds),
+        baths: parseFloat(propertyData.baths),
+        squareFeet: parseInt(propertyData.squareFeet),
+      },
+      include: {
+        location: true,
+        manager: true,
+      },
+    });
+
+    return newProperty;
+  } catch (err: any) {
+    throw new Error(`Error creating property: ${err.message}`);
+  }
+};
+


### PR DESCRIPTION
## Summary
- implement property service module with database and S3 logic
- add async handler and global error handler middleware
- refactor property routes and register error handler in app

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'supertest' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6898d60f407c8328b5f6c10593e9e111