### PR TITLE
refactor: centralize Prisma client

### DIFF
--- a/server/src/controllers/applicationControllers.ts
+++ b/server/src/controllers/applicationControllers.ts
@@ -1,7 +1,5 @@
 import { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import prisma from "../db/prisma";
 
 export const listApplications = async (
   req: Request,

--- a/server/src/controllers/leaseControllers.ts
+++ b/server/src/controllers/leaseControllers.ts
@@ -1,7 +1,5 @@
 import { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import prisma from "../db/prisma";
 
 export const getLeases = async (req: Request, res: Response): Promise<void> => {
   try {

--- a/server/src/controllers/listings.ts
+++ b/server/src/controllers/listings.ts
@@ -1,7 +1,5 @@
 import { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import prisma from "../db/prisma";
 
 export const getListings = async (req: Request, res: Response): Promise<void> => {
   try {

--- a/server/src/controllers/managerControllers.ts
+++ b/server/src/controllers/managerControllers.ts
@@ -1,8 +1,6 @@
 import { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
+import prisma from "../db/prisma";
 import { wktToGeoJSON } from "@terraformer/wkt";
-
-const prisma = new PrismaClient();
 
 export const getManager = async (
   req: Request,

--- a/server/src/controllers/propertyControllers.ts
+++ b/server/src/controllers/propertyControllers.ts
@@ -1,12 +1,11 @@
 import { Request, Response } from "express";
-import { PrismaClient, Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
+import prisma from "../db/prisma";
 import { wktToGeoJSON } from "@terraformer/wkt";
 import { S3Client } from "@aws-sdk/client-s3";
 import { Location } from "@prisma/client";
 import { Upload } from "@aws-sdk/lib-storage";
 import axios from "axios";
-
-const prisma = new PrismaClient();
 
 const s3Client = new S3Client({
   region: process.env.AWS_REGION,

--- a/server/src/controllers/tenantControllers.ts
+++ b/server/src/controllers/tenantControllers.ts
@@ -1,8 +1,6 @@
 import { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
+import prisma from "../db/prisma";
 import { wktToGeoJSON } from "@terraformer/wkt";
-
-const prisma = new PrismaClient();
 
 export const getTenant = async (req: Request, res: Response): Promise<void> => {
   try {

--- a/server/src/db/prisma.ts
+++ b/server/src/db/prisma.ts
@@ -1,0 +1,13 @@
+import { PrismaClient } from "@prisma/client";
+
+// Ensure a single PrismaClient instance is shared across the app
+// Prevent creating new instances on hot reloads in development
+const globalForPrisma = global as unknown as { prisma?: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
+
+export default prisma;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -12,6 +12,7 @@ import propertyRoutes from "./routes/propertyRoutes";
 import leaseRoutes from "./routes/leaseRoutes";
 import applicationRoutes from "./routes/applicationRoutes";
 import listingsRoutes from "./routes/listings";
+import prisma from "./db/prisma";
 
 /* CONFIGURATIONS */
 dotenv.config();
@@ -38,6 +39,16 @@ app.use("/managers", authMiddleware(["manager"]), managerRoutes);
 
 /* SERVER */
 const port = Number(process.env.PORT) || 3002;
-app.listen(port, "0.0.0.0", () => {
+const server = app.listen(port, "0.0.0.0", () => {
   console.log(`Server running on port ${port}`);
 });
+
+const shutdown = async () => {
+  await prisma.$disconnect();
+  server.close(() => {
+    process.exit(0);
+  });
+};
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);


### PR DESCRIPTION
## Summary
- add shared Prisma client instance
- replace local Prisma instantiation in controllers
- close Prisma connection on shutdown

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Cannot find module 'supertest' or its type declarations)


------
https://chatgpt.com/codex/tasks/task_e_6898d60e27cc8328b156ce3b71bb86f6