### PR TITLE
Refactor property controller with services and secure pagination

### DIFF
--- a/server/src/controllers/propertyControllers.ts
+++ b/server/src/controllers/propertyControllers.ts
@@ -1,10 +1,14 @@
 import { Request, Response } from "express";
-import { PrismaClient, Prisma } from "@prisma/client";
-import { wktToGeoJSON } from "@terraformer/wkt";
+import { PrismaClient } from "@prisma/client";
 import { S3Client } from "@aws-sdk/client-s3";
 import { Location } from "@prisma/client";
 import { Upload } from "@aws-sdk/lib-storage";
 import axios from "axios";
+import {
+  parsePropertyQuery,
+  listProperties,
+  getPropertyById,
+} from "../services/propertyService";
 
 const prisma = new PrismaClient();
 
@@ -17,131 +21,8 @@ export const getProperties = async (
   res: Response
 ): Promise<void> => {
   try {
-    const {
-      favoriteIds,
-      priceMin,
-      priceMax,
-      beds,
-      baths,
-      propertyType,
-      squareFeetMin,
-      squareFeetMax,
-      amenities,
-      availableFrom,
-      latitude,
-      longitude,
-    } = req.query;
-
-    let whereConditions: Prisma.Sql[] = [];
-
-    if (favoriteIds) {
-      const favoriteIdsArray = (favoriteIds as string).split(",").map(Number);
-      whereConditions.push(
-        Prisma.sql`p.id IN (${Prisma.join(favoriteIdsArray)})`
-      );
-    }
-
-    if (priceMin) {
-      whereConditions.push(
-        Prisma.sql`p."pricePerMonth" >= ${Number(priceMin)}`
-      );
-    }
-
-    if (priceMax) {
-      whereConditions.push(
-        Prisma.sql`p."pricePerMonth" <= ${Number(priceMax)}`
-      );
-    }
-
-    if (beds && beds !== "any") {
-      whereConditions.push(Prisma.sql`p.beds >= ${Number(beds)}`);
-    }
-
-    if (baths && baths !== "any") {
-      whereConditions.push(Prisma.sql`p.baths >= ${Number(baths)}`);
-    }
-
-    if (squareFeetMin) {
-      whereConditions.push(
-        Prisma.sql`p."squareFeet" >= ${Number(squareFeetMin)}`
-      );
-    }
-
-    if (squareFeetMax) {
-      whereConditions.push(
-        Prisma.sql`p."squareFeet" <= ${Number(squareFeetMax)}`
-      );
-    }
-
-    if (propertyType && propertyType !== "any") {
-      whereConditions.push(
-        Prisma.sql`p."propertyType" = ${propertyType}::"PropertyType"`
-      );
-    }
-
-    if (amenities && amenities !== "any") {
-      const amenitiesArray = (amenities as string).split(",");
-      whereConditions.push(Prisma.sql`p.amenities @> ${amenitiesArray}`);
-    }
-
-    if (availableFrom && availableFrom !== "any") {
-      const availableFromDate =
-        typeof availableFrom === "string" ? availableFrom : null;
-      if (availableFromDate) {
-        const date = new Date(availableFromDate);
-        if (!isNaN(date.getTime())) {
-          whereConditions.push(
-            Prisma.sql`EXISTS (
-              SELECT 1 FROM "Lease" l 
-              WHERE l."propertyId" = p.id 
-              AND l."startDate" <= ${date.toISOString()}
-            )`
-          );
-        }
-      }
-    }
-
-    if (latitude && longitude) {
-      const lat = parseFloat(latitude as string);
-      const lng = parseFloat(longitude as string);
-      const radiusInKilometers = 1000;
-      const degrees = radiusInKilometers / 111; // Converts kilometers to degrees
-
-      whereConditions.push(
-        Prisma.sql`ST_DWithin(
-          l.coordinates::geometry,
-          ST_SetSRID(ST_MakePoint(${lng}, ${lat}), 4326),
-          ${degrees}
-        )`
-      );
-    }
-
-    const completeQuery = Prisma.sql`
-      SELECT 
-        p.*,
-        json_build_object(
-          'id', l.id,
-          'address', l.address,
-          'city', l.city,
-          'state', l.state,
-          'country', l.country,
-          'postalCode', l."postalCode",
-          'coordinates', json_build_object(
-            'longitude', ST_X(l."coordinates"::geometry),
-            'latitude', ST_Y(l."coordinates"::geometry)
-          )
-        ) as location
-      FROM "Property" p
-      JOIN "Location" l ON p."locationId" = l.id
-      ${
-        whereConditions.length > 0
-          ? Prisma.sql`WHERE ${Prisma.join(whereConditions, " AND ")}`
-          : Prisma.empty
-      }
-    `;
-
-    const properties = await prisma.$queryRaw(completeQuery);
-
+    const { filters, pagination } = await parsePropertyQuery(req.query);
+    const properties = await listProperties(filters, pagination);
     res.json(properties);
   } catch (error: any) {
     res
@@ -156,32 +37,14 @@ export const getProperty = async (
 ): Promise<void> => {
   try {
     const { id } = req.params;
-    const property = await prisma.property.findUnique({
-      where: { id: Number(id) },
-      include: {
-        location: true,
-      },
-    });
-
+    const numericId = parseInt(id, 10);
+    if (isNaN(numericId)) {
+      res.status(400).json({ message: "Invalid property id" });
+      return;
+    }
+    const property = await getPropertyById(numericId);
     if (property) {
-      const coordinates: { coordinates: string }[] =
-        await prisma.$queryRaw`SELECT ST_asText(coordinates) as coordinates from "Location" where id = ${property.location.id}`;
-
-      const geoJSON: any = wktToGeoJSON(coordinates[0]?.coordinates || "");
-      const longitude = geoJSON.coordinates[0];
-      const latitude = geoJSON.coordinates[1];
-
-      const propertyWithCoordinates = {
-        ...property,
-        location: {
-          ...property.location,
-          coordinates: {
-            longitude,
-            latitude,
-          },
-        },
-      };
-      res.json(propertyWithCoordinates);
+      res.json(property);
     }
   } catch (err: any) {
     res

--- a/server/src/services/propertyService.ts
+++ b/server/src/services/propertyService.ts
@@ -1,0 +1,218 @@
+import {
+  PrismaClient,
+  Prisma,
+  Amenity,
+  PropertyType,
+} from "@prisma/client";
+import { wktToGeoJSON } from "@terraformer/wkt";
+
+const prisma = new PrismaClient();
+
+export interface PropertyFilters {
+  favoriteIds?: number[];
+  priceMin?: number;
+  priceMax?: number;
+  beds?: number;
+  baths?: number;
+  propertyType?: PropertyType;
+  squareFeetMin?: number;
+  squareFeetMax?: number;
+  amenities?: Amenity[];
+  availableFrom?: Date;
+  locationIds?: number[];
+}
+
+export interface Pagination {
+  page: number;
+  pageSize: number;
+}
+
+export const parsePropertyQuery = async (
+  query: any
+): Promise<{ filters: PropertyFilters; pagination: Pagination }> => {
+  const filters: PropertyFilters = {};
+  const pagination: Pagination = { page: 1, pageSize: 10 };
+
+  if (typeof query.favoriteIds === "string") {
+    const ids = query.favoriteIds
+      .split(",")
+      .map((id: string) => parseInt(id, 10))
+      .filter((id: number) => !isNaN(id));
+    if (ids.length) filters.favoriteIds = ids;
+  }
+
+  const priceMin = parseFloat(query.priceMin);
+  if (!isNaN(priceMin)) filters.priceMin = priceMin;
+
+  const priceMax = parseFloat(query.priceMax);
+  if (!isNaN(priceMax)) filters.priceMax = priceMax;
+
+  const beds = parseInt(query.beds, 10);
+  if (!isNaN(beds)) filters.beds = beds;
+
+  const baths = parseInt(query.baths, 10);
+  if (!isNaN(baths)) filters.baths = baths;
+
+  const squareFeetMin = parseInt(query.squareFeetMin, 10);
+  if (!isNaN(squareFeetMin)) filters.squareFeetMin = squareFeetMin;
+
+  const squareFeetMax = parseInt(query.squareFeetMax, 10);
+  if (!isNaN(squareFeetMax)) filters.squareFeetMax = squareFeetMax;
+
+  if (
+    typeof query.propertyType === "string" &&
+    Object.values(PropertyType).includes(query.propertyType as PropertyType)
+  ) {
+    filters.propertyType = query.propertyType as PropertyType;
+  }
+
+  if (typeof query.amenities === "string" && query.amenities !== "any") {
+    const amenitiesArray = query.amenities.split(",");
+    filters.amenities = amenitiesArray.filter((a: string) =>
+      Object.values(Amenity).includes(a as Amenity)
+    ) as Amenity[];
+  }
+
+  if (typeof query.availableFrom === "string" && query.availableFrom !== "any") {
+    const date = new Date(query.availableFrom);
+    if (!isNaN(date.getTime())) {
+      filters.availableFrom = date;
+    }
+  }
+
+  if (typeof query.latitude === "string" && typeof query.longitude === "string") {
+    const lat = parseFloat(query.latitude);
+    const lng = parseFloat(query.longitude);
+    if (!isNaN(lat) && !isNaN(lng)) {
+      const locationIds = await getLocationIdsWithinRadius(lat, lng, 1000);
+      if (locationIds.length) {
+        filters.locationIds = locationIds;
+      }
+    }
+  }
+
+  const page = parseInt(query.page, 10);
+  if (!isNaN(page) && page > 0) pagination.page = page;
+
+  const pageSize = parseInt(query.pageSize, 10);
+  if (!isNaN(pageSize) && pageSize > 0 && pageSize <= 100) pagination.pageSize = pageSize;
+
+  return { filters, pagination };
+};
+
+export const listProperties = async (
+  filters: PropertyFilters,
+  pagination: Pagination
+) => {
+  const where: Prisma.PropertyWhereInput = {};
+
+  if (filters.favoriteIds?.length) {
+    where.id = { in: filters.favoriteIds };
+  }
+
+  if (filters.priceMin !== undefined || filters.priceMax !== undefined) {
+    where.pricePerMonth = {};
+    if (filters.priceMin !== undefined) {
+      (where.pricePerMonth as Prisma.IntFilter).gte = filters.priceMin;
+    }
+    if (filters.priceMax !== undefined) {
+      (where.pricePerMonth as Prisma.IntFilter).lte = filters.priceMax;
+    }
+  }
+
+  if (filters.beds !== undefined) {
+    where.beds = { gte: filters.beds };
+  }
+
+  if (filters.baths !== undefined) {
+    where.baths = { gte: filters.baths };
+  }
+
+  if (filters.squareFeetMin !== undefined || filters.squareFeetMax !== undefined) {
+    where.squareFeet = {};
+    if (filters.squareFeetMin !== undefined) {
+      (where.squareFeet as Prisma.IntFilter).gte = filters.squareFeetMin;
+    }
+    if (filters.squareFeetMax !== undefined) {
+      (where.squareFeet as Prisma.IntFilter).lte = filters.squareFeetMax;
+    }
+  }
+
+  if (filters.propertyType) {
+    where.propertyType = filters.propertyType as any;
+  }
+
+  if (filters.amenities?.length) {
+    where.amenities = { hasEvery: filters.amenities };
+  }
+
+  if (filters.availableFrom) {
+    where.leases = {
+      some: {
+        startDate: {
+          lte: filters.availableFrom,
+        },
+      },
+    };
+  }
+
+  if (filters.locationIds?.length) {
+    where.locationId = { in: filters.locationIds };
+  }
+
+  return prisma.property.findMany({
+    where,
+    include: {
+      location: true,
+    },
+    skip: (pagination.page - 1) * pagination.pageSize,
+    take: pagination.pageSize,
+  });
+};
+
+export const getLocationIdsWithinRadius = async (
+  lat: number,
+  lng: number,
+  radiusInKilometers: number
+): Promise<number[]> => {
+  const degrees = radiusInKilometers / 111;
+  const locations = await prisma.$queryRaw<{ id: number }[]>`
+    SELECT id FROM "Location"
+    WHERE ST_DWithin(
+      coordinates::geometry,
+      ST_SetSRID(ST_MakePoint(${lng}, ${lat}), 4326),
+      ${degrees}
+    )
+  `;
+  return locations.map((l) => l.id);
+};
+
+export const getPropertyById = async (id: number) => {
+  const property = await prisma.property.findUnique({
+    where: { id },
+    include: {
+      location: true,
+    },
+  });
+
+  if (!property) return null;
+
+  const coordinates: { coordinates: string }[] = await prisma.$queryRaw`
+    SELECT ST_asText(coordinates) as coordinates from "Location" where id = ${property.location.id}
+  `;
+
+  const geoJSON: any = wktToGeoJSON(coordinates[0]?.coordinates || "");
+  const longitude = geoJSON.coordinates[0];
+  const latitude = geoJSON.coordinates[1];
+
+  return {
+    ...property,
+    location: {
+      ...property.location,
+      coordinates: {
+        longitude,
+        latitude,
+      },
+    },
+  };
+};


### PR DESCRIPTION
## Summary
- Extract property retrieval logic into dedicated service functions
- Replace raw SQL with Prisma `findMany` calls and parameterized `where` filters
- Add pagination and query parameter sanitization to reduce injection risk

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'supertest' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6898d60416b88328bd594f4759d794eb