### PR TITLE
feat: verify JWTs

### DIFF
--- a/server/src/middleware/authMiddleware.ts
+++ b/server/src/middleware/authMiddleware.ts
@@ -27,7 +27,16 @@ export const authMiddleware = (allowedRoles: string[]) => {
     }
 
     try {
-      const decoded = jwt.decode(token) as DecodedToken;
+      const decoded = jwt.verify(
+        token,
+        process.env.COGNITO_JWT_PUBLIC_KEY || process.env.JWT_SECRET || "",
+        {
+          algorithms: ["RS256"],
+          audience: process.env.COGNITO_AUDIENCE,
+          issuer: process.env.COGNITO_ISSUER,
+        }
+      ) as DecodedToken;
+
       const userRole = decoded["custom:role"] || "";
       req.user = {
         id: decoded.sub,
@@ -39,12 +48,12 @@ export const authMiddleware = (allowedRoles: string[]) => {
         res.status(403).json({ message: "Access Denied" });
         return;
       }
+
+      next();
     } catch (err) {
-      console.error("Failed to decode token:", err);
-      res.status(400).json({ message: "Invalid token" });
+      console.error("Failed to verify token:", err);
+      res.status(401).json({ message: "Invalid or expired token" });
       return;
     }
-
-    next();
   };
 };


### PR DESCRIPTION
## Summary
- verify tokens using jwt.verify and Cognito public key
- validate aud/iss claims and enforce role-based access
- respond 401 for invalid or expired tokens

## Testing
- `cd server && npm test` *(fails: src/controllers/propertyControllers.ts:105:1 - error TS1472: 'catch' or 'finally' expected.)*

------
https://chatgpt.com/codex/tasks/task_e_68994f69bd2c8328be049a3a2113b965