### PR TITLE
Use jwt.verify in auth middleware and add tests

### DIFF
--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};

--- a/server/src/__tests__/authMiddleware.test.ts
+++ b/server/src/__tests__/authMiddleware.test.ts
@@ -1,0 +1,36 @@
+import express from 'express';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { authMiddleware } from '../middleware/authMiddleware';
+
+describe('authMiddleware', () => {
+  const app = express();
+  app.get('/protected', authMiddleware(['admin']), (req, res) => {
+    res.status(200).json({ user: req.user });
+  });
+
+  beforeAll(() => {
+    process.env.JWT_SECRET = 'test-secret';
+  });
+
+  it('allows access with a valid token', async () => {
+    const token = jwt.sign({ sub: '123', 'custom:role': 'admin' }, process.env.JWT_SECRET!, { expiresIn: '1h' });
+    const res = await request(app).get('/protected').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.user.id).toBe('123');
+  });
+
+  it('rejects an expired token', async () => {
+    const token = jwt.sign({ sub: '123', 'custom:role': 'admin' }, process.env.JWT_SECRET!, { expiresIn: -1 });
+    const res = await request(app).get('/protected').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(401);
+    expect(res.body.message).toBe('Token expired');
+  });
+
+  it('rejects a tampered token', async () => {
+    const token = jwt.sign({ sub: '123', 'custom:role': 'admin' }, 'wrong-secret', { expiresIn: '1h' });
+    const res = await request(app).get('/protected').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(401);
+    expect(res.body.message).toBe('Invalid token');
+  });
+});

--- a/server/src/middleware/authMiddleware.ts
+++ b/server/src/middleware/authMiddleware.ts
@@ -27,7 +27,11 @@ export const authMiddleware = (allowedRoles: string[]) => {
     }
 
     try {
-      const decoded = jwt.decode(token) as DecodedToken;
+      const decoded = jwt.verify(
+        token,
+        process.env.JWT_SECRET || ""
+      ) as DecodedToken;
+
       const userRole = decoded["custom:role"] || "";
       req.user = {
         id: decoded.sub,
@@ -40,8 +44,13 @@ export const authMiddleware = (allowedRoles: string[]) => {
         return;
       }
     } catch (err) {
-      console.error("Failed to decode token:", err);
-      res.status(400).json({ message: "Invalid token" });
+      if (err instanceof jwt.TokenExpiredError) {
+        res.status(401).json({ message: "Token expired" });
+      } else if (err instanceof jwt.JsonWebTokenError) {
+        res.status(401).json({ message: "Invalid token" });
+      } else {
+        res.status(401).json({ message: "Unauthorized" });
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- verify JWTs with secret and handle expiration/signature errors
- add Jest config and unit tests for valid, expired, and tampered tokens

## Testing
- `npx --prefix server jest --config server/jest.config.js server/src/__tests__/authMiddleware.test.ts`
- `npx --prefix server jest --config server/jest.config.js` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_6898d618e4f08328a43542e9aa07f3f8