### PR TITLE
Refactor property creation with helpers and transaction

### DIFF
--- a/server/src/controllers/propertyControllers.ts
+++ b/server/src/controllers/propertyControllers.ts
@@ -1,16 +1,12 @@
 import { Request, Response } from "express";
 import { PrismaClient, Prisma } from "@prisma/client";
 import { wktToGeoJSON } from "@terraformer/wkt";
-import { S3Client } from "@aws-sdk/client-s3";
 import { Location } from "@prisma/client";
-import { Upload } from "@aws-sdk/lib-storage";
-import axios from "axios";
+import { uploadFiles } from "../utils/s3Upload";
+import { geocodeAddress } from "../utils/geocode";
 
 const prisma = new PrismaClient();
 
-const s3Client = new S3Client({
-  region: process.env.AWS_REGION,
-});
 
 export const getProperties = async (
   req: Request,
@@ -206,82 +202,50 @@ export const createProperty = async (
       ...propertyData
     } = req.body;
 
-    const photoUrls = await Promise.all(
-      files.map(async (file) => {
-        const uploadParams = {
-          Bucket: process.env.S3_BUCKET_NAME!,
-          Key: `properties/${Date.now()}-${file.originalname}`,
-          Body: file.buffer,
-          ContentType: file.mimetype,
-        };
+    const photoUrls = await uploadFiles(files);
 
-        const uploadResult = await new Upload({
-          client: s3Client,
-          params: uploadParams,
-        }).done();
-
-        return uploadResult.Location;
-      })
-    );
-
-    const geocodingUrl = `https://nominatim.openstreetmap.org/search?${new URLSearchParams(
-      {
-        street: address,
-        city,
-        country,
-        postalcode: postalCode,
-        format: "json",
-        limit: "1",
-      }
-    ).toString()}`;
-    const geocodingResponse = await axios.get(geocodingUrl, {
-      headers: {
-        "User-Agent": "RealEstateApp (justsomedummyemail@gmail.com",
-      },
+    const { longitude, latitude } = await geocodeAddress({
+      address,
+      city,
+      country,
+      postalCode,
     });
-    const [longitude, latitude] =
-      geocodingResponse.data[0]?.lon && geocodingResponse.data[0]?.lat
-        ? [
-            parseFloat(geocodingResponse.data[0]?.lon),
-            parseFloat(geocodingResponse.data[0]?.lat),
-          ]
-        : [0, 0];
 
-    // create location
-    const [location] = await prisma.$queryRaw<Location[]>`
-      INSERT INTO "Location" (address, city, state, country, "postalCode", coordinates)
-      VALUES (${address}, ${city}, ${state}, ${country}, ${postalCode}, ST_SetSRID(ST_MakePoint(${longitude}, ${latitude}), 4326))
-      RETURNING id, address, city, state, country, "postalCode", ST_AsText(coordinates) as coordinates;
-    `;
+    const newProperty = await prisma.$transaction(async (tx) => {
+      const [location] = await tx.$queryRaw<Location[]>`
+        INSERT INTO "Location" (address, city, state, country, "postalCode", coordinates)
+        VALUES (${address}, ${city}, ${state}, ${country}, ${postalCode}, ST_SetSRID(ST_MakePoint(${longitude}, ${latitude}), 4326))
+        RETURNING id;
+      `;
 
-    // create property
-    const newProperty = await prisma.property.create({
-      data: {
-        ...propertyData,
-        photoUrls,
-        locationId: location.id,
-        managerCognitoId,
-        amenities:
-          typeof propertyData.amenities === "string"
-            ? propertyData.amenities.split(",")
-            : [],
-        highlights:
-          typeof propertyData.highlights === "string"
-            ? propertyData.highlights.split(",")
-            : [],
-        isPetsAllowed: propertyData.isPetsAllowed === "true",
-        isParkingIncluded: propertyData.isParkingIncluded === "true",
-        pricePerMonth: parseFloat(propertyData.pricePerMonth),
-        securityDeposit: parseFloat(propertyData.securityDeposit),
-        applicationFee: parseFloat(propertyData.applicationFee),
-        beds: parseInt(propertyData.beds),
-        baths: parseFloat(propertyData.baths),
-        squareFeet: parseInt(propertyData.squareFeet),
-      },
-      include: {
-        location: true,
-        manager: true,
-      },
+      return tx.property.create({
+        data: {
+          ...propertyData,
+          photoUrls,
+          locationId: location.id,
+          managerCognitoId,
+          amenities:
+            typeof propertyData.amenities === "string"
+              ? propertyData.amenities.split(",")
+              : [],
+          highlights:
+            typeof propertyData.highlights === "string"
+              ? propertyData.highlights.split(",")
+              : [],
+          isPetsAllowed: propertyData.isPetsAllowed === "true",
+          isParkingIncluded: propertyData.isParkingIncluded === "true",
+          pricePerMonth: parseFloat(propertyData.pricePerMonth),
+          securityDeposit: parseFloat(propertyData.securityDeposit),
+          applicationFee: parseFloat(propertyData.applicationFee),
+          beds: parseInt(propertyData.beds),
+          baths: parseFloat(propertyData.baths),
+          squareFeet: parseInt(propertyData.squareFeet),
+        },
+        include: {
+          location: true,
+          manager: true,
+        },
+      });
     });
 
     res.status(201).json(newProperty);

--- a/server/src/utils/geocode.ts
+++ b/server/src/utils/geocode.ts
@@ -1,0 +1,44 @@
+import axios from "axios";
+
+export interface GeocodeInput {
+  address: string;
+  city: string;
+  country: string;
+  postalCode: string;
+}
+
+export interface Coordinates {
+  longitude: number;
+  latitude: number;
+}
+
+export const geocodeAddress = async ({
+  address,
+  city,
+  country,
+  postalCode,
+}: GeocodeInput): Promise<Coordinates> => {
+  const geocodingUrl = `https://nominatim.openstreetmap.org/search?${new URLSearchParams({
+    street: address,
+    city,
+    country,
+    postalcode: postalCode,
+    format: "json",
+    limit: "1",
+  }).toString()}`;
+
+  const geocodingResponse = await axios.get(geocodingUrl, {
+    headers: {
+      "User-Agent": "RealEstateApp (justsomedummyemail@gmail.com)",
+    },
+  });
+
+  const longitude = geocodingResponse.data[0]?.lon
+    ? parseFloat(geocodingResponse.data[0].lon)
+    : 0;
+  const latitude = geocodingResponse.data[0]?.lat
+    ? parseFloat(geocodingResponse.data[0].lat)
+    : 0;
+
+  return { longitude, latitude };
+};

--- a/server/src/utils/s3Upload.ts
+++ b/server/src/utils/s3Upload.ts
@@ -1,0 +1,31 @@
+import { S3Client } from "@aws-sdk/client-s3";
+import { Upload } from "@aws-sdk/lib-storage";
+
+export const uploadFiles = async (
+  files: Express.Multer.File[]
+): Promise<string[]> => {
+  const { AWS_REGION, S3_BUCKET_NAME } = process.env;
+  if (!AWS_REGION || !S3_BUCKET_NAME) {
+    throw new Error("Missing AWS_REGION or S3_BUCKET_NAME environment variables");
+  }
+
+  const s3Client = new S3Client({ region: AWS_REGION });
+
+  return Promise.all(
+    files.map(async (file) => {
+      const uploadParams = {
+        Bucket: S3_BUCKET_NAME,
+        Key: `properties/${Date.now()}-${file.originalname}`,
+        Body: file.buffer,
+        ContentType: file.mimetype,
+      };
+
+      const uploadResult = await new Upload({
+        client: s3Client,
+        params: uploadParams,
+      }).done();
+
+      return (uploadResult as any).Location as string;
+    })
+  );
+};


### PR DESCRIPTION
## Summary
- reuseable geocoding and S3 upload helpers
- wrap location insert and property creation in prisma transaction
- validate AWS env vars before uploading

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run build` *(fails: Cannot find module 'supertest' / missing test runner types)*

------
https://chatgpt.com/codex/tasks/task_e_6898d5da31b4832893b1893006591d5f