### PR TITLE
feat(server): add geocode caching

### DIFF
--- a/server/src/__tests__/geocodeAddressCache.test.ts
+++ b/server/src/__tests__/geocodeAddressCache.test.ts
@@ -1,0 +1,47 @@
+import axios from 'axios';
+import { clearCache } from '../utils/geocodeCache';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+let geocodeAddress: (
+  address: string,
+  city: string,
+  country: string,
+  postalCode: string,
+) => Promise<[number, number]>;
+
+describe('geocodeAddress caching', () => {
+  beforeEach(() => {
+    clearCache();
+    mockedAxios.get.mockReset();
+    Object.assign(process.env, {
+      GEOCODE_USER_AGENT: 'test-agent',
+      DATABASE_URL: 'https://example.com',
+      COGNITO_AUDIENCE: 'aud',
+      COGNITO_ISSUER: 'issuer',
+      AWS_REGION: 'us-east-1',
+      S3_BUCKET_NAME: 'bucket',
+      AWS_ACCESS_KEY_ID: 'key',
+      AWS_SECRET_ACCESS_KEY: 'secret',
+      JWT_SECRET: 'jwt',
+    });
+    geocodeAddress = require('../utils/geocodeAddress').geocodeAddress;
+  });
+
+  it('reuses cached coordinates on repeated calls', async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: [{ lon: '1', lat: '2' }],
+    });
+
+    const params: [string, string, string, string] = ['123 Main', 'Town', 'USA', '12345'];
+
+    const first = await geocodeAddress(...params);
+    expect(first).toEqual([1, 2]);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+
+    const second = await geocodeAddress(...params);
+    expect(second).toEqual([1, 2]);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/src/utils/geocodeAddress.ts
+++ b/server/src/utils/geocodeAddress.ts
@@ -1,5 +1,6 @@
-import axios from "axios";
-import { GEOCODE_USER_AGENT } from "../env";
+import axios from 'axios';
+import { GEOCODE_USER_AGENT } from '../env';
+import { getCacheKey, getCachedCoordinates, setCachedCoordinates } from './geocodeCache';
 
 export const geocodeAddress = async (
   address: string,
@@ -7,35 +8,41 @@ export const geocodeAddress = async (
   country: string,
   postalCode: string,
 ): Promise<[number, number]> => {
+  const cacheKey = getCacheKey(address, city, country, postalCode);
+  const cached = getCachedCoordinates(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
   const geocodingUrl = `https://nominatim.openstreetmap.org/search?${new URLSearchParams({
     street: address,
     city,
     country,
     postalcode: postalCode,
-    format: "json",
-    limit: "1",
+    format: 'json',
+    limit: '1',
   }).toString()}`;
 
   if (!GEOCODE_USER_AGENT) {
-    throw new Error(
-      "GEOCODE_USER_AGENT environment variable is required for geocoding requests",
-    );
+    throw new Error('GEOCODE_USER_AGENT environment variable is required for geocoding requests');
   }
 
   const geocodingResponse = await axios.get(geocodingUrl, {
     headers: {
-      "User-Agent": GEOCODE_USER_AGENT,
+      'User-Agent': GEOCODE_USER_AGENT,
     },
   });
 
   if (!geocodingResponse.data?.[0]) {
-    throw new Error("Geocoding failed");
+    throw new Error('Geocoding failed');
   }
 
-  return [
+  const coordinates: [number, number] = [
     parseFloat(geocodingResponse.data[0].lon),
     parseFloat(geocodingResponse.data[0].lat),
   ];
+  setCachedCoordinates(cacheKey, coordinates);
+  return coordinates;
 };
 
 export default geocodeAddress;

--- a/server/src/utils/geocodeCache.ts
+++ b/server/src/utils/geocodeCache.ts
@@ -1,0 +1,45 @@
+export type Coordinates = [number, number];
+
+interface CacheEntry {
+  value: Coordinates;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+const DEFAULT_TTL_MS = 1000 * 60 * 60 * 24; // 24 hours
+
+export const getCacheKey = (
+  address: string,
+  city: string,
+  country: string,
+  postalCode: string,
+): string => `${address}|${city}|${country}|${postalCode}`.toLowerCase();
+
+export const getCachedCoordinates = (key: string): Coordinates | undefined => {
+  const entry = cache.get(key);
+  if (!entry) return undefined;
+  if (Date.now() > entry.expiresAt) {
+    cache.delete(key);
+    return undefined;
+  }
+  return entry.value;
+};
+
+export const setCachedCoordinates = (
+  key: string,
+  value: Coordinates,
+  ttlMs: number = DEFAULT_TTL_MS,
+): void => {
+  cache.set(key, { value, expiresAt: Date.now() + ttlMs });
+};
+
+export const clearCache = (): void => {
+  cache.clear();
+};
+
+export default {
+  getCacheKey,
+  getCachedCoordinates,
+  setCachedCoordinates,
+  clearCache,
+};


### PR DESCRIPTION
## Summary
- add in-memory geocode cache with TTL
- use cache in `geocodeAddress` to avoid redundant lookups
- test repeated calls return cached coordinates

## Testing
- `npm test` *(fails: SyntaxError in existing tests)*
- `npx jest src/__tests__/geocodeAddressCache.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689b8c149b008328a4e1dad325c225c5