### PR TITLE
Add global error boundary

### DIFF
--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Providers from "./providers";
 import { Toaster } from "@/components/ui/sonner";
+import ErrorBoundary from "@/components/error-boundary";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -26,11 +27,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        <Providers>{children}</Providers>
-        <Toaster closeButton />
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <ErrorBoundary>
+          <Providers>{children}</Providers>
+          <Toaster closeButton />
+        </ErrorBoundary>
       </body>
     </html>
   );

--- a/client/src/components/error-boundary.tsx
+++ b/client/src/components/error-boundary.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import React, { Component, ErrorInfo, ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(_: Error): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error("Error caught in ErrorBoundary:", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return React.createElement("p", null, "Something went wrong.");
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;
+

--- a/client/tests/error-boundary.test.tsx
+++ b/client/tests/error-boundary.test.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import ErrorBoundary from "@/components/error-boundary";
+
+const ThrowingComponent = () => {
+  throw new Error("Test error");
+};
+
+describe("ErrorBoundary", () => {
+  it("renders fallback message when child throws", () => {
+    render(
+      React.createElement(
+        ErrorBoundary,
+        null,
+        React.createElement(ThrowingComponent)
+      )
+    );
+
+    expect(screen.getByText("Something went wrong.")).toBeTruthy();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add reusable ErrorBoundary component that logs and shows a fallback message
- wrap the root layout in ErrorBoundary to surface a friendly error screen
- test that a component throwing an error renders the fallback UI

## Testing
- `npm test --prefix client` *(fails: Code style issues found in 110 files)*
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_689b8c1bd580832880c2b93d40ee4065