### PR TITLE
refactor: centralize prisma client usage

### DIFF
--- a/server/src/controllers/applicationControllers.ts
+++ b/server/src/controllers/applicationControllers.ts
@@ -1,7 +1,5 @@
 import { Request, Response, NextFunction } from "express";
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import prisma from "../prismaClient";
 
 export const listApplications = async (
   req: Request,

--- a/server/src/controllers/leaseControllers.ts
+++ b/server/src/controllers/leaseControllers.ts
@@ -1,7 +1,5 @@
 import { Request, Response, NextFunction } from "express";
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import prisma from "../prismaClient";
 
 export const getLeases = async (
   req: Request,

--- a/server/src/controllers/listings.ts
+++ b/server/src/controllers/listings.ts
@@ -1,7 +1,5 @@
 import { Request, Response, NextFunction } from "express";
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import prisma from "../prismaClient";
 
 export const getListings = async (
   req: Request,

--- a/server/src/controllers/managerControllers.ts
+++ b/server/src/controllers/managerControllers.ts
@@ -1,8 +1,6 @@
 import { Request, Response, NextFunction } from "express";
-import { PrismaClient } from "@prisma/client";
 import { wktToGeoJSON } from "@terraformer/wkt";
-
-const prisma = new PrismaClient();
+import prisma from "../prismaClient";
 
 export const getManager = async (
   req: Request,

--- a/server/src/controllers/propertyControllers.ts
+++ b/server/src/controllers/propertyControllers.ts
@@ -1,13 +1,11 @@
 import { Request, Response, NextFunction } from "express";
-import { PrismaClient, Prisma } from "@prisma/client";
+import { Prisma, Location } from "@prisma/client";
 import { buildPropertyFilters } from "../utils/buildPropertyFilters";
 import { wktToGeoJSON } from "@terraformer/wkt";
 import { S3Client } from "@aws-sdk/client-s3";
-import { Location } from "@prisma/client";
 import { Upload } from "@aws-sdk/lib-storage";
 import axios from "axios";
-
-const prisma = new PrismaClient();
+import prisma from "../prismaClient";
 
 const s3Client = new S3Client({
   region: process.env.AWS_REGION,
@@ -100,7 +98,9 @@ export const getProperties = async (
       },
     }));
 
-    
+    res.json(propertiesWithCoordinates);
+  } catch (err) {
+    next(err);
   }
 };
 

--- a/server/src/controllers/tenantControllers.ts
+++ b/server/src/controllers/tenantControllers.ts
@@ -1,8 +1,6 @@
 import { Request, Response, NextFunction } from "express";
-import { PrismaClient } from "@prisma/client";
 import { wktToGeoJSON } from "@terraformer/wkt";
-
-const prisma = new PrismaClient();
+import prisma from "../prismaClient";
 
 export const getTenant = async (
   req: Request,

--- a/server/src/prismaClient.ts
+++ b/server/src/prismaClient.ts
@@ -1,0 +1,19 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const shutdown = async () => {
+  await prisma.$disconnect();
+};
+
+process.on('beforeExit', shutdown);
+process.on('SIGINT', async () => {
+  await shutdown();
+  process.exit(0);
+});
+process.on('SIGTERM', async () => {
+  await shutdown();
+  process.exit(0);
+});
+
+export default prisma;


### PR DESCRIPTION
## Summary
- add shared Prisma client with graceful shutdown
- replace per-controller Prisma instantiations with shared client

## Testing
- `npm test` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68994f6a635483289857b3a4bddcaa38