### PR TITLE
Verify JWT tokens via env-based config and enforce roles

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,0 +1,12 @@
+import dotenv from "dotenv";
+import type { Algorithm } from "jsonwebtoken";
+
+dotenv.config();
+
+export const jwtConfig = {
+  secret: process.env.JWT_SECRET || "",
+  algorithms: (process.env.JWT_ALGORITHMS
+    ? process.env.JWT_ALGORITHMS.split(",")
+    : ["HS256"]) as Algorithm[],
+};
+

--- a/server/src/middleware/authMiddleware.ts
+++ b/server/src/middleware/authMiddleware.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import jwt, { JwtPayload } from "jsonwebtoken";
+import { jwtConfig } from "../config";
 
 interface DecodedToken extends JwtPayload {
   sub: string;
@@ -27,8 +28,17 @@ export const authMiddleware = (allowedRoles: string[]) => {
     }
 
     try {
-      const decoded = jwt.decode(token) as DecodedToken;
+      const decoded = jwt.verify(token, jwtConfig.secret, {
+        algorithms: jwtConfig.algorithms,
+      }) as DecodedToken;
+
       const userRole = decoded["custom:role"] || "";
+
+      if (!decoded.sub || !decoded.exp || !userRole) {
+        res.status(401).json({ message: "Invalid token" });
+        return;
+      }
+
       req.user = {
         id: decoded.sub,
         role: userRole,
@@ -40,8 +50,8 @@ export const authMiddleware = (allowedRoles: string[]) => {
         return;
       }
     } catch (err) {
-      console.error("Failed to decode token:", err);
-      res.status(400).json({ message: "Invalid token" });
+      console.error("Failed to verify token:", err);
+      res.status(401).json({ message: "Unauthorized" });
       return;
     }
 


### PR DESCRIPTION
## Summary
- add environment-based JWT configuration module
- verify tokens using secret and algorithms from config, validating exp and required claims
- return 401 for invalid or expired tokens and 403 for disallowed roles

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Cannot find module 'supertest' or type declarations in tests)


------
https://chatgpt.com/codex/tasks/task_e_6898d60d0c188328861d190e6fce73bd