### PR TITLE
feat: update api base url

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ npm run dev
 ```
 Open <http://localhost:3000> in your browser.
 
+The client reads the API URL from the `NEXT_PUBLIC_API_URL` environment variable. If not set, it defaults to `http://localhost:3001`.
+
 ### Server
 ```bash
 cd server

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { Property } from "@/types/prismaTypes";
 
 const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:3002",
+  baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001",
 });
 
 export const fetchListings = async (search?: string): Promise<Property[]> => {

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { Property } from "@/types/prismaTypes";
 
 const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:3002",
+  baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001",
 });
 
 export const fetchListings = async (search?: string): Promise<Property[]> => {


### PR DESCRIPTION
## Summary
- set API client fallback URL to http://localhost:3001
- document NEXT_PUBLIC_API_URL override in README

## Testing
- `cd client && npm test`
- `node -e "const express=require('./client/node_modules/express'); const app=express(); app.get('/properties',(req,res)=>res.json([{id:1,name:'Sample'}])); app.listen(3001,()=>console.log('stub server running')); setTimeout(()=>{}, 1000*10);" &`
- `curl http://localhost:3001/properties`


------
https://chatgpt.com/codex/tasks/task_e_689afb7f1b088328b09763c2a1fa5fd2