### PR TITLE
refactor: extract location formatting utility

### DIFF
--- a/server/src/__tests__/property.test.ts
+++ b/server/src/__tests__/property.test.ts
@@ -10,6 +10,10 @@ jest.mock("../utils/geocodeAddress", () => ({
   geocodeAddress: jest.fn().mockResolvedValue([0, 0]),
 }));
 
+jest.mock("../utils/formatLocation", () => ({
+  formatLocation: jest.fn().mockResolvedValue({ longitude: 0, latitude: 0 }),
+}));
+
 const mockPrisma = {
   property: {
     deleteMany: jest.fn(),

--- a/server/src/controllers/managerControllers.ts
+++ b/server/src/controllers/managerControllers.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from "express";
-import { wktToGeoJSON } from "@terraformer/wkt";
 import prisma from "../utils/prisma";
+import { formatLocation } from "../utils/formatLocation";
 
 export const getManager = async (
   req: Request,
@@ -86,12 +86,9 @@ export const getManagerProperties = async (
 
     const propertiesWithFormattedLocation = await Promise.all(
       properties.map(async (property) => {
-        const coordinates: { coordinates: string }[] =
-          await prisma.$queryRaw`SELECT ST_asText(coordinates) as coordinates from "Location" where id = ${property.location.id}`;
-
-        const geoJSON: any = wktToGeoJSON(coordinates[0]?.coordinates || "");
-        const longitude = geoJSON.coordinates[0];
-        const latitude = geoJSON.coordinates[1];
+        const { longitude, latitude } = await formatLocation(
+          property.location.id
+        );
 
         return {
           ...property,

--- a/server/src/controllers/propertyControllers.ts
+++ b/server/src/controllers/propertyControllers.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import { Prisma, Location } from "@prisma/client";
 import { buildPropertyFilters } from "../utils/buildPropertyFilters";
-import { wktToGeoJSON } from "@terraformer/wkt";
+import { formatLocation } from "../utils/formatLocation";
 import { uploadFilesToS3 } from "../utils/s3Upload";
 import { geocodeAddress } from "../utils/geocodeAddress";
 import { z } from "zod";
@@ -137,12 +137,9 @@ export const getProperty = async (
     });
 
     if (property) {
-      const coordinates: { coordinates: string }[] =
-        await prisma.$queryRaw`SELECT ST_asText(coordinates) as coordinates from "Location" where id = ${property.location.id}`;
-
-    const geoJSON: any = wktToGeoJSON(coordinates[0]?.coordinates || "");
-    const longitude = geoJSON.coordinates[0];
-    const latitude = geoJSON.coordinates[1];
+      const { longitude, latitude } = await formatLocation(
+        property.location.id
+      );
 
       const propertyWithCoordinates = {
         ...property,

--- a/server/src/controllers/tenantControllers.ts
+++ b/server/src/controllers/tenantControllers.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from "express";
-import { wktToGeoJSON } from "@terraformer/wkt";
 import prisma from "../utils/prisma";
+import { formatLocation } from "../utils/formatLocation";
 
 export const getTenant = async (
   req: Request,
@@ -89,12 +89,9 @@ export const getCurrentResidences = async (
 
     const residencesWithFormattedLocation = await Promise.all(
       properties.map(async (property) => {
-        const coordinates: { coordinates: string }[] =
-          await prisma.$queryRaw`SELECT ST_asText(coordinates) as coordinates from "Location" where id = ${property.location.id}`;
-
-        const geoJSON: any = wktToGeoJSON(coordinates[0]?.coordinates || "");
-        const longitude = geoJSON.coordinates[0];
-        const latitude = geoJSON.coordinates[1];
+        const { longitude, latitude } = await formatLocation(
+          property.location.id
+        );
 
         return {
           ...property,

--- a/server/src/utils/__tests__/formatLocation.test.ts
+++ b/server/src/utils/__tests__/formatLocation.test.ts
@@ -1,0 +1,17 @@
+import { formatLocation } from "../formatLocation";
+import prisma from "../prisma";
+
+jest.mock("../prisma", () => ({
+  $queryRaw: jest.fn(),
+}));
+
+describe("formatLocation", () => {
+  it("returns longitude and latitude", async () => {
+    (prisma.$queryRaw as jest.Mock).mockResolvedValue([
+      { coordinates: "POINT(-73.935242 40.73061)" },
+    ]);
+
+    const result = await formatLocation(1);
+    expect(result).toEqual({ longitude: -73.935242, latitude: 40.73061 });
+  });
+});

--- a/server/src/utils/formatLocation.ts
+++ b/server/src/utils/formatLocation.ts
@@ -1,0 +1,15 @@
+import { wktToGeoJSON } from "@terraformer/wkt";
+import prisma from "./prisma";
+
+export const formatLocation = async (
+  locationId: number
+): Promise<{ longitude: number; latitude: number }> => {
+  const coordinates: { coordinates: string }[] =
+    await prisma.$queryRaw`SELECT ST_asText(coordinates) as coordinates from "Location" where id = ${locationId}`;
+
+  const geoJSON: any = wktToGeoJSON(coordinates[0]?.coordinates || "");
+  const longitude = geoJSON.coordinates[0];
+  const latitude = geoJSON.coordinates[1];
+
+  return { longitude, latitude };
+};


### PR DESCRIPTION
## Summary
- add `formatLocation` helper to run ST_AsText query and parse coordinates
- refactor tenant, manager, and property controllers to use `formatLocation`
- mock new helper in existing tests and add unit tests

## Testing
- `npm test`
- `npm run lint` *(fails: A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689b0e93898c8328b79b810bdfac5e74