### PR TITLE
refactor: centralize s3 client and add upload validation

### DIFF
--- a/server/src/__tests__/s3Upload.test.ts
+++ b/server/src/__tests__/s3Upload.test.ts
@@ -1,0 +1,36 @@
+jest.mock('../env', () => ({
+  AWS_REGION: 'us-east-1',
+  S3_BUCKET_NAME: 'test-bucket',
+  AWS_ACCESS_KEY_ID: 'test',
+  AWS_SECRET_ACCESS_KEY: 'secret',
+}));
+
+jest.mock('@aws-sdk/lib-storage', () => ({
+  Upload: jest.fn().mockImplementation(() => ({
+    done: jest.fn().mockResolvedValue({ Location: 'https://example.com/file' }),
+  })),
+}));
+
+import { uploadFilesToS3 } from '../utils/s3Upload';
+
+describe('uploadFilesToS3 validation', () => {
+  it('throws error for invalid file type', async () => {
+    const file: any = {
+      originalname: 'file.txt',
+      mimetype: 'text/plain',
+      size: 100,
+      buffer: Buffer.from('a'),
+    };
+    await expect(uploadFilesToS3([file])).rejects.toThrow('Invalid file type');
+  });
+
+  it('throws error for oversized file', async () => {
+    const file: any = {
+      originalname: 'big.png',
+      mimetype: 'image/png',
+      size: 6 * 1024 * 1024,
+      buffer: Buffer.from('a'),
+    };
+    await expect(uploadFilesToS3([file])).rejects.toThrow('File too large');
+  });
+});

--- a/server/src/utils/s3Client.ts
+++ b/server/src/utils/s3Client.ts
@@ -1,0 +1,12 @@
+import { S3Client } from '@aws-sdk/client-s3';
+import { AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY } from '../env';
+
+export const s3Client = new S3Client({
+  region: AWS_REGION,
+  credentials: {
+    accessKeyId: AWS_ACCESS_KEY_ID,
+    secretAccessKey: AWS_SECRET_ACCESS_KEY,
+  },
+});
+
+export default s3Client;

--- a/server/src/utils/s3Upload.ts
+++ b/server/src/utils/s3Upload.ts
@@ -1,27 +1,24 @@
-import type { Express } from "express";
-import { S3Client } from "@aws-sdk/client-s3";
-import { Upload } from "@aws-sdk/lib-storage";
-import {
-  AWS_REGION,
-  S3_BUCKET_NAME,
-  AWS_ACCESS_KEY_ID,
-  AWS_SECRET_ACCESS_KEY,
-} from "../env";
+import type { Express } from 'express';
+import { Upload } from '@aws-sdk/lib-storage';
+import { S3_BUCKET_NAME } from '../env';
+import s3Client from './s3Client';
 
-export const uploadFilesToS3 = async (
-  files: Express.Multer.File[],
-): Promise<string[]> => {
-  const s3Client = new S3Client({
-    region: AWS_REGION,
-    credentials: {
-      accessKeyId: AWS_ACCESS_KEY_ID,
-      secretAccessKey: AWS_SECRET_ACCESS_KEY,
-    },
-  });
+const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif'];
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+export const uploadFilesToS3 = async (files: Express.Multer.File[]): Promise<string[]> => {
   const bucket = S3_BUCKET_NAME;
 
   return Promise.all(
     files.map(async (file) => {
+      if (!ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+        throw new Error(`Invalid file type: ${file.mimetype}`);
+      }
+
+      if (file.size > MAX_FILE_SIZE) {
+        throw new Error(`File too large: ${file.originalname}`);
+      }
+
       const uploadResult = await new Upload({
         client: s3Client,
         params: {
@@ -33,7 +30,7 @@ export const uploadFilesToS3 = async (
       }).done();
 
       return uploadResult.Location as string;
-    })
+    }),
   );
 };
 


### PR DESCRIPTION
## Summary
- centralize AWS S3 client configuration in a reusable singleton
- add mimetype and size validation for S3 uploads with descriptive errors
- test s3 upload rejects oversized or invalid file types

## Testing
- `npx jest src/__tests__/s3Upload.test.ts`
- `npm test` *(fails: SyntaxError in existing test files)*

------
https://chatgpt.com/codex/tasks/task_e_689b8c13c928832888d9a50e5b7eeaf0