### PR TITLE
feat: centralize server error handling

### DIFF
--- a/server/src/controllers/applicationControllers.ts
+++ b/server/src/controllers/applicationControllers.ts
@@ -1,13 +1,11 @@
 import { Request, Response } from "express";
 import { PrismaClient } from "@prisma/client";
+import { asyncHandler } from "../middleware/asyncHandler";
 
 const prisma = new PrismaClient();
 
-export const listApplications = async (
-  req: Request,
-  res: Response
-): Promise<void> => {
-  try {
+export const listApplications = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
     const { userId, userType } = req.query;
 
     let whereClause = {};
@@ -76,18 +74,11 @@ export const listApplications = async (
     );
 
     res.json(formattedApplications);
-  } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error retrieving applications: ${error.message}` });
   }
-};
+);
 
-export const createApplication = async (
-  req: Request,
-  res: Response
-): Promise<void> => {
-  try {
+export const createApplication = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
     const {
       applicationDate,
       status,
@@ -158,18 +149,11 @@ export const createApplication = async (
     });
 
     res.status(201).json(newApplication);
-  } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error creating application: ${error.message}` });
   }
-};
+);
 
-export const updateApplicationStatus = async (
-  req: Request,
-  res: Response
-): Promise<void> => {
-  try {
+export const updateApplicationStatus = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
     const { id } = req.params;
     const { status } = req.body;
     console.log("status:", status);
@@ -240,9 +224,5 @@ export const updateApplicationStatus = async (
     });
 
     res.json(updatedApplication);
-  } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error updating application status: ${error.message}` });
   }
-};
+);

--- a/server/src/controllers/leaseControllers.ts
+++ b/server/src/controllers/leaseControllers.ts
@@ -1,10 +1,11 @@
 import { Request, Response } from "express";
 import { PrismaClient } from "@prisma/client";
+import { asyncHandler } from "../middleware/asyncHandler";
 
 const prisma = new PrismaClient();
 
-export const getLeases = async (req: Request, res: Response): Promise<void> => {
-  try {
+export const getLeases = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
     const leases = await prisma.lease.findMany({
       include: {
         tenant: true,
@@ -12,26 +13,15 @@ export const getLeases = async (req: Request, res: Response): Promise<void> => {
       },
     });
     res.json(leases);
-  } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error retrieving leases: ${error.message}` });
   }
-};
+);
 
-export const getLeasePayments = async (
-  req: Request,
-  res: Response
-): Promise<void> => {
-  try {
+export const getLeasePayments = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
     const { id } = req.params;
     const payments = await prisma.payment.findMany({
       where: { leaseId: Number(id) },
     });
     res.json(payments);
-  } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error retrieving lease payments: ${error.message}` });
   }
-};
+);

--- a/server/src/controllers/listings.ts
+++ b/server/src/controllers/listings.ts
@@ -1,21 +1,18 @@
 import { Request, Response } from "express";
 import { PrismaClient } from "@prisma/client";
+import { asyncHandler } from "../middleware/asyncHandler";
 
 const prisma = new PrismaClient();
 
-export const getListings = async (req: Request, res: Response): Promise<void> => {
-  try {
+export const getListings = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
     const listings = await prisma.listing.findMany();
     res.json(listings);
-  } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error retrieving listings: ${error.message}` });
   }
-};
+);
 
-export const getListing = async (req: Request, res: Response): Promise<void> => {
-  try {
+export const getListing = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
     const { id } = req.params;
     const listing = await prisma.listing.findUnique({
       where: { id: Number(id) },
@@ -25,15 +22,11 @@ export const getListing = async (req: Request, res: Response): Promise<void> => 
     } else {
       res.status(404).json({ message: "Listing not found" });
     }
-  } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error retrieving listing: ${error.message}` });
   }
-};
+);
 
-export const createListing = async (req: Request, res: Response): Promise<void> => {
-  try {
+export const createListing = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
     const { title, description, price } = req.body;
     const listing = await prisma.listing.create({
       data: {
@@ -43,15 +36,11 @@ export const createListing = async (req: Request, res: Response): Promise<void> 
       },
     });
     res.status(201).json(listing);
-  } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error creating listing: ${error.message}` });
   }
-};
+);
 
-export const updateListing = async (req: Request, res: Response): Promise<void> => {
-  try {
+export const updateListing = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
     const { id } = req.params;
     const { title, description, price } = req.body;
     const listing = await prisma.listing.update({
@@ -63,21 +52,13 @@ export const updateListing = async (req: Request, res: Response): Promise<void> 
       },
     });
     res.json(listing);
-  } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error updating listing: ${error.message}` });
   }
-};
+);
 
-export const deleteListing = async (req: Request, res: Response): Promise<void> => {
-  try {
+export const deleteListing = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
     const { id } = req.params;
     await prisma.listing.delete({ where: { id: Number(id) } });
     res.status(204).send();
-  } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error deleting listing: ${error.message}` });
   }
-};
+);

--- a/server/src/controllers/managerControllers.ts
+++ b/server/src/controllers/managerControllers.ts
@@ -1,14 +1,12 @@
 import { Request, Response } from "express";
 import { PrismaClient } from "@prisma/client";
 import { wktToGeoJSON } from "@terraformer/wkt";
+import { asyncHandler } from "../middleware/asyncHandler";
 
 const prisma = new PrismaClient();
 
-export const getManager = async (
-  req: Request,
-  res: Response
-): Promise<void> => {
-  try {
+export const getManager = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
     const { cognitoId } = req.params;
     const manager = await prisma.manager.findUnique({
       where: { cognitoId },
@@ -19,18 +17,11 @@ export const getManager = async (
     } else {
       res.status(404).json({ message: "Manager not found" });
     }
-  } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error retrieving manager: ${error.message}` });
   }
-};
+);
 
-export const createManager = async (
-  req: Request,
-  res: Response
-): Promise<void> => {
-  try {
+export const createManager = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
     const { cognitoId, name, email, phoneNumber } = req.body;
 
     const manager = await prisma.manager.create({
@@ -43,18 +34,11 @@ export const createManager = async (
     });
 
     res.status(201).json(manager);
-  } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error creating manager: ${error.message}` });
   }
-};
+);
 
-export const updateManager = async (
-  req: Request,
-  res: Response
-): Promise<void> => {
-  try {
+export const updateManager = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
     const { cognitoId } = req.params;
     const { name, email, phoneNumber } = req.body;
 
@@ -68,18 +52,11 @@ export const updateManager = async (
     });
 
     res.json(updateManager);
-  } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error updating manager: ${error.message}` });
   }
-};
+);
 
-export const getManagerProperties = async (
-  req: Request,
-  res: Response
-): Promise<void> => {
-  try {
+export const getManagerProperties = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
     const { cognitoId } = req.params;
     const properties = await prisma.property.findMany({
       where: { managerCognitoId: cognitoId },
@@ -111,9 +88,5 @@ export const getManagerProperties = async (
     );
 
     res.json(propertiesWithFormattedLocation);
-  } catch (err: any) {
-    res
-      .status(500)
-      .json({ message: `Error retrieving manager properties: ${err.message}` });
   }
-};
+);

--- a/server/src/controllers/propertyControllers.ts
+++ b/server/src/controllers/propertyControllers.ts
@@ -5,6 +5,7 @@ import { S3Client } from "@aws-sdk/client-s3";
 import { Location } from "@prisma/client";
 import { Upload } from "@aws-sdk/lib-storage";
 import axios from "axios";
+import { asyncHandler } from "../middleware/asyncHandler";
 
 const prisma = new PrismaClient();
 
@@ -12,11 +13,8 @@ const s3Client = new S3Client({
   region: process.env.AWS_REGION,
 });
 
-export const getProperties = async (
-  req: Request,
-  res: Response
-): Promise<void> => {
-  try {
+export const getProperties = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
     const {
       favoriteIds,
       priceMin,
@@ -143,18 +141,11 @@ export const getProperties = async (
     const properties = await prisma.$queryRaw(completeQuery);
 
     res.json(properties);
-  } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error retrieving properties: ${error.message}` });
   }
-};
+);
 
-export const getProperty = async (
-  req: Request,
-  res: Response
-): Promise<void> => {
-  try {
+export const getProperty = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
     const { id } = req.params;
     const property = await prisma.property.findUnique({
       where: { id: Number(id) },
@@ -183,18 +174,11 @@ export const getProperty = async (
       };
       res.json(propertyWithCoordinates);
     }
-  } catch (err: any) {
-    res
-      .status(500)
-      .json({ message: `Error retrieving property: ${err.message}` });
   }
-};
+);
 
-export const createProperty = async (
-  req: Request,
-  res: Response
-): Promise<void> => {
-  try {
+export const createProperty = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
     const files = req.files as Express.Multer.File[];
     const {
       address,
@@ -285,9 +269,5 @@ export const createProperty = async (
     });
 
     res.status(201).json(newProperty);
-  } catch (err: any) {
-    res
-      .status(500)
-      .json({ message: `Error creating property: ${err.message}` });
   }
-};
+);

--- a/server/src/controllers/tenantControllers.ts
+++ b/server/src/controllers/tenantControllers.ts
@@ -1,11 +1,12 @@
 import { Request, Response } from "express";
 import { PrismaClient } from "@prisma/client";
 import { wktToGeoJSON } from "@terraformer/wkt";
+import { asyncHandler } from "../middleware/asyncHandler";
 
 const prisma = new PrismaClient();
 
-export const getTenant = async (req: Request, res: Response): Promise<void> => {
-  try {
+export const getTenant = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
     const { cognitoId } = req.params;
     const tenant = await prisma.tenant.findUnique({
       where: { cognitoId },
@@ -19,18 +20,11 @@ export const getTenant = async (req: Request, res: Response): Promise<void> => {
     } else {
       res.status(404).json({ message: "Tenant not found" });
     }
-  } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error retrieving tenant: ${error.message}` });
   }
-};
+);
 
-export const createTenant = async (
-  req: Request,
-  res: Response
-): Promise<void> => {
-  try {
+export const createTenant = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
     const { cognitoId, name, email, phoneNumber } = req.body;
 
     const tenant = await prisma.tenant.create({
@@ -43,18 +37,11 @@ export const createTenant = async (
     });
 
     res.status(201).json(tenant);
-  } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error creating tenant: ${error.message}` });
   }
-};
+);
 
-export const updateTenant = async (
-  req: Request,
-  res: Response
-): Promise<void> => {
-  try {
+export const updateTenant = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
     const { cognitoId } = req.params;
     const { name, email, phoneNumber } = req.body;
 
@@ -68,18 +55,11 @@ export const updateTenant = async (
     });
 
     res.json(updateTenant);
-  } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error updating tenant: ${error.message}` });
   }
-};
+);
 
-export const getCurrentResidences = async (
-  req: Request,
-  res: Response
-): Promise<void> => {
-  try {
+export const getCurrentResidences = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
     const { cognitoId } = req.params;
     const properties = await prisma.property.findMany({
       where: { tenants: { some: { cognitoId } } },
@@ -111,18 +91,11 @@ export const getCurrentResidences = async (
     );
 
     res.json(residencesWithFormattedLocation);
-  } catch (err: any) {
-    res
-      .status(500)
-      .json({ message: `Error retrieving manager properties: ${err.message}` });
   }
-};
+);
 
-export const addFavoriteProperty = async (
-  req: Request,
-  res: Response
-): Promise<void> => {
-  try {
+export const addFavoriteProperty = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
     const { cognitoId, propertyId } = req.params;
     const tenant = await prisma.tenant.findUnique({
       where: { cognitoId },
@@ -151,18 +124,11 @@ export const addFavoriteProperty = async (
     } else {
       res.status(409).json({ message: "Property already added as favorite" });
     }
-  } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error adding favorite property: ${error.message}` });
   }
-};
+);
 
-export const removeFavoriteProperty = async (
-  req: Request,
-  res: Response
-): Promise<void> => {
-  try {
+export const removeFavoriteProperty = asyncHandler(
+  async (req: Request, res: Response): Promise<void> => {
     const { cognitoId, propertyId } = req.params;
     const propertyIdNumber = Number(propertyId);
 
@@ -177,9 +143,5 @@ export const removeFavoriteProperty = async (
     });
 
     res.json(updatedTenant);
-  } catch (err: any) {
-    res
-      .status(500)
-      .json({ message: `Error removing favorite property: ${err.message}` });
   }
-};
+);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,7 @@ import cors from "cors";
 import helmet from "helmet";
 import morgan from "morgan";
 import { authMiddleware } from "./middleware/authMiddleware";
+import { errorHandler } from "./middleware/errorHandler";
 /* ROUTE IMPORT */
 import tenantRoutes from "./routes/tenantRoutes";
 import managerRoutes from "./routes/managerRoutes";
@@ -35,6 +36,8 @@ app.use("/leases", leaseRoutes);
 app.use("/listings", listingsRoutes);
 app.use("/tenants", authMiddleware(["tenant"]), tenantRoutes);
 app.use("/managers", authMiddleware(["manager"]), managerRoutes);
+
+app.use(errorHandler);
 
 /* SERVER */
 const port = Number(process.env.PORT) || 3002;

--- a/server/src/middleware/asyncHandler.ts
+++ b/server/src/middleware/asyncHandler.ts
@@ -1,0 +1,16 @@
+import { Request, Response, NextFunction } from "express";
+
+type AsyncRouteHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => Promise<any>;
+
+export const asyncHandler = (fn: AsyncRouteHandler) => (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
+  Promise.resolve(fn(req, res, next)).catch(next);
+};
+

--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -1,0 +1,14 @@
+import { Request, Response, NextFunction } from "express";
+
+export const errorHandler = (
+  err: any,
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
+  console.error(err);
+  const statusCode = err.status || 500;
+  const message = err.message || "Internal Server Error";
+  res.status(statusCode).json({ message });
+};
+


### PR DESCRIPTION
## Summary
- add asyncHandler and errorHandler middleware
- wrap controllers with asyncHandler and remove try/catch blocks
- register errorHandler after routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'supertest' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6898d5f5ca908328933a652954a32261