### PR TITLE
Verify JWT tokens in auth middleware

### DIFF
--- a/server/src/middleware/authMiddleware.ts
+++ b/server/src/middleware/authMiddleware.ts
@@ -27,21 +27,26 @@ export const authMiddleware = (allowedRoles: string[]) => {
     }
 
     try {
-      const decoded = jwt.decode(token) as DecodedToken;
-      const userRole = decoded["custom:role"] || "";
+      const secretOrPublicKey =
+        process.env.JWT_PUBLIC_KEY || process.env.JWT_SECRET || "";
+      const decoded = jwt.verify(token, secretOrPublicKey) as DecodedToken;
+      const userRole = (decoded["custom:role"] || "").toLowerCase();
+
       req.user = {
         id: decoded.sub,
         role: userRole,
       };
 
-      const hasAccess = allowedRoles.includes(userRole.toLowerCase());
+      const hasAccess = allowedRoles
+        .map((role) => role.toLowerCase())
+        .includes(userRole);
       if (!hasAccess) {
         res.status(403).json({ message: "Access Denied" });
         return;
       }
     } catch (err) {
-      console.error("Failed to decode token:", err);
-      res.status(400).json({ message: "Invalid token" });
+      console.error("Failed to verify token:", err);
+      res.status(401).json({ message: "Unauthorized" });
       return;
     }
 


### PR DESCRIPTION
## Summary
- verify JWT tokens using secret or public key
- attach decoded user id and role to the request
- return 401 for invalid or malformed tokens

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898d5fa48fc8328b72267b16c482900