### PR TITLE
refactor: centralize Prisma client management

### DIFF
--- a/server/src/controllers/applicationControllers.ts
+++ b/server/src/controllers/applicationControllers.ts
@@ -1,7 +1,5 @@
 import { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import prisma from "../prismaClient";
 
 export const listApplications = async (
   req: Request,

--- a/server/src/controllers/leaseControllers.ts
+++ b/server/src/controllers/leaseControllers.ts
@@ -1,7 +1,5 @@
 import { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import prisma from "../prismaClient";
 
 export const getLeases = async (req: Request, res: Response): Promise<void> => {
   try {

--- a/server/src/controllers/listings.ts
+++ b/server/src/controllers/listings.ts
@@ -1,7 +1,5 @@
 import { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import prisma from "../prismaClient";
 
 export const getListings = async (req: Request, res: Response): Promise<void> => {
   try {

--- a/server/src/controllers/managerControllers.ts
+++ b/server/src/controllers/managerControllers.ts
@@ -1,8 +1,6 @@
 import { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
 import { wktToGeoJSON } from "@terraformer/wkt";
-
-const prisma = new PrismaClient();
+import prisma from "../prismaClient";
 
 export const getManager = async (
   req: Request,

--- a/server/src/controllers/propertyControllers.ts
+++ b/server/src/controllers/propertyControllers.ts
@@ -1,12 +1,10 @@
 import { Request, Response } from "express";
-import { PrismaClient, Prisma } from "@prisma/client";
+import { Prisma, Location } from "@prisma/client";
 import { wktToGeoJSON } from "@terraformer/wkt";
 import { S3Client } from "@aws-sdk/client-s3";
-import { Location } from "@prisma/client";
 import { Upload } from "@aws-sdk/lib-storage";
 import axios from "axios";
-
-const prisma = new PrismaClient();
+import prisma from "../prismaClient";
 
 const s3Client = new S3Client({
   region: process.env.AWS_REGION,

--- a/server/src/controllers/tenantControllers.ts
+++ b/server/src/controllers/tenantControllers.ts
@@ -1,8 +1,6 @@
 import { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
 import { wktToGeoJSON } from "@terraformer/wkt";
-
-const prisma = new PrismaClient();
+import prisma from "../prismaClient";
 
 export const getTenant = async (req: Request, res: Response): Promise<void> => {
   try {

--- a/server/src/prismaClient.ts
+++ b/server/src/prismaClient.ts
@@ -1,0 +1,19 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+const disconnect = async () => {
+  await prisma.$disconnect();
+};
+
+process.on("beforeExit", disconnect);
+process.on("SIGINT", async () => {
+  await disconnect();
+  process.exit(0);
+});
+process.on("SIGTERM", async () => {
+  await disconnect();
+  process.exit(0);
+});
+
+export default prisma;


### PR DESCRIPTION
## Summary
- add reusable Prisma client and graceful shutdown handlers
- switch controllers to shared Prisma client

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'supertest' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6898d5d67c8483288b175f74b48f845f