### PR TITLE
feat(server): add env validation

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,10 +1,10 @@
 import express from "express";
-import dotenv from "dotenv";
 import cors from "cors";
 import helmet from "helmet";
 import morgan from "morgan";
 import { authMiddleware } from "./middleware/authMiddleware";
 import { errorHandler } from "./middleware/errorHandler";
+import env from "./utils/env";
 /* ROUTE IMPORT */
 import tenantRoutes from "./routes/tenantRoutes";
 import managerRoutes from "./routes/managerRoutes";
@@ -13,7 +13,6 @@ import leaseRoutes from "./routes/leaseRoutes";
 import applicationRoutes from "./routes/applicationRoutes";
 
 /* CONFIGURATIONS */
-dotenv.config();
 const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
@@ -36,7 +35,7 @@ app.use("/managers", authMiddleware(["manager"]), managerRoutes);
 app.use(errorHandler);
 
 /* SERVER */
-const port = Number(process.env.PORT) || 3002;
+const port = env.PORT;
 app.listen(port, "0.0.0.0", () => {
   console.log(`Server running on port ${port}`);
 });

--- a/server/src/utils/__tests__/env.test.ts
+++ b/server/src/utils/__tests__/env.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, beforeEach, afterEach, jest } from "@jest/globals";
+
+describe("env validation", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+  });
+
+  it("returns parsed env on success", () => {
+    Object.assign(process.env, {
+      DATABASE_URL: "https://example.com",
+      PORT: "3000",
+      GEOCODE_USER_AGENT: "test-agent",
+      COGNITO_JWT_PUBLIC_KEY: "key",
+      COGNITO_AUDIENCE: "aud",
+      COGNITO_ISSUER: "issuer",
+      S3_BUCKET_NAME: "bucket",
+      S3_REGION: "us-east-1",
+    });
+
+    const env = require("../env").default;
+    expect(env.PORT).toBe(3000);
+    expect(env.DATABASE_URL).toBe("https://example.com");
+  });
+
+  it("throws when required var missing", () => {
+    Object.assign(process.env, {
+      PORT: "3000",
+      GEOCODE_USER_AGENT: "test-agent",
+      COGNITO_JWT_PUBLIC_KEY: "key",
+      COGNITO_AUDIENCE: "aud",
+      COGNITO_ISSUER: "issuer",
+      S3_BUCKET_NAME: "bucket",
+      S3_REGION: "us-east-1",
+    });
+
+    expect(() => require("../env")).toThrow();
+  });
+});

--- a/server/src/utils/env.ts
+++ b/server/src/utils/env.ts
@@ -1,0 +1,19 @@
+import dotenv from "dotenv";
+import { z } from "zod";
+
+dotenv.config();
+
+const envSchema = z.object({
+  DATABASE_URL: z.string().url(),
+  PORT: z.coerce.number().int().positive(),
+  GEOCODE_USER_AGENT: z.string().min(1),
+  COGNITO_JWT_PUBLIC_KEY: z.string().min(1),
+  COGNITO_AUDIENCE: z.string().min(1),
+  COGNITO_ISSUER: z.string().min(1),
+  S3_BUCKET_NAME: z.string().min(1),
+  S3_REGION: z.string().min(1),
+});
+
+const env = envSchema.parse(process.env);
+
+export default env;


### PR DESCRIPTION
## Summary
- validate DATABASE_URL, PORT, COGNITO_*, S3_*, and GEOCODE_USER_AGENT with Zod
- consume validated env config in server startup
- test env parsing success and failure cases

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689aed0106e88328bd58bd198e1b9234