### PR TITLE
Guard useIsMobile hook for non-browser environments

### DIFF
--- a/client/hooks/use-mobile.tsx
+++ b/client/hooks/use-mobile.tsx
@@ -3,9 +3,12 @@ import * as React from "react"
 const MOBILE_BREAKPOINT = 768
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
+    typeof window === "undefined" ? false : undefined
+  )
 
   React.useEffect(() => {
+    if (typeof window === "undefined") return
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)

--- a/client/src/hooks/use-mobile.test.tsx
+++ b/client/src/hooks/use-mobile.test.tsx
@@ -1,0 +1,16 @@
+/** @jest-environment node */
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { useIsMobile } from './use-mobile';
+
+function TestComponent() {
+  useIsMobile();
+  return null;
+}
+
+describe('useIsMobile', () => {
+  it('does not crash in a Node environment', () => {
+    expect(() => renderToString(React.createElement(TestComponent))).not.toThrow();
+  });
+});
+

--- a/client/src/hooks/use-mobile.tsx
+++ b/client/src/hooks/use-mobile.tsx
@@ -3,9 +3,12 @@ import * as React from "react"
 const MOBILE_BREAKPOINT = 768
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
+    typeof window === "undefined" ? false : undefined
+  )
 
   React.useEffect(() => {
+    if (typeof window === "undefined") return
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)


### PR DESCRIPTION
## Summary
- wrap useIsMobile hook window references with `typeof window !== 'undefined'`
- default to `false` when `window` is undefined
- add test confirming hook renders without crashing in a Node environment

## Testing
- `cd client && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_689b0e989fc0832897fea050c906e416