### PR TITLE
Centralize Express error handling

### DIFF
--- a/server/src/controllers/applicationControllers.ts
+++ b/server/src/controllers/applicationControllers.ts
@@ -1,11 +1,12 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
 export const listApplications = async (
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> => {
   try {
     const { userId, userType } = req.query;
@@ -77,15 +78,14 @@ export const listApplications = async (
 
     res.json(formattedApplications);
   } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error retrieving applications: ${error.message}` });
+    next(error);
   }
 };
 
 export const createApplication = async (
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> => {
   try {
     const {
@@ -159,15 +159,14 @@ export const createApplication = async (
 
     res.status(201).json(newApplication);
   } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error creating application: ${error.message}` });
+    next(error);
   }
 };
 
 export const updateApplicationStatus = async (
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> => {
   try {
     const { id } = req.params;
@@ -241,8 +240,6 @@ export const updateApplicationStatus = async (
 
     res.json(updatedApplication);
   } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error updating application status: ${error.message}` });
+    next(error);
   }
 };

--- a/server/src/controllers/leaseControllers.ts
+++ b/server/src/controllers/leaseControllers.ts
@@ -1,9 +1,13 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
-export const getLeases = async (req: Request, res: Response): Promise<void> => {
+export const getLeases = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
   try {
     const leases = await prisma.lease.findMany({
       include: {
@@ -13,15 +17,14 @@ export const getLeases = async (req: Request, res: Response): Promise<void> => {
     });
     res.json(leases);
   } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error retrieving leases: ${error.message}` });
+    next(error);
   }
 };
 
 export const getLeasePayments = async (
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> => {
   try {
     const { id } = req.params;
@@ -30,8 +33,6 @@ export const getLeasePayments = async (
     });
     res.json(payments);
   } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error retrieving lease payments: ${error.message}` });
+    next(error);
   }
 };

--- a/server/src/controllers/listings.ts
+++ b/server/src/controllers/listings.ts
@@ -1,20 +1,26 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
-export const getListings = async (req: Request, res: Response): Promise<void> => {
+export const getListings = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
   try {
     const listings = await prisma.listing.findMany();
     res.json(listings);
   } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error retrieving listings: ${error.message}` });
+    next(error);
   }
 };
 
-export const getListing = async (req: Request, res: Response): Promise<void> => {
+export const getListing = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
   try {
     const { id } = req.params;
     const listing = await prisma.listing.findUnique({
@@ -26,13 +32,15 @@ export const getListing = async (req: Request, res: Response): Promise<void> => 
       res.status(404).json({ message: "Listing not found" });
     }
   } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error retrieving listing: ${error.message}` });
+    next(error);
   }
 };
 
-export const createListing = async (req: Request, res: Response): Promise<void> => {
+export const createListing = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
   try {
     const { title, description, price } = req.body;
     const listing = await prisma.listing.create({
@@ -44,13 +52,15 @@ export const createListing = async (req: Request, res: Response): Promise<void> 
     });
     res.status(201).json(listing);
   } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error creating listing: ${error.message}` });
+    next(error);
   }
 };
 
-export const updateListing = async (req: Request, res: Response): Promise<void> => {
+export const updateListing = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
   try {
     const { id } = req.params;
     const { title, description, price } = req.body;
@@ -64,20 +74,20 @@ export const updateListing = async (req: Request, res: Response): Promise<void> 
     });
     res.json(listing);
   } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error updating listing: ${error.message}` });
+    next(error);
   }
 };
 
-export const deleteListing = async (req: Request, res: Response): Promise<void> => {
+export const deleteListing = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
   try {
     const { id } = req.params;
     await prisma.listing.delete({ where: { id: Number(id) } });
     res.status(204).send();
   } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error deleting listing: ${error.message}` });
+    next(error);
   }
 };

--- a/server/src/controllers/managerControllers.ts
+++ b/server/src/controllers/managerControllers.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import { PrismaClient } from "@prisma/client";
 import { wktToGeoJSON } from "@terraformer/wkt";
 
@@ -6,7 +6,8 @@ const prisma = new PrismaClient();
 
 export const getManager = async (
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> => {
   try {
     const { cognitoId } = req.params;
@@ -20,15 +21,14 @@ export const getManager = async (
       res.status(404).json({ message: "Manager not found" });
     }
   } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error retrieving manager: ${error.message}` });
+    next(error);
   }
 };
 
 export const createManager = async (
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> => {
   try {
     const { cognitoId, name, email, phoneNumber } = req.body;
@@ -44,15 +44,14 @@ export const createManager = async (
 
     res.status(201).json(manager);
   } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error creating manager: ${error.message}` });
+    next(error);
   }
 };
 
 export const updateManager = async (
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> => {
   try {
     const { cognitoId } = req.params;
@@ -69,15 +68,14 @@ export const updateManager = async (
 
     res.json(updateManager);
   } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error updating manager: ${error.message}` });
+    next(error);
   }
 };
 
 export const getManagerProperties = async (
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> => {
   try {
     const { cognitoId } = req.params;
@@ -112,8 +110,6 @@ export const getManagerProperties = async (
 
     res.json(propertiesWithFormattedLocation);
   } catch (err: any) {
-    res
-      .status(500)
-      .json({ message: `Error retrieving manager properties: ${err.message}` });
+    next(err);
   }
 };

--- a/server/src/controllers/propertyControllers.ts
+++ b/server/src/controllers/propertyControllers.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import { PrismaClient, Prisma } from "@prisma/client";
 import { wktToGeoJSON } from "@terraformer/wkt";
 import { S3Client } from "@aws-sdk/client-s3";
@@ -14,7 +14,8 @@ const s3Client = new S3Client({
 
 export const getProperties = async (
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> => {
   try {
     const {
@@ -144,15 +145,14 @@ export const getProperties = async (
 
     res.json(properties);
   } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error retrieving properties: ${error.message}` });
+    next(error);
   }
 };
 
 export const getProperty = async (
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> => {
   try {
     const { id } = req.params;
@@ -184,15 +184,14 @@ export const getProperty = async (
       res.json(propertyWithCoordinates);
     }
   } catch (err: any) {
-    res
-      .status(500)
-      .json({ message: `Error retrieving property: ${err.message}` });
+    next(err);
   }
 };
 
 export const createProperty = async (
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> => {
   try {
     const files = req.files as Express.Multer.File[];
@@ -286,8 +285,6 @@ export const createProperty = async (
 
     res.status(201).json(newProperty);
   } catch (err: any) {
-    res
-      .status(500)
-      .json({ message: `Error creating property: ${err.message}` });
+    next(err);
   }
 };

--- a/server/src/controllers/tenantControllers.ts
+++ b/server/src/controllers/tenantControllers.ts
@@ -1,10 +1,14 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import { PrismaClient } from "@prisma/client";
 import { wktToGeoJSON } from "@terraformer/wkt";
 
 const prisma = new PrismaClient();
 
-export const getTenant = async (req: Request, res: Response): Promise<void> => {
+export const getTenant = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
   try {
     const { cognitoId } = req.params;
     const tenant = await prisma.tenant.findUnique({
@@ -20,15 +24,14 @@ export const getTenant = async (req: Request, res: Response): Promise<void> => {
       res.status(404).json({ message: "Tenant not found" });
     }
   } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error retrieving tenant: ${error.message}` });
+    next(error);
   }
 };
 
 export const createTenant = async (
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> => {
   try {
     const { cognitoId, name, email, phoneNumber } = req.body;
@@ -44,15 +47,14 @@ export const createTenant = async (
 
     res.status(201).json(tenant);
   } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error creating tenant: ${error.message}` });
+    next(error);
   }
 };
 
 export const updateTenant = async (
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> => {
   try {
     const { cognitoId } = req.params;
@@ -69,15 +71,14 @@ export const updateTenant = async (
 
     res.json(updateTenant);
   } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error updating tenant: ${error.message}` });
+    next(error);
   }
 };
 
 export const getCurrentResidences = async (
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> => {
   try {
     const { cognitoId } = req.params;
@@ -112,15 +113,14 @@ export const getCurrentResidences = async (
 
     res.json(residencesWithFormattedLocation);
   } catch (err: any) {
-    res
-      .status(500)
-      .json({ message: `Error retrieving manager properties: ${err.message}` });
+    next(err);
   }
 };
 
 export const addFavoriteProperty = async (
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> => {
   try {
     const { cognitoId, propertyId } = req.params;
@@ -152,15 +152,14 @@ export const addFavoriteProperty = async (
       res.status(409).json({ message: "Property already added as favorite" });
     }
   } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error adding favorite property: ${error.message}` });
+    next(error);
   }
 };
 
 export const removeFavoriteProperty = async (
   req: Request,
-  res: Response
+  res: Response,
+  next: NextFunction
 ): Promise<void> => {
   try {
     const { cognitoId, propertyId } = req.params;
@@ -178,8 +177,6 @@ export const removeFavoriteProperty = async (
 
     res.json(updatedTenant);
   } catch (err: any) {
-    res
-      .status(500)
-      .json({ message: `Error removing favorite property: ${err.message}` });
+    next(err);
   }
 };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,7 @@ import cors from "cors";
 import helmet from "helmet";
 import morgan from "morgan";
 import { authMiddleware } from "./middleware/authMiddleware";
+import { errorHandler } from "./middleware/errorHandler";
 /* ROUTE IMPORT */
 import tenantRoutes from "./routes/tenantRoutes";
 import managerRoutes from "./routes/managerRoutes";
@@ -35,6 +36,9 @@ app.use("/leases", leaseRoutes);
 app.use("/listings", listingsRoutes);
 app.use("/tenants", authMiddleware(["tenant"]), tenantRoutes);
 app.use("/managers", authMiddleware(["manager"]), managerRoutes);
+
+/* ERROR HANDLER */
+app.use(errorHandler);
 
 /* SERVER */
 const port = Number(process.env.PORT) || 3002;

--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -1,0 +1,14 @@
+import { Request, Response, NextFunction } from "express";
+
+export const errorHandler = (
+  err: any,
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
+  console.error(err);
+  const status = err.status || err.statusCode || 500;
+  const message = err.message || "Internal Server Error";
+  res.status(status).json({ message });
+};
+


### PR DESCRIPTION
## Summary
- Add global errorHandler middleware to shape server error responses
- Route controllers now forward errors with `next(err)` instead of responding directly
- Register errorHandler after all routes in server entrypoint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'supertest' and missing test runner types)*

------
https://chatgpt.com/codex/tasks/task_e_6898d5fd05a8832896c3b41e90a75678