### PR TITLE
Use authenticated manager ID for property creation

### DIFF
--- a/client/components/forms/ListingForm.tsx
+++ b/client/components/forms/ListingForm.tsx
@@ -7,7 +7,6 @@ import { CustomFormField } from "../FormField";
 import { createListing } from "@/lib/api";
 
 const listingSchema = z.object({
-  managerCognitoId: z.string().min(1, "Manager ID is required"),
   name: z.string().min(1, "Name is required"),
   description: z.string().min(1, "Description is required"),
   pricePerMonth: z.coerce.number().positive("Price must be positive"),
@@ -44,7 +43,6 @@ const ListingForm = ({ onSuccess }: { onSuccess?: () => void }) => {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-        <CustomFormField name="managerCognitoId" label="Manager ID" />
         <CustomFormField name="name" label="Property Name" />
         <CustomFormField name="description" label="Description" type="textarea" />
         <CustomFormField

--- a/client/src/app/(dashboard)/managers/newproperty/page.tsx
+++ b/client/src/app/(dashboard)/managers/newproperty/page.tsx
@@ -4,7 +4,7 @@ import { CustomFormField } from "@/components/FormField";
 import Header from "@/components/Header";
 import { Form } from "@/components/ui/form";
 import { PropertyFormData, propertySchema } from "@/lib/schemas";
-import { useCreatePropertyMutation, useGetAuthUserQuery } from "@/state/api";
+import { useCreatePropertyMutation } from "@/state/api";
 import { AmenityEnum, HighlightEnum, PropertyTypeEnum } from "@/lib/constants";
 import { zodResolver } from "@hookform/resolvers/zod";
 import React from "react";
@@ -13,7 +13,6 @@ import { Button } from "@/components/ui/button";
 
 const NewProperty = () => {
   const [createProperty] = useCreatePropertyMutation();
-  const { data: authUser } = useGetAuthUserQuery();
 
   const form = useForm<PropertyFormData>({
     resolver: zodResolver(propertySchema),
@@ -40,10 +39,6 @@ const NewProperty = () => {
   });
 
   const onSubmit = async (data: PropertyFormData) => {
-    if (!authUser?.cognitoInfo?.userId) {
-      throw new Error("No manager ID found");
-    }
-
     const formData = new FormData();
     Object.entries(data).forEach(([key, value]) => {
       if (key === "photoUrls") {
@@ -57,8 +52,6 @@ const NewProperty = () => {
         formData.append(key, String(value));
       }
     });
-
-    formData.append("managerCognitoId", authUser.cognitoInfo.userId);
 
     await createProperty(formData);
   };

--- a/client/src/components/forms/ListingForm.tsx
+++ b/client/src/components/forms/ListingForm.tsx
@@ -7,7 +7,6 @@ import { CustomFormField } from "../FormField";
 import { createListing } from "@/lib/api";
 
 const listingSchema = z.object({
-  managerCognitoId: z.string().min(1, "Manager ID is required"),
   name: z.string().min(1, "Name is required"),
   description: z.string().min(1, "Description is required"),
   pricePerMonth: z.coerce.number().positive("Price must be positive"),
@@ -44,7 +43,6 @@ const ListingForm = ({ onSuccess }: { onSuccess?: () => void }) => {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-        <CustomFormField name="managerCognitoId" label="Manager ID" />
         <CustomFormField name="name" label="Property Name" />
         <CustomFormField name="description" label="Description" type="textarea" />
         <CustomFormField

--- a/server/src/__tests__/property.test.ts
+++ b/server/src/__tests__/property.test.ts
@@ -30,17 +30,16 @@ import prisma from "../utils/prisma";
 
 const app = express();
 app.use(express.json());
-// custom route to bypass auth and file upload middleware
+// custom route to bypass file upload middleware and simulate auth
 app.post("/properties", (req, res, next) => {
   (req as any).files = [];
+  (req as any).user = { id: "manager", role: "manager" };
   createProperty(req, res, next);
 });
 // other property routes
 app.use("/properties", propertyRoutes);
 
-const describeOrSkip = process.env.DATABASE_URL ? describe : describe.skip;
-
-describeOrSkip("Property API", () => {
+describe("Property API", () => {
   beforeEach(async () => {
     jest.clearAllMocks();
     await prisma.property.deleteMany();
@@ -58,6 +57,15 @@ describeOrSkip("Property API", () => {
   });
 
   it("creates property with valid payload", async () => {
+    const propertyCreateMock = jest.fn().mockResolvedValue({
+      id: 1,
+      name: "My Property",
+      locationId: 1,
+      managerCognitoId: "manager",
+      location: {},
+      manager: {},
+    });
+
     mockPrisma.$transaction.mockImplementation(async (cb: any) => {
       const tx = {
         $queryRaw: jest
@@ -73,18 +81,7 @@ describeOrSkip("Property API", () => {
               coordinates: "",
             },
           ]),
-        property: {
-          create: jest
-            .fn()
-            .mockResolvedValue({
-              id: 1,
-              name: "My Property",
-              locationId: 1,
-              managerCognitoId: "manager",
-              location: {},
-              manager: {},
-            }),
-        },
+        property: { create: propertyCreateMock },
       };
       return cb(tx);
     });
@@ -95,7 +92,6 @@ describeOrSkip("Property API", () => {
       state: "TS",
       country: "USA",
       postalCode: "12345",
-      managerCognitoId: "manager",
       name: "My Property",
       description: "Nice place",
       pricePerMonth: "1000",
@@ -110,6 +106,11 @@ describeOrSkip("Property API", () => {
     const res = await request(app).post("/properties").send(payload);
     expect(res.status).toBe(201);
     expect(mockPrisma.$transaction).toHaveBeenCalled();
+    expect(propertyCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ managerCognitoId: "manager" }),
+      })
+    );
   });
 
   it("returns 400 for invalid payload", async () => {
@@ -119,7 +120,6 @@ describeOrSkip("Property API", () => {
       state: "TS",
       country: "USA",
       postalCode: "12345",
-      managerCognitoId: "manager",
       // name missing
       description: "Nice place",
       pricePerMonth: "1000",

--- a/server/src/__tests__/propertySearch.test.ts
+++ b/server/src/__tests__/propertySearch.test.ts
@@ -1,7 +1,10 @@
 import request from "supertest";
 import express from "express";
-import propertyRoutes from "../routes/propertyRoutes";
 import prisma from "../utils/prisma";
+
+process.env.GEOCODE_USER_AGENT = "test-agent";
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const propertyRoutes = require("../routes/propertyRoutes").default;
 const app = express();
 app.use(express.json());
 app.use("/properties", propertyRoutes);

--- a/server/src/controllers/propertyControllers.ts
+++ b/server/src/controllers/propertyControllers.ts
@@ -13,7 +13,6 @@ const createPropertySchema = z.object({
   state: z.string(),
   country: z.string(),
   postalCode: z.string(),
-  managerCognitoId: z.string(),
   name: z.string(),
   description: z.string(),
   pricePerMonth: z.string(),
@@ -178,13 +177,18 @@ export const createProperty = async (
       return;
     }
 
+    const managerCognitoId = req.user?.id;
+    if (!managerCognitoId) {
+      res.status(401).json({ message: "Unauthorized" });
+      return;
+    }
+
     const {
       address,
       city,
       state,
       country,
       postalCode,
-      managerCognitoId,
       ...propertyData
     } = parsed.data;
 


### PR DESCRIPTION
## Summary
- remove `managerCognitoId` input from listing UI
- read manager ID from `req.user` in property controller
- add test coverage for implicit manager assignment

## Testing
- `cd server && npm test`
- `cd client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689afb7fdc988328a57ce3dd491b2ad4