### PR TITLE
Align client API with /properties endpoint

### DIFF
--- a/client/app/listings/page.tsx
+++ b/client/app/listings/page.tsx
@@ -3,14 +3,14 @@
 import { useCallback, useEffect, useState } from "react";
 import ListingCard, { Listing } from "@/components/ListingCard";
 import ListingForm from "@/components/forms/ListingForm";
-import { fetchListings } from "@/lib/api";
+import { fetchProperties } from "@/lib/api";
 
 const ListingsPage = () => {
   const [listings, setListings] = useState<Listing[]>([]);
   const [query, setQuery] = useState("");
 
   const loadListings = useCallback(async () => {
-    const data = await fetchListings(query);
+    const data = await fetchProperties(query);
     setListings(data);
   }, [query]);
 

--- a/client/components/forms/ListingForm.tsx
+++ b/client/components/forms/ListingForm.tsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 import { Form } from "@/components/ui/form";
 import { Button } from "@/components/ui/button";
 import { CustomFormField } from "../FormField";
-import { createListing } from "@/lib/api";
+import { createProperty } from "@/lib/api";
 
 const listingSchema = z.object({
   title: z.string().min(1, "Title is required"),
@@ -20,7 +20,7 @@ const ListingForm = ({ onSuccess }: { onSuccess?: () => void }) => {
   });
 
   const onSubmit = async (data: ListingFormData) => {
-    await createListing(data);
+    await createProperty(data);
     form.reset();
     onSuccess?.();
   };

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -4,12 +4,12 @@ const api = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:3002",
 });
 
-export const fetchListings = async (search?: string) => {
+export const fetchProperties = async (search?: string) => {
   const response = await api.get("/properties", { params: { q: search } });
   return response.data;
 };
 
-export const createListing = async (data: any) => {
+export const createProperty = async (data: any) => {
   const response = await api.post("/properties", data);
   return response.data;
 };

--- a/client/src/app/listings/page.tsx
+++ b/client/src/app/listings/page.tsx
@@ -3,14 +3,14 @@
 import { useCallback, useEffect, useState } from "react";
 import ListingCard, { Listing } from "@/components/ListingCard";
 import ListingForm from "@/components/forms/ListingForm";
-import { fetchListings } from "@/lib/api";
+import { fetchProperties } from "@/lib/api";
 
 const ListingsPage = () => {
   const [listings, setListings] = useState<Listing[]>([]);
   const [query, setQuery] = useState("");
 
   const loadListings = useCallback(async () => {
-    const data = await fetchListings(query);
+    const data = await fetchProperties(query);
     setListings(data);
   }, [query]);
 

--- a/client/src/components/forms/ListingForm.tsx
+++ b/client/src/components/forms/ListingForm.tsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 import { Form } from "@/components/ui/form";
 import { Button } from "@/components/ui/button";
 import { CustomFormField } from "../FormField";
-import { createListing } from "@/lib/api";
+import { createProperty } from "@/lib/api";
 
 const listingSchema = z.object({
   title: z.string().min(1, "Title is required"),
@@ -20,7 +20,7 @@ const ListingForm = ({ onSuccess }: { onSuccess?: () => void }) => {
   });
 
   const onSubmit = async (data: ListingFormData) => {
-    await createListing(data);
+    await createProperty(data);
     form.reset();
     onSuccess?.();
   };

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -4,12 +4,12 @@ const api = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:3002",
 });
 
-export const fetchListings = async (search?: string) => {
+export const fetchProperties = async (search?: string) => {
   const response = await api.get("/properties", { params: { q: search } });
   return response.data;
 };
 
-export const createListing = async (data: any) => {
+export const createProperty = async (data: any) => {
   const response = await api.post("/properties", data);
   return response.data;
 };


### PR DESCRIPTION
## Summary
- choose `/properties` as the canonical route
- rename API helpers to `fetchProperties`/`createProperty`
- update listing page and form to use the new helpers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm test` (server) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898d6004ba083288993d5453d856671