### PR TITLE
feat: manage application status updates in service

### DIFF
--- a/server/src/controllers/applicationControllers.ts
+++ b/server/src/controllers/applicationControllers.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, ApplicationStatus } from "@prisma/client";
+import { updateApplicationStatus as updateApplicationStatusService } from "../services/applicationService";
 
 const prisma = new PrismaClient();
 
@@ -172,77 +173,20 @@ export const updateApplicationStatus = async (
   try {
     const { id } = req.params;
     const { status } = req.body;
-    console.log("status:", status);
 
-    const application = await prisma.application.findUnique({
-      where: { id: Number(id) },
-      include: {
-        property: true,
-        tenant: true,
-      },
-    });
-
-    if (!application) {
-      res.status(404).json({ message: "Application not found." });
-      return;
-    }
-
-    if (status === "Approved") {
-      const newLease = await prisma.lease.create({
-        data: {
-          startDate: new Date(),
-          endDate: new Date(
-            new Date().setFullYear(new Date().getFullYear() + 1)
-          ),
-          rent: application.property.pricePerMonth,
-          deposit: application.property.securityDeposit,
-          propertyId: application.propertyId,
-          tenantCognitoId: application.tenantCognitoId,
-        },
-      });
-
-      // Update the property to connect the tenant
-      await prisma.property.update({
-        where: { id: application.propertyId },
-        data: {
-          tenants: {
-            connect: { cognitoId: application.tenantCognitoId },
-          },
-        },
-      });
-
-      // Update the application with the new lease ID
-      await prisma.application.update({
-        where: { id: Number(id) },
-        data: { status, leaseId: newLease.id },
-        include: {
-          property: true,
-          tenant: true,
-          lease: true,
-        },
-      });
-    } else {
-      // Update the application status (for both "Denied" and other statuses)
-      await prisma.application.update({
-        where: { id: Number(id) },
-        data: { status },
-      });
-    }
-
-    // Respond with the updated application details
-    const updatedApplication = await prisma.application.findUnique({
-      where: { id: Number(id) },
-      include: {
-        property: true,
-        tenant: true,
-        lease: true,
-      },
-    });
+    const updatedApplication = await updateApplicationStatusService(
+      Number(id),
+      status as ApplicationStatus
+    );
 
     res.json(updatedApplication);
   } catch (error: any) {
-    res
-      .status(500)
-      .json({ message: `Error updating application status: ${error.message}` });
+    if (error.message === "Application not found") {
+      res.status(404).json({ message: error.message });
+    } else {
+      res
+        .status(500)
+        .json({ message: `Error updating application status: ${error.message}` });
+    }
   }
 };

--- a/server/src/services/applicationService.ts
+++ b/server/src/services/applicationService.ts
@@ -1,0 +1,53 @@
+import { PrismaClient, ApplicationStatus } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+export async function updateApplicationStatus(
+  id: number,
+  status: ApplicationStatus
+) {
+  return prisma.$transaction(async (tx) => {
+    const application = await tx.application.findUnique({
+      where: { id },
+      include: { property: true, tenant: true },
+    });
+
+    if (!application) {
+      throw new Error("Application not found");
+    }
+
+    if (status === "Approved") {
+      const newLease = await tx.lease.create({
+        data: {
+          startDate: new Date(),
+          endDate: new Date(new Date().setFullYear(new Date().getFullYear() + 1)),
+          rent: application.property.pricePerMonth,
+          deposit: application.property.securityDeposit,
+          propertyId: application.propertyId,
+          tenantCognitoId: application.tenantCognitoId,
+        },
+      });
+
+      await tx.property.update({
+        where: { id: application.propertyId },
+        data: {
+          tenants: {
+            connect: { cognitoId: application.tenantCognitoId },
+          },
+        },
+      });
+
+      return tx.application.update({
+        where: { id },
+        data: { status, leaseId: newLease.id },
+        include: { property: true, tenant: true, lease: true },
+      });
+    }
+
+    return tx.application.update({
+      where: { id },
+      data: { status },
+      include: { property: true, tenant: true, lease: true },
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- handle application status updates within service and Prisma transaction
- integrate service in controller and remove debug logging

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Cannot find module 'supertest' or its corresponding type declarations)


------
https://chatgpt.com/codex/tasks/task_e_6898d5d9130c83289832a4aef4093683