### PR TITLE
feat(server): validate environment configuration

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -23,7 +23,8 @@
         "morgan": "^1.10.1",
         "multer": "^1.4.5-lts.1",
         "prisma": "^6.13.0",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
@@ -5283,6 +5284,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/server/package.json
+++ b/server/package.json
@@ -29,7 +29,8 @@
     "morgan": "^1.10.1",
     "multer": "^1.4.5-lts.1",
     "prisma": "^6.13.0",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,0 +1,15 @@
+import { config as dotenvConfig } from 'dotenv';
+import { z } from 'zod';
+
+dotenvConfig();
+
+const envSchema = z.object({
+  PORT: z.coerce.number().int().positive(),
+  DATABASE_URL: z.string().min(1),
+  AWS_REGION: z.string().min(1),
+  S3_BUCKET_NAME: z.string().min(1),
+});
+
+const env = envSchema.parse(process.env);
+
+export default env;

--- a/server/src/controllers/propertyControllers.ts
+++ b/server/src/controllers/propertyControllers.ts
@@ -5,11 +5,12 @@ import { S3Client } from "@aws-sdk/client-s3";
 import { Location } from "@prisma/client";
 import { Upload } from "@aws-sdk/lib-storage";
 import axios from "axios";
+import env from "../config";
 
 const prisma = new PrismaClient();
 
 const s3Client = new S3Client({
-  region: process.env.AWS_REGION,
+  region: env.AWS_REGION,
 });
 
 export const getProperties = async (
@@ -208,12 +209,12 @@ export const createProperty = async (
 
     const photoUrls = await Promise.all(
       files.map(async (file) => {
-        const uploadParams = {
-          Bucket: process.env.S3_BUCKET_NAME!,
-          Key: `properties/${Date.now()}-${file.originalname}`,
-          Body: file.buffer,
-          ContentType: file.mimetype,
-        };
+          const uploadParams = {
+            Bucket: env.S3_BUCKET_NAME,
+            Key: `properties/${Date.now()}-${file.originalname}`,
+            Body: file.buffer,
+            ContentType: file.mimetype,
+          };
 
         const uploadResult = await new Upload({
           client: s3Client,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,4 @@
 import express from "express";
-import dotenv from "dotenv";
 import bodyParser from "body-parser";
 import cors from "cors";
 import helmet from "helmet";
@@ -12,9 +11,9 @@ import propertyRoutes from "./routes/propertyRoutes";
 import leaseRoutes from "./routes/leaseRoutes";
 import applicationRoutes from "./routes/applicationRoutes";
 import listingsRoutes from "./routes/listings";
+import env from "./config";
 
 /* CONFIGURATIONS */
-dotenv.config();
 const app = express();
 app.use(express.json());
 app.use(helmet());
@@ -37,7 +36,7 @@ app.use("/tenants", authMiddleware(["tenant"]), tenantRoutes);
 app.use("/managers", authMiddleware(["manager"]), managerRoutes);
 
 /* SERVER */
-const port = Number(process.env.PORT) || 3002;
+const port = env.PORT;
 app.listen(port, "0.0.0.0", () => {
   console.log(`Server running on port ${port}`);
 });


### PR DESCRIPTION
## Summary
- use zod to load and validate required env vars
- centralize AWS config via new server/src/config module
- hook server startup to typed config values

## Testing
- `PORT=3000 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/test_db AWS_REGION=us-east-1 S3_BUCKET_NAME=test-bucket npm test` (fails: Missing script "test")
- `PORT=3000 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/test_db AWS_REGION=us-east-1 S3_BUCKET_NAME=test-bucket npm run build` (fails: cannot find module 'supertest')

------
https://chatgpt.com/codex/tasks/task_e_6898d607e04c83289863dfdcf6f25c83