### PR TITLE
feat: configure geocode user agent via env

### DIFF
--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -98,6 +98,8 @@ S3_REGION=us-east-1
 # Server
 PORT=3001
 NODE_ENV=development
+# Geocoding
+GEOCODE_USER_AGENT=your_app_name (contact@example.com)
 ```
 
 ## AWS Services Setup

--- a/server/src/env.ts
+++ b/server/src/env.ts
@@ -1,0 +1,17 @@
+import dotenv from "dotenv";
+import { z } from "zod";
+
+dotenv.config();
+
+const envSchema = z.object({
+  GEOCODE_USER_AGENT: z
+    .string()
+    .min(1, "GEOCODE_USER_AGENT is required"),
+});
+
+type Env = z.infer<typeof envSchema>;
+
+const env: Env = envSchema.parse(process.env);
+
+export const GEOCODE_USER_AGENT = env.GEOCODE_USER_AGENT;
+export default env;

--- a/server/src/utils/geocodeAddress.ts
+++ b/server/src/utils/geocodeAddress.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { GEOCODE_USER_AGENT } from "../env";
 
 export const geocodeAddress = async (
   address: string,
@@ -15,9 +16,15 @@ export const geocodeAddress = async (
     limit: "1",
   }).toString()}`;
 
+  if (!GEOCODE_USER_AGENT) {
+    throw new Error(
+      "GEOCODE_USER_AGENT environment variable is required for geocoding requests",
+    );
+  }
+
   const geocodingResponse = await axios.get(geocodingUrl, {
     headers: {
-      "User-Agent": "RealEstateApp (justsomedummyemail@gmail.com)",
+      "User-Agent": GEOCODE_USER_AGENT,
     },
   });
 


### PR DESCRIPTION
## Summary
- add GEOCODE_USER_AGENT variable validated with zod
- use environment-based user agent in geocoding utility
- document GEOCODE_USER_AGENT in setup guide

## Testing
- `cd server && GEOCODE_USER_AGENT='test-user-agent' npm test`


------
https://chatgpt.com/codex/tasks/task_e_689aed0095e88328b9e1aad55ac60fa4