### PR TITLE
Add express-validator schemas and input sanitization

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -18,6 +18,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.6.1",
         "express": "^4.21.2",
+        "express-validator": "^7.2.1",
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.1",
@@ -2868,6 +2869,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-validator": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
+      "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "~13.12.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
@@ -3532,7 +3546,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -5053,6 +5066,15 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/server/package.json
+++ b/server/package.json
@@ -24,6 +24,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.6.1",
     "express": "^4.21.2",
+    "express-validator": "^7.2.1",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.1",

--- a/server/src/controllers/applicationControllers.ts
+++ b/server/src/controllers/applicationControllers.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, ApplicationStatus } from "@prisma/client";
+import { matchedData } from "express-validator";
 
 const prisma = new PrismaClient();
 
@@ -8,17 +9,20 @@ export const listApplications = async (
   res: Response
 ): Promise<void> => {
   try {
-    const { userId, userType } = req.query;
+    const { userId, userType } = matchedData(req) as {
+      userId?: string;
+      userType?: string;
+    };
 
     let whereClause = {};
 
     if (userId && userType) {
       if (userType === "tenant") {
-        whereClause = { tenantCognitoId: String(userId) };
+        whereClause = { tenantCognitoId: userId };
       } else if (userType === "manager") {
         whereClause = {
           property: {
-            managerCognitoId: String(userId),
+            managerCognitoId: userId,
           },
         };
       }
@@ -97,7 +101,16 @@ export const createApplication = async (
       email,
       phoneNumber,
       message,
-    } = req.body;
+    } = matchedData(req) as {
+      applicationDate: string;
+      status: ApplicationStatus;
+      propertyId: number;
+      tenantCognitoId: string;
+      name: string;
+      email: string;
+      phoneNumber: string;
+      message?: string;
+    };
 
     const property = await prisma.property.findUnique({
       where: { id: propertyId },
@@ -170,12 +183,14 @@ export const updateApplicationStatus = async (
   res: Response
 ): Promise<void> => {
   try {
-    const { id } = req.params;
-    const { status } = req.body;
+    const { id, status } = matchedData(req) as {
+      id: number;
+      status: ApplicationStatus;
+    };
     console.log("status:", status);
 
     const application = await prisma.application.findUnique({
-      where: { id: Number(id) },
+      where: { id },
       include: {
         property: true,
         tenant: true,
@@ -213,7 +228,7 @@ export const updateApplicationStatus = async (
 
       // Update the application with the new lease ID
       await prisma.application.update({
-        where: { id: Number(id) },
+        where: { id },
         data: { status, leaseId: newLease.id },
         include: {
           property: true,
@@ -224,14 +239,14 @@ export const updateApplicationStatus = async (
     } else {
       // Update the application status (for both "Denied" and other statuses)
       await prisma.application.update({
-        where: { id: Number(id) },
+        where: { id },
         data: { status },
       });
     }
 
     // Respond with the updated application details
     const updatedApplication = await prisma.application.findUnique({
-      where: { id: Number(id) },
+      where: { id },
       include: {
         property: true,
         tenant: true,

--- a/server/src/controllers/leaseControllers.ts
+++ b/server/src/controllers/leaseControllers.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import { PrismaClient } from "@prisma/client";
+import { matchedData } from "express-validator";
 
 const prisma = new PrismaClient();
 
@@ -24,9 +25,9 @@ export const getLeasePayments = async (
   res: Response
 ): Promise<void> => {
   try {
-    const { id } = req.params;
+    const { id } = matchedData(req) as { id: number };
     const payments = await prisma.payment.findMany({
-      where: { leaseId: Number(id) },
+      where: { leaseId: id },
     });
     res.json(payments);
   } catch (error: any) {

--- a/server/src/controllers/listings.ts
+++ b/server/src/controllers/listings.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import { PrismaClient } from "@prisma/client";
+import { matchedData } from "express-validator";
 
 const prisma = new PrismaClient();
 
@@ -16,9 +17,9 @@ export const getListings = async (req: Request, res: Response): Promise<void> =>
 
 export const getListing = async (req: Request, res: Response): Promise<void> => {
   try {
-    const { id } = req.params;
+    const { id } = matchedData(req) as { id: number };
     const listing = await prisma.listing.findUnique({
-      where: { id: Number(id) },
+      where: { id },
     });
     if (listing) {
       res.json(listing);
@@ -34,12 +35,16 @@ export const getListing = async (req: Request, res: Response): Promise<void> => 
 
 export const createListing = async (req: Request, res: Response): Promise<void> => {
   try {
-    const { title, description, price } = req.body;
+    const { title, description, price } = matchedData(req) as {
+      title: string;
+      description: string;
+      price: number;
+    };
     const listing = await prisma.listing.create({
       data: {
         title,
         description,
-        price: Number(price),
+        price,
       },
     });
     res.status(201).json(listing);
@@ -52,14 +57,18 @@ export const createListing = async (req: Request, res: Response): Promise<void> 
 
 export const updateListing = async (req: Request, res: Response): Promise<void> => {
   try {
-    const { id } = req.params;
-    const { title, description, price } = req.body;
+    const { id, title, description, price } = matchedData(req) as {
+      id: number;
+      title: string;
+      description: string;
+      price: number;
+    };
     const listing = await prisma.listing.update({
-      where: { id: Number(id) },
+      where: { id },
       data: {
         title,
         description,
-        price: Number(price),
+        price,
       },
     });
     res.json(listing);
@@ -72,8 +81,8 @@ export const updateListing = async (req: Request, res: Response): Promise<void> 
 
 export const deleteListing = async (req: Request, res: Response): Promise<void> => {
   try {
-    const { id } = req.params;
-    await prisma.listing.delete({ where: { id: Number(id) } });
+    const { id } = matchedData(req) as { id: number };
+    await prisma.listing.delete({ where: { id } });
     res.status(204).send();
   } catch (error: any) {
     res

--- a/server/src/controllers/managerControllers.ts
+++ b/server/src/controllers/managerControllers.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import { PrismaClient } from "@prisma/client";
 import { wktToGeoJSON } from "@terraformer/wkt";
+import { matchedData } from "express-validator";
 
 const prisma = new PrismaClient();
 
@@ -9,7 +10,7 @@ export const getManager = async (
   res: Response
 ): Promise<void> => {
   try {
-    const { cognitoId } = req.params;
+    const { cognitoId } = matchedData(req) as { cognitoId: string };
     const manager = await prisma.manager.findUnique({
       where: { cognitoId },
     });
@@ -31,7 +32,12 @@ export const createManager = async (
   res: Response
 ): Promise<void> => {
   try {
-    const { cognitoId, name, email, phoneNumber } = req.body;
+    const { cognitoId, name, email, phoneNumber } = matchedData(req) as {
+      cognitoId: string;
+      name: string;
+      email: string;
+      phoneNumber: string;
+    };
 
     const manager = await prisma.manager.create({
       data: {
@@ -55,8 +61,12 @@ export const updateManager = async (
   res: Response
 ): Promise<void> => {
   try {
-    const { cognitoId } = req.params;
-    const { name, email, phoneNumber } = req.body;
+    const { cognitoId, name, email, phoneNumber } = matchedData(req) as {
+      cognitoId: string;
+      name: string;
+      email: string;
+      phoneNumber: string;
+    };
 
     const updateManager = await prisma.manager.update({
       where: { cognitoId },
@@ -80,7 +90,7 @@ export const getManagerProperties = async (
   res: Response
 ): Promise<void> => {
   try {
-    const { cognitoId } = req.params;
+    const { cognitoId } = matchedData(req) as { cognitoId: string };
     const properties = await prisma.property.findMany({
       where: { managerCognitoId: cognitoId },
       include: {

--- a/server/src/controllers/propertyControllers.ts
+++ b/server/src/controllers/propertyControllers.ts
@@ -5,6 +5,7 @@ import { S3Client } from "@aws-sdk/client-s3";
 import { Location } from "@prisma/client";
 import { Upload } from "@aws-sdk/lib-storage";
 import axios from "axios";
+import { matchedData } from "express-validator";
 
 const prisma = new PrismaClient();
 
@@ -30,80 +31,89 @@ export const getProperties = async (
       availableFrom,
       latitude,
       longitude,
-    } = req.query;
+    } = matchedData(req) as {
+      favoriteIds?: string;
+      priceMin?: number;
+      priceMax?: number;
+      beds?: number;
+      baths?: number;
+      propertyType?: string;
+      squareFeetMin?: number;
+      squareFeetMax?: number;
+      amenities?: string;
+      availableFrom?: string;
+      latitude?: number;
+      longitude?: number;
+    };
 
     let whereConditions: Prisma.Sql[] = [];
 
     if (favoriteIds) {
-      const favoriteIdsArray = (favoriteIds as string).split(",").map(Number);
+      const favoriteIdsArray = favoriteIds.split(",").map(Number);
       whereConditions.push(
         Prisma.sql`p.id IN (${Prisma.join(favoriteIdsArray)})`
       );
     }
 
-    if (priceMin) {
+    if (priceMin !== undefined) {
       whereConditions.push(
-        Prisma.sql`p."pricePerMonth" >= ${Number(priceMin)}`
+        Prisma.sql`p."pricePerMonth" >= ${priceMin}`
       );
     }
 
-    if (priceMax) {
+    if (priceMax !== undefined) {
       whereConditions.push(
-        Prisma.sql`p."pricePerMonth" <= ${Number(priceMax)}`
+        Prisma.sql`p."pricePerMonth" <= ${priceMax}`
       );
     }
 
-    if (beds && beds !== "any") {
-      whereConditions.push(Prisma.sql`p.beds >= ${Number(beds)}`);
+    if (beds !== undefined) {
+      whereConditions.push(Prisma.sql`p.beds >= ${beds}`);
     }
 
-    if (baths && baths !== "any") {
-      whereConditions.push(Prisma.sql`p.baths >= ${Number(baths)}`);
+    if (baths !== undefined) {
+      whereConditions.push(Prisma.sql`p.baths >= ${baths}`);
     }
 
-    if (squareFeetMin) {
+    if (squareFeetMin !== undefined) {
       whereConditions.push(
-        Prisma.sql`p."squareFeet" >= ${Number(squareFeetMin)}`
+        Prisma.sql`p."squareFeet" >= ${squareFeetMin}`
       );
     }
 
-    if (squareFeetMax) {
+    if (squareFeetMax !== undefined) {
       whereConditions.push(
-        Prisma.sql`p."squareFeet" <= ${Number(squareFeetMax)}`
+        Prisma.sql`p."squareFeet" <= ${squareFeetMax}`
       );
     }
 
-    if (propertyType && propertyType !== "any") {
+    if (propertyType) {
       whereConditions.push(
         Prisma.sql`p."propertyType" = ${propertyType}::"PropertyType"`
       );
     }
 
-    if (amenities && amenities !== "any") {
-      const amenitiesArray = (amenities as string).split(",");
+    if (amenities) {
+      const amenitiesArray = amenities.split(",");
       whereConditions.push(Prisma.sql`p.amenities @> ${amenitiesArray}`);
     }
 
-    if (availableFrom && availableFrom !== "any") {
-      const availableFromDate =
-        typeof availableFrom === "string" ? availableFrom : null;
-      if (availableFromDate) {
-        const date = new Date(availableFromDate);
-        if (!isNaN(date.getTime())) {
-          whereConditions.push(
-            Prisma.sql`EXISTS (
-              SELECT 1 FROM "Lease" l 
-              WHERE l."propertyId" = p.id 
-              AND l."startDate" <= ${date.toISOString()}
-            )`
-          );
-        }
+    if (availableFrom) {
+      const date = new Date(availableFrom);
+      if (!isNaN(date.getTime())) {
+        whereConditions.push(
+          Prisma.sql`EXISTS (
+            SELECT 1 FROM "Lease" l
+            WHERE l."propertyId" = p.id
+            AND l."startDate" <= ${date.toISOString()}
+          )`
+        );
       }
     }
 
-    if (latitude && longitude) {
-      const lat = parseFloat(latitude as string);
-      const lng = parseFloat(longitude as string);
+    if (latitude !== undefined && longitude !== undefined) {
+      const lat = latitude;
+      const lng = longitude;
       const radiusInKilometers = 1000;
       const degrees = radiusInKilometers / 111; // Converts kilometers to degrees
 
@@ -155,9 +165,9 @@ export const getProperty = async (
   res: Response
 ): Promise<void> => {
   try {
-    const { id } = req.params;
+    const { id } = matchedData(req) as { id: number };
     const property = await prisma.property.findUnique({
-      where: { id: Number(id) },
+      where: { id },
       include: {
         location: true,
       },
@@ -203,8 +213,35 @@ export const createProperty = async (
       country,
       postalCode,
       managerCognitoId,
-      ...propertyData
-    } = req.body;
+      pricePerMonth,
+      securityDeposit,
+      applicationFee,
+      beds,
+      baths,
+      squareFeet,
+    } = matchedData(req) as {
+      address: string;
+      city: string;
+      state: string;
+      country: string;
+      postalCode: string;
+      managerCognitoId: string;
+      pricePerMonth: number;
+      securityDeposit: number;
+      applicationFee: number;
+      beds: number;
+      baths: number;
+      squareFeet: number;
+    };
+    const propertyData = {
+      ...req.body,
+      pricePerMonth,
+      securityDeposit,
+      applicationFee,
+      beds,
+      baths,
+      squareFeet,
+    };
 
     const photoUrls = await Promise.all(
       files.map(async (file) => {
@@ -271,12 +308,12 @@ export const createProperty = async (
             : [],
         isPetsAllowed: propertyData.isPetsAllowed === "true",
         isParkingIncluded: propertyData.isParkingIncluded === "true",
-        pricePerMonth: parseFloat(propertyData.pricePerMonth),
-        securityDeposit: parseFloat(propertyData.securityDeposit),
-        applicationFee: parseFloat(propertyData.applicationFee),
-        beds: parseInt(propertyData.beds),
-        baths: parseFloat(propertyData.baths),
-        squareFeet: parseInt(propertyData.squareFeet),
+        pricePerMonth: propertyData.pricePerMonth,
+        securityDeposit: propertyData.securityDeposit,
+        applicationFee: propertyData.applicationFee,
+        beds: propertyData.beds,
+        baths: propertyData.baths,
+        squareFeet: propertyData.squareFeet,
       },
       include: {
         location: true,

--- a/server/src/controllers/tenantControllers.ts
+++ b/server/src/controllers/tenantControllers.ts
@@ -1,12 +1,13 @@
 import { Request, Response } from "express";
 import { PrismaClient } from "@prisma/client";
 import { wktToGeoJSON } from "@terraformer/wkt";
+import { matchedData } from "express-validator";
 
 const prisma = new PrismaClient();
 
 export const getTenant = async (req: Request, res: Response): Promise<void> => {
   try {
-    const { cognitoId } = req.params;
+    const { cognitoId } = matchedData(req) as { cognitoId: string };
     const tenant = await prisma.tenant.findUnique({
       where: { cognitoId },
       include: {
@@ -31,7 +32,12 @@ export const createTenant = async (
   res: Response
 ): Promise<void> => {
   try {
-    const { cognitoId, name, email, phoneNumber } = req.body;
+    const { cognitoId, name, email, phoneNumber } = matchedData(req) as {
+      cognitoId: string;
+      name: string;
+      email: string;
+      phoneNumber: string;
+    };
 
     const tenant = await prisma.tenant.create({
       data: {
@@ -55,8 +61,12 @@ export const updateTenant = async (
   res: Response
 ): Promise<void> => {
   try {
-    const { cognitoId } = req.params;
-    const { name, email, phoneNumber } = req.body;
+    const { cognitoId, name, email, phoneNumber } = matchedData(req) as {
+      cognitoId: string;
+      name: string;
+      email: string;
+      phoneNumber: string;
+    };
 
     const updateTenant = await prisma.tenant.update({
       where: { cognitoId },
@@ -80,7 +90,7 @@ export const getCurrentResidences = async (
   res: Response
 ): Promise<void> => {
   try {
-    const { cognitoId } = req.params;
+    const { cognitoId } = matchedData(req) as { cognitoId: string };
     const properties = await prisma.property.findMany({
       where: { tenants: { some: { cognitoId } } },
       include: {
@@ -123,7 +133,10 @@ export const addFavoriteProperty = async (
   res: Response
 ): Promise<void> => {
   try {
-    const { cognitoId, propertyId } = req.params;
+    const { cognitoId, propertyId } = matchedData(req) as {
+      cognitoId: string;
+      propertyId: number;
+    };
     const tenant = await prisma.tenant.findUnique({
       where: { cognitoId },
       include: { favorites: true },
@@ -134,15 +147,14 @@ export const addFavoriteProperty = async (
       return;
     }
 
-    const propertyIdNumber = Number(propertyId);
     const existingFavorites = tenant.favorites || [];
 
-    if (!existingFavorites.some((fav) => fav.id === propertyIdNumber)) {
+    if (!existingFavorites.some((fav) => fav.id === propertyId)) {
       const updatedTenant = await prisma.tenant.update({
         where: { cognitoId },
         data: {
           favorites: {
-            connect: { id: propertyIdNumber },
+            connect: { id: propertyId },
           },
         },
         include: { favorites: true },
@@ -163,14 +175,16 @@ export const removeFavoriteProperty = async (
   res: Response
 ): Promise<void> => {
   try {
-    const { cognitoId, propertyId } = req.params;
-    const propertyIdNumber = Number(propertyId);
+    const { cognitoId, propertyId } = matchedData(req) as {
+      cognitoId: string;
+      propertyId: number;
+    };
 
     const updatedTenant = await prisma.tenant.update({
       where: { cognitoId },
       data: {
         favorites: {
-          disconnect: { id: propertyIdNumber },
+          disconnect: { id: propertyId },
         },
       },
       include: { favorites: true },

--- a/server/src/middleware/validationMiddleware.ts
+++ b/server/src/middleware/validationMiddleware.ts
@@ -1,0 +1,15 @@
+import { Request, Response, NextFunction } from "express";
+import { validationResult } from "express-validator";
+
+export const validate = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    res.status(400).json({ errors: errors.array() });
+    return;
+  }
+  next();
+};

--- a/server/src/routes/applicationRoutes.ts
+++ b/server/src/routes/applicationRoutes.ts
@@ -1,15 +1,50 @@
 import express from "express";
+import { body, param, query } from "express-validator";
 import { authMiddleware } from "../middleware/authMiddleware";
 import {
   createApplication,
   listApplications,
   updateApplicationStatus,
 } from "../controllers/applicationControllers";
+import { validate } from "../middleware/validationMiddleware";
 
 const router = express.Router();
 
-router.post("/", authMiddleware(["tenant"]), createApplication);
-router.put("/:id/status", authMiddleware(["manager"]), updateApplicationStatus);
-router.get("/", authMiddleware(["manager", "tenant"]), listApplications);
+router.post(
+  "/",
+  authMiddleware(["tenant"]),
+  [
+    body("applicationDate").isISO8601(),
+    body("status").isIn(["Pending", "Approved", "Denied"]),
+    body("propertyId").isInt().toInt(),
+    body("tenantCognitoId").isString().notEmpty(),
+    body("name").isString().notEmpty(),
+    body("email").isEmail(),
+    body("phoneNumber").isString().notEmpty(),
+    body("message").optional().isString(),
+    validate,
+  ],
+  createApplication
+);
+router.put(
+  "/:id/status",
+  authMiddleware(["manager"]),
+  [
+    param("id").isInt().toInt(),
+    body("status").isIn(["Pending", "Approved", "Denied"]),
+    validate,
+  ],
+  updateApplicationStatus
+);
+router.get(
+  "/",
+  authMiddleware(["manager", "tenant"]),
+  [
+    query("userId").optional().isString(),
+    query("userType").optional().isIn(["tenant", "manager"]),
+    validate,
+  ],
+  listApplications
+);
 
 export default router;

--- a/server/src/routes/leaseRoutes.ts
+++ b/server/src/routes/leaseRoutes.ts
@@ -1,6 +1,8 @@
 import express from "express";
+import { param } from "express-validator";
 import { authMiddleware } from "../middleware/authMiddleware";
 import { getLeasePayments, getLeases } from "../controllers/leaseControllers";
+import { validate } from "../middleware/validationMiddleware";
 
 const router = express.Router();
 
@@ -8,6 +10,7 @@ router.get("/", authMiddleware(["manager", "tenant"]), getLeases);
 router.get(
   "/:id/payments",
   authMiddleware(["manager", "tenant"]),
+  [param("id").isInt().toInt(), validate],
   getLeasePayments
 );
 

--- a/server/src/routes/listings.ts
+++ b/server/src/routes/listings.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import { body, param } from "express-validator";
 import {
   getListings,
   getListing,
@@ -6,13 +7,41 @@ import {
   updateListing,
   deleteListing,
 } from "../controllers/listings";
+import { validate } from "../middleware/validationMiddleware";
 
 const router = express.Router();
 
 router.get("/", getListings);
-router.get("/:id", getListing);
-router.post("/", createListing);
-router.put("/:id", updateListing);
-router.delete("/:id", deleteListing);
+router.get(
+  "/:id",
+  [param("id").isInt().toInt(), validate],
+  getListing
+);
+router.post(
+  "/",
+  [
+    body("title").isString().notEmpty(),
+    body("description").isString().notEmpty(),
+    body("price").isFloat({ gt: 0 }).toFloat(),
+    validate,
+  ],
+  createListing
+);
+router.put(
+  "/:id",
+  [
+    param("id").isInt().toInt(),
+    body("title").isString().notEmpty(),
+    body("description").isString().notEmpty(),
+    body("price").isFloat({ gt: 0 }).toFloat(),
+    validate,
+  ],
+  updateListing
+);
+router.delete(
+  "/:id",
+  [param("id").isInt().toInt(), validate],
+  deleteListing
+);
 
 export default router;

--- a/server/src/routes/managerRoutes.ts
+++ b/server/src/routes/managerRoutes.ts
@@ -1,16 +1,46 @@
 import express from "express";
+import { body, param } from "express-validator";
 import {
   getManager,
   createManager,
   updateManager,
   getManagerProperties,
 } from "../controllers/managerControllers";
+import { validate } from "../middleware/validationMiddleware";
 
 const router = express.Router();
 
-router.get("/:cognitoId", getManager);
-router.put("/:cognitoId", updateManager);
-router.get("/:cognitoId/properties", getManagerProperties);
-router.post("/", createManager);
+router.get(
+  "/:cognitoId",
+  [param("cognitoId").isString().notEmpty(), validate],
+  getManager
+);
+router.put(
+  "/:cognitoId",
+  [
+    param("cognitoId").isString().notEmpty(),
+    body("name").isString().notEmpty(),
+    body("email").isEmail(),
+    body("phoneNumber").isString().notEmpty(),
+    validate,
+  ],
+  updateManager
+);
+router.get(
+  "/:cognitoId/properties",
+  [param("cognitoId").isString().notEmpty(), validate],
+  getManagerProperties
+);
+router.post(
+  "/",
+  [
+    body("cognitoId").isString().notEmpty(),
+    body("name").isString().notEmpty(),
+    body("email").isEmail(),
+    body("phoneNumber").isString().notEmpty(),
+    validate,
+  ],
+  createManager
+);
 
 export default router;

--- a/server/src/routes/propertyRoutes.ts
+++ b/server/src/routes/propertyRoutes.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import { body, param, query } from "express-validator";
 import {
   getProperties,
   getProperty,
@@ -6,18 +7,56 @@ import {
 } from "../controllers/propertyControllers";
 import multer from "multer";
 import { authMiddleware } from "../middleware/authMiddleware";
+import { validate } from "../middleware/validationMiddleware";
 
 const storage = multer.memoryStorage();
 const upload = multer({ storage: storage });
 
 const router = express.Router();
 
-router.get("/", getProperties);
-router.get("/:id", getProperty);
+router.get(
+  "/",
+  [
+    query("favoriteIds").optional().isString(),
+    query("priceMin").optional().isFloat().toFloat(),
+    query("priceMax").optional().isFloat().toFloat(),
+    query("beds").optional().isInt().toInt(),
+    query("baths").optional().isFloat().toFloat(),
+    query("propertyType").optional().isString(),
+    query("squareFeetMin").optional().isInt().toInt(),
+    query("squareFeetMax").optional().isInt().toInt(),
+    query("amenities").optional().isString(),
+    query("availableFrom").optional().isISO8601(),
+    query("latitude").optional().isFloat().toFloat(),
+    query("longitude").optional().isFloat().toFloat(),
+    validate,
+  ],
+  getProperties
+);
+router.get(
+  "/:id",
+  [param("id").isInt().toInt(), validate],
+  getProperty
+);
 router.post(
   "/",
   authMiddleware(["manager"]),
   upload.array("photos"),
+  [
+    body("address").isString().notEmpty(),
+    body("city").isString().notEmpty(),
+    body("state").isString().notEmpty(),
+    body("country").isString().notEmpty(),
+    body("postalCode").isString().notEmpty(),
+    body("managerCognitoId").isString().notEmpty(),
+    body("pricePerMonth").isFloat().toFloat(),
+    body("securityDeposit").isFloat().toFloat(),
+    body("applicationFee").isFloat().toFloat(),
+    body("beds").isInt().toInt(),
+    body("baths").isFloat().toFloat(),
+    body("squareFeet").isInt().toInt(),
+    validate,
+  ],
   createProperty
 );
 

--- a/server/src/routes/tenantRoutes.ts
+++ b/server/src/routes/tenantRoutes.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import { body, param } from "express-validator";
 import {
   getTenant,
   createTenant,
@@ -7,14 +8,59 @@ import {
   addFavoriteProperty,
   removeFavoriteProperty,
 } from "../controllers/tenantControllers";
+import { validate } from "../middleware/validationMiddleware";
 
 const router = express.Router();
 
-router.get("/:cognitoId", getTenant);
-router.put("/:cognitoId", updateTenant);
-router.post("/", createTenant);
-router.get("/:cognitoId/current-residences", getCurrentResidences);
-router.post("/:cognitoId/favorites/:propertyId", addFavoriteProperty);
-router.delete("/:cognitoId/favorites/:propertyId", removeFavoriteProperty);
+router.get(
+  "/:cognitoId",
+  [param("cognitoId").isString().notEmpty(), validate],
+  getTenant
+);
+router.put(
+  "/:cognitoId",
+  [
+    param("cognitoId").isString().notEmpty(),
+    body("name").isString().notEmpty(),
+    body("email").isEmail(),
+    body("phoneNumber").isString().notEmpty(),
+    validate,
+  ],
+  updateTenant
+);
+router.post(
+  "/",
+  [
+    body("cognitoId").isString().notEmpty(),
+    body("name").isString().notEmpty(),
+    body("email").isEmail(),
+    body("phoneNumber").isString().notEmpty(),
+    validate,
+  ],
+  createTenant
+);
+router.get(
+  "/:cognitoId/current-residences",
+  [param("cognitoId").isString().notEmpty(), validate],
+  getCurrentResidences
+);
+router.post(
+  "/:cognitoId/favorites/:propertyId",
+  [
+    param("cognitoId").isString().notEmpty(),
+    param("propertyId").isInt().toInt(),
+    validate,
+  ],
+  addFavoriteProperty
+);
+router.delete(
+  "/:cognitoId/favorites/:propertyId",
+  [
+    param("cognitoId").isString().notEmpty(),
+    param("propertyId").isInt().toInt(),
+    validate,
+  ],
+  removeFavoriteProperty
+);
 
 export default router;


### PR DESCRIPTION
## Summary
- add express-validator dependency and centralized validation middleware
- enforce request schemas across listings, applications, leases, properties, managers and tenants routes
- update controllers to rely on sanitized values from matched data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'supertest' or type definitions for test runner)*

------
https://chatgpt.com/codex/tasks/task_e_6898d5ff4a648328a0fbc0686d1c6f81