### PR TITLE
refactor application status updates into service

### DIFF
--- a/server/src/controllers/applicationControllers.ts
+++ b/server/src/controllers/applicationControllers.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import { PrismaClient } from "@prisma/client";
+import { updateApplicationStatus as updateApplicationStatusService } from "../services/applicationService";
 
 const prisma = new PrismaClient();
 
@@ -171,72 +172,16 @@ export const updateApplicationStatus = async (
   try {
     const { id } = req.params;
     const { status } = req.body;
-    console.log("status:", status);
 
-    const application = await prisma.application.findUnique({
-      where: { id: Number(id) },
-      include: {
-        property: true,
-        tenant: true,
-      },
-    });
+    const updatedApplication = await updateApplicationStatusService(
+      Number(id),
+      status
+    );
 
-    if (!application) {
+    if (!updatedApplication) {
       res.status(404).json({ message: "Application not found." });
       return;
     }
-
-    if (status === "Approved") {
-      const newLease = await prisma.lease.create({
-        data: {
-          startDate: new Date(),
-          endDate: new Date(
-            new Date().setFullYear(new Date().getFullYear() + 1)
-          ),
-          rent: application.property.pricePerMonth,
-          deposit: application.property.securityDeposit,
-          propertyId: application.propertyId,
-          tenantCognitoId: application.tenantCognitoId,
-        },
-      });
-
-      // Update the property to connect the tenant
-      await prisma.property.update({
-        where: { id: application.propertyId },
-        data: {
-          tenants: {
-            connect: { cognitoId: application.tenantCognitoId },
-          },
-        },
-      });
-
-      // Update the application with the new lease ID
-      await prisma.application.update({
-        where: { id: Number(id) },
-        data: { status, leaseId: newLease.id },
-        include: {
-          property: true,
-          tenant: true,
-          lease: true,
-        },
-      });
-    } else {
-      // Update the application status (for both "Denied" and other statuses)
-      await prisma.application.update({
-        where: { id: Number(id) },
-        data: { status },
-      });
-    }
-
-    // Respond with the updated application details
-    const updatedApplication = await prisma.application.findUnique({
-      where: { id: Number(id) },
-      include: {
-        property: true,
-        tenant: true,
-        lease: true,
-      },
-    });
 
     res.json(updatedApplication);
   } catch (error) {

--- a/server/src/services/applicationService.ts
+++ b/server/src/services/applicationService.ts
@@ -1,0 +1,55 @@
+import { PrismaClient, ApplicationStatus } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+export const updateApplicationStatus = async (
+  id: number,
+  status: ApplicationStatus
+) => {
+  // Find application along with property and tenant details
+  const application = await prisma.application.findUnique({
+    where: { id },
+    include: { property: true, tenant: true },
+  });
+
+  if (!application) {
+    return null;
+  }
+
+  return prisma.$transaction(async (tx) => {
+    if (status === "Approved") {
+      const lease = await tx.lease.create({
+        data: {
+          startDate: new Date(),
+          endDate: new Date(new Date().setFullYear(new Date().getFullYear() + 1)),
+          rent: application.property.pricePerMonth,
+          deposit: application.property.securityDeposit,
+          propertyId: application.propertyId,
+          tenantCognitoId: application.tenantCognitoId,
+        },
+      });
+
+      await tx.property.update({
+        where: { id: application.propertyId },
+        data: {
+          tenants: {
+            connect: { cognitoId: application.tenantCognitoId },
+          },
+        },
+      });
+
+      return tx.application.update({
+        where: { id },
+        data: { status, leaseId: lease.id },
+        include: { property: true, tenant: true, lease: true },
+      });
+    }
+
+    // For statuses other than Approved, simply update the status
+    return tx.application.update({
+      where: { id },
+      data: { status },
+      include: { property: true, tenant: true, lease: true },
+    });
+  });
+};


### PR DESCRIPTION
## Summary
- add application service with transactional status updates
- route controller uses service

## Testing
- `npm test` *(fails: propertyControllers.ts TS1472)*

------
https://chatgpt.com/codex/tasks/task_e_68994f6cb1008328b9c9d4b5a17df818