### PR TITLE
Add request validation for property creation

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -23,7 +23,8 @@
         "morgan": "^1.10.1",
         "multer": "^1.4.5-lts.1",
         "prisma": "^6.13.0",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
@@ -8817,6 +8818,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/server/package.json
+++ b/server/package.json
@@ -32,7 +32,8 @@
     "morgan": "^1.10.1",
     "multer": "^1.4.5-lts.1",
     "prisma": "^6.13.0",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",

--- a/server/src/__tests__/property.test.ts
+++ b/server/src/__tests__/property.test.ts
@@ -1,15 +1,48 @@
 import request from "supertest";
 import express from "express";
+
+// mocks must be defined before imports that use them
+jest.mock("../utils/s3Upload", () => ({
+  uploadFilesToS3: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock("../utils/geocodeAddress", () => ({
+  geocodeAddress: jest.fn().mockResolvedValue([0, 0]),
+}));
+
+const mockPrisma = {
+  property: {
+    deleteMany: jest.fn(),
+    findUnique: jest.fn(),
+  },
+  $transaction: jest.fn(),
+  $disconnect: jest.fn(),
+};
+
+jest.mock("@prisma/client", () => ({
+  PrismaClient: jest.fn(() => mockPrisma),
+  Prisma: { join: jest.fn() },
+}));
+
 import propertyRoutes from "../routes/propertyRoutes";
+import { createProperty } from "../controllers/propertyControllers";
 import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
+
 const app = express();
 app.use(express.json());
+// custom route to bypass auth and file upload middleware
+app.post("/properties", (req, res, next) => {
+  (req as any).files = [];
+  createProperty(req, res, next);
+});
+// other property routes
 app.use("/properties", propertyRoutes);
 
 describe("Property API", () => {
   beforeEach(async () => {
+    jest.clearAllMocks();
     await prisma.property.deleteMany();
   });
 
@@ -18,8 +51,89 @@ describe("Property API", () => {
   });
 
   it("returns 404 for missing property", async () => {
+    mockPrisma.property.findUnique.mockResolvedValue(null);
     const res = await request(app).get("/properties/9999");
     expect(res.status).toBe(404);
     expect(res.body).toEqual({ message: "Property not found" });
   });
+
+  it("creates property with valid payload", async () => {
+    mockPrisma.$transaction.mockImplementation(async (cb: any) => {
+      const tx = {
+        $queryRaw: jest
+          .fn()
+          .mockResolvedValue([
+            {
+              id: 1,
+              address: "123",
+              city: "Town",
+              state: "ST",
+              country: "USA",
+              postalCode: "00000",
+              coordinates: "",
+            },
+          ]),
+        property: {
+          create: jest
+            .fn()
+            .mockResolvedValue({
+              id: 1,
+              name: "My Property",
+              locationId: 1,
+              managerCognitoId: "manager",
+              location: {},
+              manager: {},
+            }),
+        },
+      };
+      return cb(tx);
+    });
+
+    const payload = {
+      address: "123 Main St",
+      city: "Townsville",
+      state: "TS",
+      country: "USA",
+      postalCode: "12345",
+      managerCognitoId: "manager",
+      name: "My Property",
+      description: "Nice place",
+      pricePerMonth: "1000",
+      securityDeposit: "500",
+      applicationFee: "50",
+      beds: "2",
+      baths: "1",
+      squareFeet: "900",
+      propertyType: "Apartment",
+    };
+
+    const res = await request(app).post("/properties").send(payload);
+    expect(res.status).toBe(201);
+    expect(mockPrisma.$transaction).toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid payload", async () => {
+    const invalidPayload = {
+      address: "123 Main St",
+      city: "Townsville",
+      state: "TS",
+      country: "USA",
+      postalCode: "12345",
+      managerCognitoId: "manager",
+      // name missing
+      description: "Nice place",
+      pricePerMonth: "1000",
+      securityDeposit: "500",
+      applicationFee: "50",
+      beds: "2",
+      baths: "1",
+      squareFeet: "900",
+      propertyType: "Apartment",
+    };
+
+    const res = await request(app).post("/properties").send(invalidPayload);
+    expect(res.status).toBe(400);
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+  });
 });
+

--- a/server/src/controllers/propertyControllers.ts
+++ b/server/src/controllers/propertyControllers.ts
@@ -4,8 +4,31 @@ import { buildPropertyFilters } from "../utils/buildPropertyFilters";
 import { wktToGeoJSON } from "@terraformer/wkt";
 import { uploadFilesToS3 } from "../utils/s3Upload";
 import { geocodeAddress } from "../utils/geocodeAddress";
+import { z } from "zod";
 
 const prisma = new PrismaClient();
+
+const createPropertySchema = z.object({
+  address: z.string(),
+  city: z.string(),
+  state: z.string(),
+  country: z.string(),
+  postalCode: z.string(),
+  managerCognitoId: z.string(),
+  name: z.string(),
+  description: z.string(),
+  pricePerMonth: z.string(),
+  securityDeposit: z.string(),
+  applicationFee: z.string(),
+  beds: z.string(),
+  baths: z.string(),
+  squareFeet: z.string(),
+  propertyType: z.string(),
+  amenities: z.string().optional(),
+  highlights: z.string().optional(),
+  isPetsAllowed: z.string().optional(),
+  isParkingIncluded: z.string().optional(),
+});
 
 export const getProperties = async (
   req: Request,
@@ -147,6 +170,13 @@ export const createProperty = async (
 ): Promise<void> => {
   try {
     const files = req.files as Express.Multer.File[];
+
+    const parsed = createPropertySchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ errors: parsed.error.flatten() });
+      return;
+    }
+
     const {
       address,
       city,
@@ -155,7 +185,7 @@ export const createProperty = async (
       postalCode,
       managerCognitoId,
       ...propertyData
-    } = req.body;
+    } = parsed.data;
 
     const photoUrls = await uploadFilesToS3(files);
 


### PR DESCRIPTION
## Summary
- validate property creation payloads with a Zod schema
- handle invalid property payloads with 400 responses
- test valid and invalid create property requests

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ad3d23ce48328b22969b290bfe272