### PR TITLE
refactor: centralize Prisma client usage

### DIFF
--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -1,8 +1,7 @@
-import { PrismaClient, Prisma } from "@prisma/client";
+import { Prisma, PrismaClient } from "@prisma/client";
 import fs from "fs";
 import path from "path";
-
-const prisma = new PrismaClient();
+import prisma from "../src/utils/prisma";
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/server/src/__tests__/property.test.ts
+++ b/server/src/__tests__/property.test.ts
@@ -26,9 +26,7 @@ jest.mock("@prisma/client", () => ({
 
 import propertyRoutes from "../routes/propertyRoutes";
 import { createProperty } from "../controllers/propertyControllers";
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import prisma from "../utils/prisma";
 
 const app = express();
 app.use(express.json());

--- a/server/src/__tests__/propertySearch.test.ts
+++ b/server/src/__tests__/propertySearch.test.ts
@@ -1,9 +1,7 @@
 import request from "supertest";
 import express from "express";
 import propertyRoutes from "../routes/propertyRoutes";
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import prisma from "../utils/prisma";
 const app = express();
 app.use(express.json());
 app.use("/properties", propertyRoutes);

--- a/server/src/controllers/applicationControllers.ts
+++ b/server/src/controllers/applicationControllers.ts
@@ -1,8 +1,6 @@
 import { Request, Response, NextFunction } from "express";
-import { PrismaClient } from "@prisma/client";
+import prisma from "../utils/prisma";
 import { updateApplicationStatus as updateApplicationStatusService } from "../services/applicationService";
-
-const prisma = new PrismaClient();
 
 export const listApplications = async (
   req: Request,

--- a/server/src/controllers/leaseControllers.ts
+++ b/server/src/controllers/leaseControllers.ts
@@ -1,7 +1,5 @@
 import { Request, Response, NextFunction } from "express";
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import prisma from "../utils/prisma";
 
 export const getLeases = async (
   req: Request,

--- a/server/src/controllers/managerControllers.ts
+++ b/server/src/controllers/managerControllers.ts
@@ -1,8 +1,6 @@
 import { Request, Response, NextFunction } from "express";
-import { PrismaClient } from "@prisma/client";
 import { wktToGeoJSON } from "@terraformer/wkt";
-
-const prisma = new PrismaClient();
+import prisma from "../utils/prisma";
 
 export const getManager = async (
   req: Request,

--- a/server/src/controllers/propertyControllers.ts
+++ b/server/src/controllers/propertyControllers.ts
@@ -1,12 +1,11 @@
 import { Request, Response, NextFunction } from "express";
-import { PrismaClient, Prisma, Location } from "@prisma/client";
+import { Prisma, Location } from "@prisma/client";
 import { buildPropertyFilters } from "../utils/buildPropertyFilters";
 import { wktToGeoJSON } from "@terraformer/wkt";
 import { uploadFilesToS3 } from "../utils/s3Upload";
 import { geocodeAddress } from "../utils/geocodeAddress";
 import { z } from "zod";
-
-const prisma = new PrismaClient();
+import prisma from "../utils/prisma";
 
 const createPropertySchema = z.object({
   address: z.string(),

--- a/server/src/controllers/tenantControllers.ts
+++ b/server/src/controllers/tenantControllers.ts
@@ -1,8 +1,6 @@
 import { Request, Response, NextFunction } from "express";
-import { PrismaClient } from "@prisma/client";
 import { wktToGeoJSON } from "@terraformer/wkt";
-
-const prisma = new PrismaClient();
+import prisma from "../utils/prisma";
 
 export const getTenant = async (
   req: Request,

--- a/server/src/services/applicationService.ts
+++ b/server/src/services/applicationService.ts
@@ -1,6 +1,5 @@
-import { PrismaClient, ApplicationStatus } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import { ApplicationStatus } from "@prisma/client";
+import prisma from "../utils/prisma";
 
 export const updateApplicationStatus = async (
   id: number,

--- a/server/src/utils/prisma.ts
+++ b/server/src/utils/prisma.ts
@@ -1,0 +1,5 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+export default prisma;


### PR DESCRIPTION
## Summary
- add shared `PrismaClient` instance in `server/src/utils/prisma`
- refactor controllers, service, tests, and seed script to use the shared client
- ensure tests and scripts disconnect the Prisma client in teardown

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689aecfe224483288b38857cc1ea3465