### PR TITLE
test: add controller test suites

### DIFF
--- a/server/src/__tests__/applicationControllers.test.ts
+++ b/server/src/__tests__/applicationControllers.test.ts
@@ -1,0 +1,149 @@
+import { Request, Response, NextFunction } from "express";
+
+// Mock external services
+jest.mock("../utils/s3Upload", () => ({ uploadFilesToS3: jest.fn() }));
+jest.mock("../utils/geocodeAddress", () => ({ geocodeAddress: jest.fn() }));
+
+jest.mock("../services/applicationService", () => ({
+  updateApplicationStatus: jest.fn(),
+}));
+
+const mockPrisma = {
+  application: { findMany: jest.fn(), create: jest.fn() },
+  property: { findUnique: jest.fn() },
+  lease: { findFirst: jest.fn(), create: jest.fn() },
+  tenant: {},
+  $transaction: jest.fn(),
+  $disconnect: jest.fn(),
+};
+
+jest.mock("@prisma/client", () => ({
+  PrismaClient: jest.fn(() => mockPrisma),
+  Prisma: { join: jest.fn() },
+}));
+
+import prisma from "../utils/prisma";
+import {
+  listApplications,
+  createApplication,
+  updateApplicationStatus,
+} from "../controllers/applicationControllers";
+import { updateApplicationStatus as updateApplicationStatusService } from "../services/applicationService";
+
+const createMockRes = () => {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res as Response;
+};
+
+describe("applicationControllers", () => {
+  const next: NextFunction = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("lists applications for tenant", async () => {
+    mockPrisma.application.findMany.mockResolvedValue([
+      {
+        property: { location: { address: "addr" }, manager: {} },
+        tenantCognitoId: "t1",
+        propertyId: 1,
+      },
+    ]);
+    mockPrisma.lease.findFirst.mockResolvedValue({
+      startDate: new Date("2023-01-01"),
+    });
+
+    const req = { query: { userId: "t1", userType: "tenant" } } as unknown as Request;
+    const res = createMockRes();
+
+    await listApplications(req, res, next);
+
+    expect(res.json).toHaveBeenCalled();
+    expect(mockPrisma.application.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { tenantCognitoId: "t1" } })
+    );
+  });
+
+  it("creates application when property exists", async () => {
+    mockPrisma.property.findUnique.mockResolvedValue({
+      pricePerMonth: 1000,
+      securityDeposit: 500,
+    });
+
+    mockPrisma.$transaction.mockImplementation(async (cb: any) => {
+      const tx = {
+        lease: { create: jest.fn().mockResolvedValue({ id: 1 }) },
+        application: {
+          create: jest.fn().mockResolvedValue({ id: 1, property: {}, tenant: {}, lease: {} }),
+        },
+      };
+      return cb(tx);
+    });
+
+    const req = {
+      body: {
+        applicationDate: new Date().toISOString(),
+        status: "PENDING",
+        propertyId: 1,
+        tenantCognitoId: "t1",
+        name: "n",
+        email: "e",
+        phoneNumber: "p",
+        message: "m",
+      },
+    } as unknown as Request;
+    const res = createMockRes();
+
+    await createApplication(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalled();
+  });
+
+  it("returns 404 when property missing", async () => {
+    mockPrisma.property.findUnique.mockResolvedValue(null);
+    const req = { body: { propertyId: 1 } } as unknown as Request;
+    const res = createMockRes();
+
+    await createApplication(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ message: "Property not found" });
+  });
+
+  it("calls next on create error", async () => {
+    mockPrisma.property.findUnique.mockRejectedValue(new Error("db"));
+    const req = { body: { propertyId: 1 } } as unknown as Request;
+    const res = createMockRes();
+    const localNext = jest.fn();
+
+    await createApplication(req, res, localNext);
+
+    expect(localNext).toHaveBeenCalled();
+  });
+
+  it("updates application status", async () => {
+    (updateApplicationStatusService as jest.Mock).mockResolvedValue({ id: 1 });
+    const req = { params: { id: "1" }, body: { status: "APPROVED" } } as unknown as Request;
+    const res = createMockRes();
+
+    await updateApplicationStatus(req, res, next);
+
+    expect(res.json).toHaveBeenCalledWith({ id: 1 });
+  });
+
+  it("returns 404 when updating missing application", async () => {
+    (updateApplicationStatusService as jest.Mock).mockResolvedValue(null);
+    const req = { params: { id: "1" }, body: { status: "APPROVED" } } as unknown as Request;
+    const res = createMockRes();
+
+    await updateApplicationStatus(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ message: "Application not found." });
+  });
+});
+

--- a/server/src/__tests__/leaseControllers.test.ts
+++ b/server/src/__tests__/leaseControllers.test.ts
@@ -1,0 +1,80 @@
+import { Request, Response, NextFunction } from "express";
+
+// Mock external services
+jest.mock("../utils/s3Upload", () => ({ uploadFilesToS3: jest.fn() }));
+jest.mock("../utils/geocodeAddress", () => ({ geocodeAddress: jest.fn() }));
+
+const mockPrisma = {
+  lease: { findMany: jest.fn() },
+  payment: { findMany: jest.fn() },
+  $disconnect: jest.fn(),
+};
+
+jest.mock("@prisma/client", () => ({
+  PrismaClient: jest.fn(() => mockPrisma),
+  Prisma: { join: jest.fn() },
+}));
+
+import prisma from "../utils/prisma";
+import { getLeases, getLeasePayments } from "../controllers/leaseControllers";
+
+const createMockRes = () => {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res as Response;
+};
+
+describe("leaseControllers", () => {
+  const next: NextFunction = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns leases", async () => {
+    mockPrisma.lease.findMany.mockResolvedValue([{ id: 1 }]);
+    const req = {} as Request;
+    const res = createMockRes();
+
+    await getLeases(req, res, next);
+
+    expect(res.json).toHaveBeenCalledWith([{ id: 1 }]);
+  });
+
+  it("calls next on lease error", async () => {
+    mockPrisma.lease.findMany.mockRejectedValue(new Error("db"));
+    const req = {} as Request;
+    const res = createMockRes();
+    const localNext = jest.fn();
+
+    await getLeases(req, res, localNext);
+
+    expect(localNext).toHaveBeenCalled();
+  });
+
+  it("returns lease payments", async () => {
+    mockPrisma.payment.findMany.mockResolvedValue([{ id: 1 }]);
+    const req = { params: { id: "1" } } as unknown as Request;
+    const res = createMockRes();
+
+    await getLeasePayments(req, res, next);
+
+    expect(mockPrisma.payment.findMany).toHaveBeenCalledWith({
+      where: { leaseId: 1 },
+    });
+    expect(res.json).toHaveBeenCalledWith([{ id: 1 }]);
+  });
+
+  it("calls next on payment error", async () => {
+    mockPrisma.payment.findMany.mockRejectedValue(new Error("db"));
+    const req = { params: { id: "1" } } as unknown as Request;
+    const res = createMockRes();
+    const localNext = jest.fn();
+
+    await getLeasePayments(req, res, localNext);
+
+    expect(localNext).toHaveBeenCalled();
+  });
+});
+

--- a/server/src/__tests__/managerControllers.test.ts
+++ b/server/src/__tests__/managerControllers.test.ts
@@ -1,0 +1,102 @@
+import { Request, Response, NextFunction } from "express";
+
+// Mock external services
+jest.mock("../utils/s3Upload", () => ({ uploadFilesToS3: jest.fn() }));
+jest.mock("../utils/geocodeAddress", () => ({ geocodeAddress: jest.fn() }));
+
+jest.mock("@terraformer/wkt", () => ({
+  wktToGeoJSON: jest.fn().mockReturnValue({ coordinates: [1, 2] }),
+}));
+
+const mockPrisma = {
+  manager: {
+    findUnique: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  },
+  property: { findMany: jest.fn() },
+  $queryRaw: jest.fn(),
+  $disconnect: jest.fn(),
+};
+
+jest.mock("@prisma/client", () => ({
+  PrismaClient: jest.fn(() => mockPrisma),
+  Prisma: { join: jest.fn() },
+}));
+
+import prisma from "../utils/prisma";
+import { getManager, getManagerProperties } from "../controllers/managerControllers";
+
+const createMockRes = () => {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res as Response;
+};
+
+describe("managerControllers", () => {
+  const next: NextFunction = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns manager when found", async () => {
+    mockPrisma.manager.findUnique.mockResolvedValue({ cognitoId: "m1" });
+    const req = { params: { cognitoId: "m1" } } as unknown as Request;
+    const res = createMockRes();
+
+    await getManager(req, res, next);
+
+    expect(res.json).toHaveBeenCalledWith({ cognitoId: "m1" });
+  });
+
+  it("returns 404 when manager missing", async () => {
+    mockPrisma.manager.findUnique.mockResolvedValue(null);
+    const req = { params: { cognitoId: "m1" } } as unknown as Request;
+    const res = createMockRes();
+
+    await getManager(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ message: "Manager not found" });
+  });
+
+  it("lists manager properties with coordinates", async () => {
+    mockPrisma.property.findMany.mockResolvedValue([
+      {
+        id: 1,
+        location: { id: 10, address: "addr" },
+      },
+    ]);
+    mockPrisma.$queryRaw.mockResolvedValue([{ coordinates: "POINT(1 2)" }]);
+
+    const req = { params: { cognitoId: "m1" } } as unknown as Request;
+    const res = createMockRes();
+
+    await getManagerProperties(req, res, next);
+
+    expect(res.json).toHaveBeenCalledWith([
+      {
+        id: 1,
+        location: {
+          id: 10,
+          address: "addr",
+          coordinates: { longitude: 1, latitude: 2 },
+        },
+      },
+    ]);
+  });
+
+  it("calls next on error", async () => {
+    mockPrisma.property.findMany.mockRejectedValue(new Error("db"));
+    const req = { params: { cognitoId: "m1" } } as unknown as Request;
+    const res = createMockRes();
+    const localNext = jest.fn();
+
+    await getManagerProperties(req, res, localNext);
+
+    expect(localNext).toHaveBeenCalled();
+  });
+});
+

--- a/server/src/__tests__/tenantControllers.test.ts
+++ b/server/src/__tests__/tenantControllers.test.ts
@@ -1,0 +1,98 @@
+import { Request, Response, NextFunction } from "express";
+
+// Mock external services
+jest.mock("../utils/s3Upload", () => ({ uploadFilesToS3: jest.fn() }));
+jest.mock("../utils/geocodeAddress", () => ({ geocodeAddress: jest.fn() }));
+
+const mockPrisma = {
+  tenant: {
+    findUnique: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  },
+  property: { findMany: jest.fn() },
+  $queryRaw: jest.fn(),
+  $disconnect: jest.fn(),
+};
+
+jest.mock("@prisma/client", () => ({
+  PrismaClient: jest.fn(() => mockPrisma),
+  Prisma: { join: jest.fn() },
+}));
+
+import prisma from "../utils/prisma";
+import { getTenant, createTenant, addFavoriteProperty } from "../controllers/tenantControllers";
+
+const createMockRes = () => {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res as Response;
+};
+
+describe("tenantControllers", () => {
+  const next: NextFunction = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns tenant when found", async () => {
+    mockPrisma.tenant.findUnique.mockResolvedValue({ cognitoId: "abc" });
+    const req = { params: { cognitoId: "abc" } } as unknown as Request;
+    const res = createMockRes();
+
+    await getTenant(req, res, next);
+
+    expect(res.json).toHaveBeenCalledWith({ cognitoId: "abc" });
+  });
+
+  it("returns 404 when tenant missing", async () => {
+    mockPrisma.tenant.findUnique.mockResolvedValue(null);
+    const req = { params: { cognitoId: "missing" } } as unknown as Request;
+    const res = createMockRes();
+
+    await getTenant(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ message: "Tenant not found" });
+  });
+
+  it("adds property to favorites", async () => {
+    mockPrisma.tenant.findUnique.mockResolvedValue({ favorites: [] });
+    mockPrisma.tenant.update.mockResolvedValue({ favorites: [{ id: 1 }] });
+
+    const req = { params: { cognitoId: "t1", propertyId: "1" } } as unknown as Request;
+    const res = createMockRes();
+
+    await addFavoriteProperty(req, res, next);
+
+    expect(mockPrisma.tenant.update).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ favorites: [{ id: 1 }] });
+  });
+
+  it("returns 409 when property already favorite", async () => {
+    mockPrisma.tenant.findUnique.mockResolvedValue({ favorites: [{ id: 1 }] });
+    const req = { params: { cognitoId: "t1", propertyId: "1" } } as unknown as Request;
+    const res = createMockRes();
+
+    await addFavoriteProperty(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith({ message: "Property already added as favorite" });
+  });
+
+  it("calls next on create error", async () => {
+    mockPrisma.tenant.create.mockRejectedValue(new Error("fail"));
+    const req = {
+      body: { cognitoId: "1", name: "a", email: "e", phoneNumber: "p" },
+    } as unknown as Request;
+    const res = createMockRes();
+    const localNext = jest.fn();
+
+    await createTenant(req, res, localNext);
+
+    expect(localNext).toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tenant controller tests for retrieval and favorites
- add manager controller tests including property formatting
- add application controller tests for listing, creation, and updates
- add lease controller tests for leases and payments

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b0e99ed0c83289049184c8f53b1f5