### PR TITLE
refactor: add services for s3 and geocoding

### DIFF
--- a/server/src/controllers/propertyControllers.ts
+++ b/server/src/controllers/propertyControllers.ts
@@ -1,16 +1,11 @@
 import { Request, Response } from "express";
-import { PrismaClient, Prisma } from "@prisma/client";
+import { PrismaClient, Prisma, Location } from "@prisma/client";
 import { wktToGeoJSON } from "@terraformer/wkt";
-import { S3Client } from "@aws-sdk/client-s3";
-import { Location } from "@prisma/client";
-import { Upload } from "@aws-sdk/lib-storage";
-import axios from "axios";
+import { uploadFile } from "../services/s3";
+import { geocodeAddress } from "../services/geocoding";
 
 const prisma = new PrismaClient();
 
-const s3Client = new S3Client({
-  region: process.env.AWS_REGION,
-});
 
 export const getProperties = async (
   req: Request,
@@ -206,46 +201,14 @@ export const createProperty = async (
       ...propertyData
     } = req.body;
 
-    const photoUrls = await Promise.all(
-      files.map(async (file) => {
-        const uploadParams = {
-          Bucket: process.env.S3_BUCKET_NAME!,
-          Key: `properties/${Date.now()}-${file.originalname}`,
-          Body: file.buffer,
-          ContentType: file.mimetype,
-        };
+    const photoUrls = await Promise.all(files.map(uploadFile));
 
-        const uploadResult = await new Upload({
-          client: s3Client,
-          params: uploadParams,
-        }).done();
-
-        return uploadResult.Location;
-      })
-    );
-
-    const geocodingUrl = `https://nominatim.openstreetmap.org/search?${new URLSearchParams(
-      {
-        street: address,
-        city,
-        country,
-        postalcode: postalCode,
-        format: "json",
-        limit: "1",
-      }
-    ).toString()}`;
-    const geocodingResponse = await axios.get(geocodingUrl, {
-      headers: {
-        "User-Agent": "RealEstateApp (justsomedummyemail@gmail.com",
-      },
+    const [longitude, latitude] = await geocodeAddress({
+      address,
+      city,
+      country,
+      postalCode,
     });
-    const [longitude, latitude] =
-      geocodingResponse.data[0]?.lon && geocodingResponse.data[0]?.lat
-        ? [
-            parseFloat(geocodingResponse.data[0]?.lon),
-            parseFloat(geocodingResponse.data[0]?.lat),
-          ]
-        : [0, 0];
 
     // create location
     const [location] = await prisma.$queryRaw<Location[]>`

--- a/server/src/services/geocoding.ts
+++ b/server/src/services/geocoding.ts
@@ -1,0 +1,57 @@
+import axios from "axios";
+
+interface GeocodeParams {
+  address: string;
+  city: string;
+  country: string;
+  postalCode: string;
+}
+
+const cache = new Map<string, [number, number]>();
+let lastRequestTime = 0;
+const RATE_LIMIT_MS = 1000;
+
+export const geocodeAddress = async ({
+  address,
+  city,
+  country,
+  postalCode,
+}: GeocodeParams): Promise<[number, number]> => {
+  const cacheKey = `${address}|${city}|${country}|${postalCode}`;
+  if (cache.has(cacheKey)) {
+    return cache.get(cacheKey)!;
+  }
+
+  const now = Date.now();
+  const waitTime = Math.max(0, RATE_LIMIT_MS - (now - lastRequestTime));
+  if (waitTime > 0) {
+    await new Promise((resolve) => setTimeout(resolve, waitTime));
+  }
+  lastRequestTime = Date.now();
+
+  const geocodingUrl = `https://nominatim.openstreetmap.org/search?${new URLSearchParams({
+    street: address,
+    city,
+    country,
+    postalcode: postalCode,
+    format: "json",
+    limit: "1",
+  }).toString()}`;
+
+  const response = await axios.get(geocodingUrl, {
+    headers: {
+      "User-Agent": "RealEstateApp (justsomedummyemail@gmail.com",
+    },
+  });
+
+  const [longitude, latitude] =
+    response.data[0]?.lon && response.data[0]?.lat
+      ? [
+          parseFloat(response.data[0]?.lon),
+          parseFloat(response.data[0]?.lat),
+        ]
+      : [0, 0];
+
+  cache.set(cacheKey, [longitude, latitude]);
+  return [longitude, latitude];
+};

--- a/server/src/services/s3.ts
+++ b/server/src/services/s3.ts
@@ -1,0 +1,24 @@
+import { S3Client } from "@aws-sdk/client-s3";
+import { Upload } from "@aws-sdk/lib-storage";
+
+const s3Client = new S3Client({
+  region: process.env.AWS_REGION,
+});
+
+export const uploadFile = async (
+  file: Express.Multer.File
+): Promise<string> => {
+  const uploadParams = {
+    Bucket: process.env.S3_BUCKET_NAME!,
+    Key: `properties/${Date.now()}-${file.originalname}`,
+    Body: file.buffer,
+    ContentType: file.mimetype,
+  };
+
+  const uploadResult = await new Upload({
+    client: s3Client,
+    params: uploadParams,
+  }).done();
+
+  return (uploadResult as any).Location as string;
+};


### PR DESCRIPTION
## Summary
- extract AWS S3 upload into reusable service module
- centralize geocoding with caching and rate limiting
- update property controller to orchestrate uploads and geocoding services

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'supertest' or its types)*

------
https://chatgpt.com/codex/tasks/task_e_6898d606b9d48328af970172bf3088c0