### PR TITLE
Add request validation for tenant and manager endpoints

### DIFF
--- a/server/src/__tests__/userControllers.test.ts
+++ b/server/src/__tests__/userControllers.test.ts
@@ -1,0 +1,122 @@
+import request from "supertest";
+import express from "express";
+
+const mockPrisma = {
+  tenant: {
+    create: jest.fn(),
+    update: jest.fn(),
+  },
+  manager: {
+    create: jest.fn(),
+    update: jest.fn(),
+  },
+};
+
+jest.mock("../utils/prisma", () => ({
+  __esModule: true,
+  default: mockPrisma,
+}));
+
+import { createTenant, updateTenant } from "../controllers/tenantControllers";
+import { createManager, updateManager } from "../controllers/managerControllers";
+
+const app = express();
+app.use(express.json());
+app.post("/tenants", createTenant);
+app.put("/tenants/:cognitoId", updateTenant);
+app.post("/managers", createManager);
+app.put("/managers/:cognitoId", updateManager);
+
+describe("Tenant validation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates tenant with valid payload", async () => {
+    mockPrisma.tenant.create.mockResolvedValue({ id: 1 });
+    const res = await request(app).post("/tenants").send({
+      cognitoId: "abc",
+      name: "John Doe",
+      email: "john@example.com",
+      phoneNumber: "1234567890",
+    });
+    expect(res.status).toBe(201);
+    expect(mockPrisma.tenant.create).toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid tenant payload", async () => {
+    const res = await request(app).post("/tenants").send({
+      cognitoId: "abc",
+      name: "John Doe",
+      phoneNumber: "123",
+    });
+    expect(res.status).toBe(400);
+    expect(mockPrisma.tenant.create).not.toHaveBeenCalled();
+  });
+
+  it("updates tenant with valid payload", async () => {
+    mockPrisma.tenant.update.mockResolvedValue({ id: 1 });
+    const res = await request(app).put("/tenants/abc").send({
+      name: "Jane Doe",
+      email: "jane@example.com",
+      phoneNumber: "0987654321",
+    });
+    expect(res.status).toBe(200);
+    expect(mockPrisma.tenant.update).toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid tenant update", async () => {
+    const res = await request(app).put("/tenants/abc").send({
+      name: "Jane Doe",
+    });
+    expect(res.status).toBe(400);
+    expect(mockPrisma.tenant.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("Manager validation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates manager with valid payload", async () => {
+    mockPrisma.manager.create.mockResolvedValue({ id: 1 });
+    const res = await request(app).post("/managers").send({
+      cognitoId: "abc",
+      name: "John Manager",
+      email: "manager@example.com",
+      phoneNumber: "1234567890",
+    });
+    expect(res.status).toBe(201);
+    expect(mockPrisma.manager.create).toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid manager payload", async () => {
+    const res = await request(app).post("/managers").send({
+      cognitoId: "abc",
+      name: "John Manager",
+      phoneNumber: "123",
+    });
+    expect(res.status).toBe(400);
+    expect(mockPrisma.manager.create).not.toHaveBeenCalled();
+  });
+
+  it("updates manager with valid payload", async () => {
+    mockPrisma.manager.update.mockResolvedValue({ id: 1 });
+    const res = await request(app).put("/managers/abc").send({
+      name: "Jane Manager",
+      email: "jane.manager@example.com",
+      phoneNumber: "0987654321",
+    });
+    expect(res.status).toBe(200);
+    expect(mockPrisma.manager.update).toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid manager update", async () => {
+    const res = await request(app).put("/managers/abc").send({
+      name: "Jane Manager",
+    });
+    expect(res.status).toBe(400);
+    expect(mockPrisma.manager.update).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/controllers/managerControllers.ts
+++ b/server/src/controllers/managerControllers.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import { wktToGeoJSON } from "@terraformer/wkt";
 import prisma from "../utils/prisma";
+import { createUserSchema, updateUserSchema } from "../validators/userValidators";
 
 export const getManager = async (
   req: Request,
@@ -29,7 +30,12 @@ export const createManager = async (
   next: NextFunction
 ): Promise<void> => {
   try {
-    const { cognitoId, name, email, phoneNumber } = req.body;
+    const parsed = createUserSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ errors: parsed.error.errors });
+      return;
+    }
+    const { cognitoId, name, email, phoneNumber } = parsed.data;
 
     const manager = await prisma.manager.create({
       data: {
@@ -53,7 +59,12 @@ export const updateManager = async (
 ): Promise<void> => {
   try {
     const { cognitoId } = req.params;
-    const { name, email, phoneNumber } = req.body;
+    const parsed = updateUserSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ errors: parsed.error.errors });
+      return;
+    }
+    const { name, email, phoneNumber } = parsed.data;
 
     const updateManager = await prisma.manager.update({
       where: { cognitoId },

--- a/server/src/controllers/tenantControllers.ts
+++ b/server/src/controllers/tenantControllers.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import { wktToGeoJSON } from "@terraformer/wkt";
 import prisma from "../utils/prisma";
+import { createUserSchema, updateUserSchema } from "../validators/userValidators";
 
 export const getTenant = async (
   req: Request,
@@ -32,7 +33,12 @@ export const createTenant = async (
   next: NextFunction
 ): Promise<void> => {
   try {
-    const { cognitoId, name, email, phoneNumber } = req.body;
+    const parsed = createUserSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ errors: parsed.error.errors });
+      return;
+    }
+    const { cognitoId, name, email, phoneNumber } = parsed.data;
 
     const tenant = await prisma.tenant.create({
       data: {
@@ -56,7 +62,12 @@ export const updateTenant = async (
 ): Promise<void> => {
   try {
     const { cognitoId } = req.params;
-    const { name, email, phoneNumber } = req.body;
+    const parsed = updateUserSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ errors: parsed.error.errors });
+      return;
+    }
+    const { name, email, phoneNumber } = parsed.data;
 
     const updateTenant = await prisma.tenant.update({
       where: { cognitoId },

--- a/server/src/validators/userValidators.ts
+++ b/server/src/validators/userValidators.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  cognitoId: z.string(),
+  name: z.string(),
+  email: z.string().email(),
+  phoneNumber: z.string().min(10),
+});
+
+export const updateUserSchema = z.object({
+  name: z.string(),
+  email: z.string().email(),
+  phoneNumber: z.string().min(10),
+});
+


### PR DESCRIPTION
## Summary
- add shared Zod schemas for creating/updating managers and tenants
- validate request bodies in manager and tenant controllers
- test validation success and failure cases for both controllers

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b0e94e1408328b9a410d993f98fca