### PR TITLE
feat: use Property type for listings

### DIFF
--- a/client/app/listings/page.tsx
+++ b/client/app/listings/page.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import ListingCard, { Listing } from "@/components/ListingCard";
+import ListingCard from "@/components/ListingCard";
 import ListingForm from "@/components/forms/ListingForm";
 import { fetchListings } from "@/lib/api";
 import { useDebounce } from "@/hooks/use-debounce";
+import type { Property } from "@/types/prismaTypes";
 
 const ListingsPage = () => {
-  const [listings, setListings] = useState<Listing[]>([]);
+  const [listings, setListings] = useState<Property[]>([]);
   const [query, setQuery] = useState("");
   const debouncedQuery = useDebounce(query, 300);
 

--- a/client/components/ListingCard.tsx
+++ b/client/components/ListingCard.tsx
@@ -1,15 +1,8 @@
 import Image from "next/image";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import type { Property } from "@/types/prismaTypes";
 
-export interface Listing {
-  id: number | string;
-  name: string;
-  description: string;
-  pricePerMonth: number;
-  photoUrls?: string[];
-}
-
-const ListingCard = ({ listing }: { listing: Listing }) => {
+const ListingCard = ({ listing }: { listing: Property }) => {
   return (
     <Card className="overflow-hidden">
       {listing.photoUrls?.[0] && (

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { mapPropertyToListing } from "./utils";
 
 const api = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:3002",
@@ -7,7 +6,7 @@ const api = axios.create({
 
 export const fetchListings = async (search?: string) => {
   const response = await api.get("/properties", { params: { q: search } });
-  return response.data.map(mapPropertyToListing);
+  return response.data;
 };
 
 export const createListing = async (data: any) => {

--- a/client/lib/utils.ts
+++ b/client/lib/utils.ts
@@ -1,8 +1,6 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { toast } from "sonner";
-import { Property } from "@/types/prismaTypes";
-import { Listing } from "@/components/ListingCard";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -36,14 +34,6 @@ export function cleanParams(params: Record<string, any>): Record<string, any> {
     )
   );
 }
-
-export const mapPropertyToListing = (property: Property): Listing => ({
-  id: property.id,
-  name: property.name,
-  description: property.description,
-  pricePerMonth: property.pricePerMonth,
-  photoUrls: property.photoUrls,
-});
 
 type MutationMessages = {
   success?: string;

--- a/client/src/app/listings/page.tsx
+++ b/client/src/app/listings/page.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import ListingCard, { Listing } from "@/components/ListingCard";
+import ListingCard from "@/components/ListingCard";
 import ListingForm from "@/components/forms/ListingForm";
 import { fetchListings } from "@/lib/api";
 import { useDebounce } from "@/hooks/use-debounce";
+import type { Property } from "@/types/prismaTypes";
 
 const ListingsPage = () => {
-  const [listings, setListings] = useState<Listing[]>([]);
+  const [listings, setListings] = useState<Property[]>([]);
   const [query, setQuery] = useState("");
   const debouncedQuery = useDebounce(query, 300);
 

--- a/client/src/components/ListingCard.tsx
+++ b/client/src/components/ListingCard.tsx
@@ -1,15 +1,8 @@
 import Image from "next/image";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import type { Property } from "@/types/prismaTypes";
 
-export interface Listing {
-  id: number | string;
-  name: string;
-  description: string;
-  pricePerMonth: number;
-  photoUrls?: string[];
-}
-
-const ListingCard = ({ listing }: { listing: Listing }) => {
+const ListingCard = ({ listing }: { listing: Property }) => {
   return (
     <Card className="overflow-hidden">
       {listing.photoUrls?.[0] && (

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { mapPropertyToListing } from "./utils";
 
 const api = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:3002",
@@ -7,7 +6,7 @@ const api = axios.create({
 
 export const fetchListings = async (search?: string) => {
   const response = await api.get("/properties", { params: { q: search } });
-  return response.data.map(mapPropertyToListing);
+  return response.data;
 };
 
 export const createListing = async (data: any) => {

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -1,16 +1,6 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
-import { Property } from "@/types/prismaTypes"
-import { Listing } from "@/components/ListingCard"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
-
-export const mapPropertyToListing = (property: Property): Listing => ({
-  id: property.id,
-  name: property.name,
-  description: property.description,
-  pricePerMonth: property.pricePerMonth,
-  photoUrls: property.photoUrls,
-})

--- a/client/tests/e2e/specs/property-browsing.spec.ts
+++ b/client/tests/e2e/specs/property-browsing.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('Listing browsing flow', () => {
+test.describe('Property browsing flow', () => {
   test('shows properties from API on search page', async ({ page }) => {
     await page.route('**/search', (route) => {
       route.fulfill({

--- a/client/tests/e2e/specs/property-creation.spec.ts
+++ b/client/tests/e2e/specs/property-creation.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('Listing creation flow', () => {
+test.describe('Property creation flow', () => {
   test('allows manager to fill new property form', async ({ page }) => {
     await page.route('**/managers/newproperty', (route) => {
       route.fulfill({


### PR DESCRIPTION
## Summary
- type listings with Prisma `Property`
- simplify listings API and remove unused mapping
- rename Playwright specs to property terminology

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689ad3d08dfc8328b5628d63a5fc88c5