### PR TITLE
test: add listing e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,10 @@ jobs:
         run: |
           cd client
           npm ci
+      - name: Build client
+        run: |
+          cd client
+          npm run build
       - name: Install Playwright browsers
         run: |
           cd client
@@ -104,6 +108,8 @@ jobs:
       - name: Run E2E tests
         run: |
           cd client
+          npm start &
+          npx wait-on http://localhost:3000
           npm run test:e2e
 
   deploy:

--- a/client/tests/e2e/specs/listing-browsing.spec.ts
+++ b/client/tests/e2e/specs/listing-browsing.spec.ts
@@ -1,39 +1,28 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Listing browsing flow', () => {
-  test('shows properties from API on search page', async ({ page }) => {
-    await page.route('**/search', (route) => {
-      route.fulfill({
-        status: 200,
-        contentType: 'text/html',
-        body: `<!DOCTYPE html><html><body>
-          <h1>Search Properties</h1>
-          <div id="list"></div>
-          <script>
-            fetch('/properties').then(r=>r.json()).then(data=>{
-              const div=document.getElementById('list');
-              div.innerHTML = '<div>' + data[0].name + ' - $' + data[0].pricePerMonth + '</div>';
-            });
-          </script>
-        </body></html>`
-      });
+  test('shows properties from API on listings page', async ({ page }) => {
+    await page.route('**/properties*', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([
+            {
+              id: 1,
+              name: 'Sample Property',
+              description: 'Nice place',
+              pricePerMonth: 1500,
+            },
+          ]),
+        });
+      } else {
+        await route.continue();
+      }
     });
 
-    await page.route('**/properties', (route) => {
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify([
-          {
-            id: 1,
-            name: 'Sample Property',
-            pricePerMonth: 1500
-          }
-        ])
-      });
-    });
-
-    await page.goto('http://localhost:3000/search');
-    await expect(page.getByText('Sample Property - $1500')).toBeVisible();
+    await page.goto('/listings');
+    await expect(page.getByText('Sample Property')).toBeVisible();
+    await expect(page.getByText('$1500')).toBeVisible();
   });
 });

--- a/client/tests/e2e/specs/listing-creation.spec.ts
+++ b/client/tests/e2e/specs/listing-creation.spec.ts
@@ -2,24 +2,41 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Listing creation flow', () => {
   test('allows manager to fill new property form', async ({ page }) => {
-    await page.route('**/managers/newproperty', (route) => {
-      route.fulfill({
-        status: 200,
-        contentType: 'text/html',
-        body: `<!DOCTYPE html><html><body>
-          <h1>Add New Property</h1>
-          <label>Property Name<input name="name" /></label>
-          <label>Description<textarea name="description"></textarea></label>
-          <label>Price per Month<input name="pricePerMonth" type="number" /></label>
-        </body></html>`
-      });
+    await page.route('**/properties*', async (route) => {
+      const method = route.request().method();
+      if (method === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: '[]',
+        });
+      } else if (method === 'POST') {
+        await route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: '{}',
+        });
+      } else {
+        await route.continue();
+      }
     });
 
-    await page.goto('http://localhost:3000/managers/newproperty');
+    await page.goto('/listings');
+
     await page.getByLabel('Property Name').fill('Test Property');
     await page.getByLabel('Description').fill('Great place');
     await page.getByLabel('Price per Month').fill('1500');
-    await expect(page.getByLabel('Property Name')).toHaveValue('Test Property');
-    await expect(page.getByLabel('Price per Month')).toHaveValue('1500');
+
+    const [request] = await Promise.all([
+      page.waitForRequest((req) =>
+        req.url().includes('/properties') && req.method() === 'POST'
+      ),
+      page.getByRole('button', { name: 'Submit' }).click(),
+    ]);
+    expect(request.postDataJSON()).toEqual({
+      name: 'Test Property',
+      description: 'Great place',
+      pricePerMonth: 1500,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- navigate to `/listings` in e2e specs and exercise real components
- cover property creation using the actual `ListingForm`
- boot Next.js app in CI before running Playwright tests

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689aecffff408328ba2310b022561b33