### PR TITLE
feat: enhance listings with filtering and pagination

### DIFF
--- a/client/app/listings/page.tsx
+++ b/client/app/listings/page.tsx
@@ -8,11 +8,14 @@ import { fetchListings } from "@/lib/api";
 const ListingsPage = () => {
   const [listings, setListings] = useState<Listing[]>([]);
   const [query, setQuery] = useState("");
+  const [page, setPage] = useState(1);
+  const [pageCount, setPageCount] = useState(1);
 
   const loadListings = useCallback(async () => {
-    const data = await fetchListings(query);
-    setListings(data);
-  }, [query]);
+    const result = await fetchListings({ q: query, page });
+    setListings(result.listings);
+    setPageCount(result.pageCount || 1);
+  }, [query, page]);
 
   useEffect(() => {
     loadListings();
@@ -23,7 +26,10 @@ const ListingsPage = () => {
       <input
         type="text"
         value={query}
-        onChange={(e) => setQuery(e.target.value)}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setPage(1);
+        }}
         placeholder="Search listings..."
         className="w-full rounded-md border p-2"
       />
@@ -31,6 +37,25 @@ const ListingsPage = () => {
         {listings.map((listing) => (
           <ListingCard key={listing.id} listing={listing} />
         ))}
+      </div>
+      <div className="flex items-center justify-between">
+        <button
+          className="rounded bg-gray-200 px-4 py-2 disabled:opacity-50"
+          onClick={() => setPage((p) => Math.max(p - 1, 1))}
+          disabled={page <= 1}
+        >
+          Previous
+        </button>
+        <span>
+          Page {page} of {pageCount}
+        </span>
+        <button
+          className="rounded bg-gray-200 px-4 py-2 disabled:opacity-50"
+          onClick={() => setPage((p) => p + 1)}
+          disabled={page >= pageCount}
+        >
+          Next
+        </button>
       </div>
       <ListingForm onSuccess={loadListings} />
     </div>

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -4,13 +4,27 @@ const api = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:3002",
 });
 
-export const fetchListings = async (search?: string) => {
-  const response = await api.get("/properties", { params: { q: search } });
-  return response.data;
+interface ListingParams {
+  q?: string;
+  page?: number;
+  limit?: number;
+  minPrice?: number;
+  maxPrice?: number;
+  sortBy?: string;
+  order?: "asc" | "desc";
+}
+
+export const fetchListings = async (params?: ListingParams) => {
+  const response = await api.get("/listings", { params });
+  return {
+    listings: response.data,
+    total: Number(response.headers["x-total-count"] || 0),
+    pageCount: Number(response.headers["x-page-count"] || 0),
+  };
 };
 
 export const createListing = async (data: any) => {
-  const response = await api.post("/properties", data);
+  const response = await api.post("/listings", data);
   return response.data;
 };
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -18,6 +18,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.6.1",
         "express": "^4.21.2",
+        "express-rate-limit": "^7.5.1",
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.1",
@@ -2866,6 +2867,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/exsolve": {

--- a/server/package.json
+++ b/server/package.json
@@ -24,6 +24,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.6.1",
     "express": "^4.21.2",
+    "express-rate-limit": "^7.5.1",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.1",

--- a/server/src/__tests__/listings.test.ts
+++ b/server/src/__tests__/listings.test.ts
@@ -47,4 +47,31 @@ describe("Listings API", () => {
     const res = await request(app).delete(`/listings/${listing.id}`);
     expect(res.status).toBe(204);
   });
+
+  it("filters, sorts, and paginates listings", async () => {
+    await prisma.listing.createMany({
+      data: [
+        { title: "Cheap Bike", description: "A", price: 50 },
+        { title: "Expensive Bike", description: "B", price: 150 },
+        { title: "Car", description: "C", price: 2000 },
+      ],
+    });
+
+    const res = await request(app)
+      .get("/listings")
+      .query({
+        q: "bike",
+        minPrice: 50,
+        maxPrice: 200,
+        sortBy: "price",
+        order: "desc",
+        page: 1,
+        limit: 1,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].title).toBe("Expensive Bike");
+    expect(res.headers["x-total-count"]).toBe("2");
+  });
 });

--- a/server/src/controllers/listings.ts
+++ b/server/src/controllers/listings.ts
@@ -3,9 +3,92 @@ import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
+interface CacheEntry {
+  data: any;
+  total: number;
+  timestamp: number;
+}
+
+const CACHE_TTL = 60 * 1000; // 60 seconds
+const cache = new Map<string, CacheEntry>();
+
 export const getListings = async (req: Request, res: Response): Promise<void> => {
   try {
-    const listings = await prisma.listing.findMany();
+    const {
+      q,
+      minPrice,
+      maxPrice,
+      sortBy = "createdAt",
+      order = "asc",
+      page = "1",
+      limit = "10",
+    } = req.query;
+
+    const pageNum = Math.max(parseInt(page as string, 10) || 1, 1);
+    const limitNum = Math.min(
+      Math.max(parseInt(limit as string, 10) || 10, 1),
+      100
+    );
+    const min = minPrice !== undefined ? Number(minPrice) : undefined;
+    const max = maxPrice !== undefined ? Number(maxPrice) : undefined;
+
+    if ((min !== undefined && isNaN(min)) || (max !== undefined && isNaN(max))) {
+      res.status(400).json({ message: "Invalid price filter" });
+      return;
+    }
+
+    const cacheKey = JSON.stringify({
+      q,
+      min,
+      max,
+      sortBy,
+      order,
+      page: pageNum,
+      limit: limitNum,
+    });
+    const cached = cache.get(cacheKey);
+    if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+      res.set({
+        "X-Total-Count": cached.total.toString(),
+        "X-Page-Count": Math.ceil(cached.total / limitNum).toString(),
+        "X-Current-Page": pageNum.toString(),
+      });
+      res.json(cached.data);
+      return;
+    }
+
+    const where: any = {};
+    if (q) {
+      where.OR = [
+        { title: { contains: q as string, mode: "insensitive" } },
+        { description: { contains: q as string, mode: "insensitive" } },
+      ];
+    }
+    if (min !== undefined || max !== undefined) {
+      where.price = {};
+      if (min !== undefined) where.price.gte = min;
+      if (max !== undefined) where.price.lte = max;
+    }
+
+    const skip = (pageNum - 1) * limitNum;
+    const [listings, total] = await prisma.$transaction([
+      prisma.listing.findMany({
+        where,
+        skip,
+        take: limitNum,
+        orderBy: { [sortBy as string]: order },
+      }),
+      prisma.listing.count({ where }),
+    ]);
+
+    res.set({
+      "X-Total-Count": total.toString(),
+      "X-Page-Count": Math.ceil(total / limitNum).toString(),
+      "X-Current-Page": pageNum.toString(),
+    });
+
+    cache.set(cacheKey, { data: listings, total, timestamp: Date.now() });
+
     res.json(listings);
   } catch (error: any) {
     res
@@ -35,13 +118,20 @@ export const getListing = async (req: Request, res: Response): Promise<void> => 
 export const createListing = async (req: Request, res: Response): Promise<void> => {
   try {
     const { title, description, price } = req.body;
+    const priceNum = Number(price);
+    if (!title || !description || isNaN(priceNum) || priceNum <= 0) {
+      res.status(400).json({ message: "Invalid listing data" });
+      return;
+    }
+
     const listing = await prisma.listing.create({
       data: {
         title,
         description,
-        price: Number(price),
+        price: priceNum,
       },
     });
+    cache.clear();
     res.status(201).json(listing);
   } catch (error: any) {
     res
@@ -54,14 +144,21 @@ export const updateListing = async (req: Request, res: Response): Promise<void> 
   try {
     const { id } = req.params;
     const { title, description, price } = req.body;
+    const priceNum = Number(price);
+    if (!title || !description || isNaN(priceNum) || priceNum <= 0) {
+      res.status(400).json({ message: "Invalid listing data" });
+      return;
+    }
+
     const listing = await prisma.listing.update({
       where: { id: Number(id) },
       data: {
         title,
         description,
-        price: Number(price),
+        price: priceNum,
       },
     });
+    cache.clear();
     res.json(listing);
   } catch (error: any) {
     res
@@ -74,6 +171,7 @@ export const deleteListing = async (req: Request, res: Response): Promise<void> 
   try {
     const { id } = req.params;
     await prisma.listing.delete({ where: { id: Number(id) } });
+    cache.clear();
     res.status(204).send();
   } catch (error: any) {
     res

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,7 @@ import cors from "cors";
 import helmet from "helmet";
 import morgan from "morgan";
 import { authMiddleware } from "./middleware/authMiddleware";
+import { apiRateLimiter } from "./middleware/rateLimiter";
 /* ROUTE IMPORT */
 import tenantRoutes from "./routes/tenantRoutes";
 import managerRoutes from "./routes/managerRoutes";
@@ -23,6 +24,7 @@ app.use(morgan("common"));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cors());
+app.use(apiRateLimiter);
 
 /* ROUTES */
 app.get("/", (req, res) => {

--- a/server/src/middleware/rateLimiter.ts
+++ b/server/src/middleware/rateLimiter.ts
@@ -1,0 +1,11 @@
+import rateLimit from "express-rate-limit";
+
+export const apiRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => process.env.NODE_ENV === "test",
+});
+
+export default apiRateLimiter;


### PR DESCRIPTION
## Summary
- add filtering, pagination, and caching to listings API
- wire listings page to new paginated API
- enforce basic rate limiting for server routes

## Testing
- `npx --yes jest src/__tests__/listings.test.ts` *(fails: Jest encountered an unexpected token)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68955a23c9988328858638bb73ea6b9d