### PR TITLE
feat: add pagination for property search

### DIFF
--- a/client/src/app/(dashboard)/tenants/favorites/page.tsx
+++ b/client/src/app/(dashboard)/tenants/favorites/page.tsx
@@ -1,32 +1,31 @@
-"use client";
+'use client';
 
-import Card from "@/components/Card";
-import Header from "@/components/Header";
-import Loading from "@/components/Loading";
-import {
-  useGetAuthUserQuery,
-  useGetPropertiesQuery,
-  useGetTenantQuery,
-} from "@/state/api";
-import React from "react";
+import Card from '@/components/Card';
+import Header from '@/components/Header';
+import Loading from '@/components/Loading';
+import { useGetAuthUserQuery, useGetPropertiesQuery, useGetTenantQuery } from '@/state/api';
+import React from 'react';
 
 const Favorites = () => {
   const { data: authUser } = useGetAuthUserQuery();
-  const { data: tenant } = useGetTenantQuery(
-    authUser?.cognitoInfo?.userId || "",
-    {
-      skip: !authUser?.cognitoInfo?.userId,
-    }
-  );
+  const { data: tenant } = useGetTenantQuery(authUser?.cognitoInfo?.userId || '', {
+    skip: !authUser?.cognitoInfo?.userId,
+  });
 
   const {
-    data: favoriteProperties,
+    data: favoritePropertyData,
     isLoading,
     error,
   } = useGetPropertiesQuery(
-    { favoriteIds: tenant?.favorites?.map((fav: { id: number }) => fav.id) },
-    { skip: !tenant?.favorites || tenant?.favorites.length === 0 }
+    {
+      favoriteIds: tenant?.favorites?.map((fav: { id: number }) => fav.id),
+      page: 1,
+      pageSize: tenant?.favorites?.length || 10,
+    },
+    { skip: !tenant?.favorites || tenant?.favorites.length === 0 },
   );
+
+  const favoriteProperties = favoritePropertyData?.properties;
 
   if (isLoading) return <Loading />;
   if (error) return <div>Error loading favorites</div>;

--- a/client/src/app/(nondashboard)/search/FiltersBar.tsx
+++ b/client/src/app/(nondashboard)/search/FiltersBar.tsx
@@ -1,35 +1,28 @@
-import {
-  FiltersState,
-  setFilters,
-  setViewMode,
-  toggleFiltersFullOpen,
-} from "@/state";
-import { useAppSelector } from "@/state/redux";
-import { usePathname, useRouter } from "next/navigation";
-import React, { useState } from "react";
-import { useDispatch } from "react-redux";
-import { debounce } from "lodash";
-import { cleanParams, cn, formatPriceValue } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
-import { Filter, Grid, List, Search } from "lucide-react";
-import { Input } from "@/components/ui/input";
+import { FiltersState, setFilters, setViewMode, toggleFiltersFullOpen } from '@/state';
+import { useAppSelector } from '@/state/redux';
+import { usePathname, useRouter } from 'next/navigation';
+import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { debounce } from 'lodash';
+import { cleanParams, cn, formatPriceValue } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Filter, Grid, List, Search } from 'lucide-react';
+import { Input } from '@/components/ui/input';
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/ui/select";
-import { PropertyTypeIcons } from "@/lib/constants";
+} from '@/components/ui/select';
+import { PropertyTypeIcons } from '@/lib/constants';
 
 const FiltersBar = () => {
   const dispatch = useDispatch();
   const router = useRouter();
   const pathname = usePathname();
   const filters = useAppSelector((state) => state.global.filters);
-  const isFiltersFullOpen = useAppSelector(
-    (state) => state.global.isFiltersFullOpen
-  );
+  const isFiltersFullOpen = useAppSelector((state) => state.global.isFiltersFullOpen);
   const viewMode = useAppSelector((state) => state.global.viewMode);
   const [searchInput, setSearchInput] = useState(filters.location);
 
@@ -38,36 +31,29 @@ const FiltersBar = () => {
     const updatedSearchParams = new URLSearchParams();
 
     Object.entries(cleanFilters).forEach(([key, value]) => {
-      updatedSearchParams.set(
-        key,
-        Array.isArray(value) ? value.join(",") : value.toString()
-      );
+      updatedSearchParams.set(key, Array.isArray(value) ? value.join(',') : value.toString());
     });
 
     router.push(`${pathname}?${updatedSearchParams.toString()}`);
   });
 
-  const handleFilterChange = (
-    key: string,
-    value: any,
-    isMin: boolean | null
-  ) => {
+  const handleFilterChange = (key: string, value: any, isMin: boolean | null) => {
     let newValue = value;
 
-    if (key === "priceRange" || key === "squareFeet") {
+    if (key === 'priceRange' || key === 'squareFeet') {
       const currentArrayRange = [...filters[key]];
       if (isMin !== null) {
         const index = isMin ? 0 : 1;
-        currentArrayRange[index] = value === "any" ? null : Number(value);
+        currentArrayRange[index] = value === 'any' ? null : Number(value);
       }
       newValue = currentArrayRange;
-    } else if (key === "coordinates") {
-      newValue = value === "any" ? [0, 0] : value.map(Number);
+    } else if (key === 'coordinates') {
+      newValue = value === 'any' ? [0, 0] : value.map(Number);
     } else {
-      newValue = value === "any" ? "any" : value;
+      newValue = value === 'any' ? 'any' : value;
     }
 
-    const newFilters = { ...filters, [key]: newValue };
+    const newFilters = { ...filters, [key]: newValue, page: 1 };
     dispatch(setFilters(newFilters));
     updateURL(newFilters);
   };
@@ -76,10 +62,8 @@ const FiltersBar = () => {
     try {
       const response = await fetch(
         `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(
-          searchInput
-        )}.json?access_token=${
-          process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
-        }&fuzzyMatch=true`
+          searchInput,
+        )}.json?access_token=${process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN}&fuzzyMatch=true`,
       );
       const data = await response.json();
       if (data.features && data.features.length > 0) {
@@ -88,11 +72,12 @@ const FiltersBar = () => {
           setFilters({
             location: searchInput,
             coordinates: [lng, lat],
-          })
+            page: 1,
+          }),
         );
       }
     } catch (err) {
-      console.error("Error search location:", err);
+      console.error('Error search location:', err);
     }
   };
 
@@ -104,8 +89,8 @@ const FiltersBar = () => {
         <Button
           variant="outline"
           className={cn(
-            "gap-2 rounded-xl border-primary-400 hover:bg-primary-500 hover:text-primary-100",
-            isFiltersFullOpen && "bg-primary-700 text-primary-100"
+            'gap-2 rounded-xl border-primary-400 hover:bg-primary-500 hover:text-primary-100',
+            isFiltersFullOpen && 'bg-primary-700 text-primary-100',
           )}
           onClick={() => dispatch(toggleFiltersFullOpen())}
         >
@@ -134,15 +119,11 @@ const FiltersBar = () => {
         <div className="flex gap-1">
           {/* Minimum Price Selector */}
           <Select
-            value={filters.priceRange[0]?.toString() || "any"}
-            onValueChange={(value) =>
-              handleFilterChange("priceRange", value, true)
-            }
+            value={filters.priceRange[0]?.toString() || 'any'}
+            onValueChange={(value) => handleFilterChange('priceRange', value, true)}
           >
             <SelectTrigger className="w-22 rounded-xl border-primary-400">
-              <SelectValue>
-                {formatPriceValue(filters.priceRange[0], true)}
-              </SelectValue>
+              <SelectValue>{formatPriceValue(filters.priceRange[0], true)}</SelectValue>
             </SelectTrigger>
             <SelectContent className="bg-white">
               <SelectItem value="any">Any Min Price</SelectItem>
@@ -156,15 +137,11 @@ const FiltersBar = () => {
 
           {/* Maximum Price Selector */}
           <Select
-            value={filters.priceRange[1]?.toString() || "any"}
-            onValueChange={(value) =>
-              handleFilterChange("priceRange", value, false)
-            }
+            value={filters.priceRange[1]?.toString() || 'any'}
+            onValueChange={(value) => handleFilterChange('priceRange', value, false)}
           >
             <SelectTrigger className="w-22 rounded-xl border-primary-400">
-              <SelectValue>
-                {formatPriceValue(filters.priceRange[1], false)}
-              </SelectValue>
+              <SelectValue>{formatPriceValue(filters.priceRange[1], false)}</SelectValue>
             </SelectTrigger>
             <SelectContent className="bg-white">
               <SelectItem value="any">Any Max Price</SelectItem>
@@ -182,7 +159,7 @@ const FiltersBar = () => {
           {/* Beds */}
           <Select
             value={filters.beds}
-            onValueChange={(value) => handleFilterChange("beds", value, null)}
+            onValueChange={(value) => handleFilterChange('beds', value, null)}
           >
             <SelectTrigger className="w-26 rounded-xl border-primary-400">
               <SelectValue placeholder="Beds" />
@@ -199,7 +176,7 @@ const FiltersBar = () => {
           {/* Baths */}
           <Select
             value={filters.baths}
-            onValueChange={(value) => handleFilterChange("baths", value, null)}
+            onValueChange={(value) => handleFilterChange('baths', value, null)}
           >
             <SelectTrigger className="w-26 rounded-xl border-primary-400">
               <SelectValue placeholder="Baths" />
@@ -215,10 +192,8 @@ const FiltersBar = () => {
 
         {/* Property Type */}
         <Select
-          value={filters.propertyType || "any"}
-          onValueChange={(value) =>
-            handleFilterChange("propertyType", value, null)
-          }
+          value={filters.propertyType || 'any'}
+          onValueChange={(value) => handleFilterChange('propertyType', value, null)}
         >
           <SelectTrigger className="w-32 rounded-xl border-primary-400">
             <SelectValue placeholder="Home Type" />
@@ -243,20 +218,20 @@ const FiltersBar = () => {
           <Button
             variant="ghost"
             className={cn(
-              "px-3 py-1 rounded-none rounded-l-xl hover:bg-primary-600 hover:text-primary-50",
-              viewMode === "list" ? "bg-primary-700 text-primary-50" : ""
+              'px-3 py-1 rounded-none rounded-l-xl hover:bg-primary-600 hover:text-primary-50',
+              viewMode === 'list' ? 'bg-primary-700 text-primary-50' : '',
             )}
-            onClick={() => dispatch(setViewMode("list"))}
+            onClick={() => dispatch(setViewMode('list'))}
           >
             <List className="w-5 h-5" />
           </Button>
           <Button
             variant="ghost"
             className={cn(
-              "px-3 py-1 rounded-none rounded-r-xl hover:bg-primary-600 hover:text-primary-50",
-              viewMode === "grid" ? "bg-primary-700 text-primary-50" : ""
+              'px-3 py-1 rounded-none rounded-r-xl hover:bg-primary-600 hover:text-primary-50',
+              viewMode === 'grid' ? 'bg-primary-700 text-primary-50' : '',
             )}
-            onClick={() => dispatch(setViewMode("grid"))}
+            onClick={() => dispatch(setViewMode('grid'))}
           >
             <Grid className="w-5 h-5" />
           </Button>

--- a/client/src/app/(nondashboard)/search/Listings.tsx
+++ b/client/src/app/(nondashboard)/search/Listings.tsx
@@ -4,38 +4,35 @@ import {
   useGetPropertiesQuery,
   useGetTenantQuery,
   useRemoveFavoritePropertyMutation,
-} from "@/state/api";
-import { useAppSelector } from "@/state/redux";
-import { Property } from "@/types/prismaTypes";
-import Card from "@/components/Card";
-import React from "react";
-import CardCompact from "@/components/CardCompact";
+} from '@/state/api';
+import { setFilters } from '@/state';
+import { useAppDispatch, useAppSelector } from '@/state/redux';
+import { Property } from '@/types/prismaTypes';
+import Card from '@/components/Card';
+import React from 'react';
+import CardCompact from '@/components/CardCompact';
+import Pagination from '@/components/Pagination';
 
 const Listings = () => {
   const { data: authUser } = useGetAuthUserQuery();
-  const { data: tenant } = useGetTenantQuery(
-    authUser?.cognitoInfo?.userId || "",
-    {
-      skip: !authUser?.cognitoInfo?.userId,
-    }
-  );
+  const { data: tenant } = useGetTenantQuery(authUser?.cognitoInfo?.userId || '', {
+    skip: !authUser?.cognitoInfo?.userId,
+  });
   const [addFavorite] = useAddFavoritePropertyMutation();
   const [removeFavorite] = useRemoveFavoritePropertyMutation();
+  const dispatch = useAppDispatch();
   const viewMode = useAppSelector((state) => state.global.viewMode);
   const filters = useAppSelector((state) => state.global.filters);
 
-  const {
-    data: properties,
-    isLoading,
-    isError,
-  } = useGetPropertiesQuery(filters);
+  const { data: propertyData, isLoading, isError } = useGetPropertiesQuery(filters);
+
+  const properties = propertyData?.properties || [];
+  const total = propertyData?.total || 0;
 
   const handleFavoriteToggle = async (propertyId: number) => {
     if (!authUser) return;
 
-    const isFavorite = tenant?.favorites?.some(
-      (fav: Property) => fav.id === propertyId
-    );
+    const isFavorite = tenant?.favorites?.some((fav: Property) => fav.id === propertyId);
 
     if (isFavorite) {
       await removeFavorite({
@@ -51,27 +48,22 @@ const Listings = () => {
   };
 
   if (isLoading) return <>Loading...</>;
-  if (isError || !properties) return <div>Failed to fetch properties</div>;
+  if (isError || !propertyData) return <div>Failed to fetch properties</div>;
 
   return (
     <div className="w-full">
       <h3 className="text-sm px-4 font-bold">
-        {properties.length}{" "}
-        <span className="text-gray-700 font-normal">
-          Places in {filters.location}
-        </span>
+        {total} <span className="text-gray-700 font-normal">Places in {filters.location}</span>
       </h3>
       <div className="flex">
         <div className="p-4 w-full">
-          {properties?.map((property) =>
-            viewMode === "grid" ? (
+          {properties.map((property) =>
+            viewMode === 'grid' ? (
               <Card
                 key={property.id}
                 property={property}
                 isFavorite={
-                  tenant?.favorites?.some(
-                    (fav: Property) => fav.id === property.id
-                  ) || false
+                  tenant?.favorites?.some((fav: Property) => fav.id === property.id) || false
                 }
                 onFavoriteToggle={() => handleFavoriteToggle(property.id)}
                 showFavoriteButton={!!authUser}
@@ -82,18 +74,24 @@ const Listings = () => {
                 key={property.id}
                 property={property}
                 isFavorite={
-                  tenant?.favorites?.some(
-                    (fav: Property) => fav.id === property.id
-                  ) || false
+                  tenant?.favorites?.some((fav: Property) => fav.id === property.id) || false
                 }
                 onFavoriteToggle={() => handleFavoriteToggle(property.id)}
                 showFavoriteButton={!!authUser}
                 propertyLink={`/search/${property.id}`}
               />
-            )
+            ),
           )}
         </div>
       </div>
+      {total > filters.pageSize && (
+        <Pagination
+          page={filters.page}
+          pageSize={filters.pageSize}
+          total={total}
+          onPageChange={(page) => dispatch(setFilters({ page }))}
+        />
+      )}
     </div>
   );
 };

--- a/client/src/app/(nondashboard)/search/Map.tsx
+++ b/client/src/app/(nondashboard)/search/Map.tsx
@@ -1,28 +1,25 @@
-"use client";
-import React, { useEffect, useRef } from "react";
-import mapboxgl from "mapbox-gl";
-import "mapbox-gl/dist/mapbox-gl.css";
-import { useAppSelector } from "@/state/redux";
-import { useGetPropertiesQuery } from "@/state/api";
-import { Property } from "@/types/prismaTypes";
+'use client';
+import React, { useEffect, useRef } from 'react';
+import mapboxgl from 'mapbox-gl';
+import 'mapbox-gl/dist/mapbox-gl.css';
+import { useAppSelector } from '@/state/redux';
+import { useGetPropertiesQuery } from '@/state/api';
+import { Property } from '@/types/prismaTypes';
 
 mapboxgl.accessToken = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN as string;
 
 const Map = () => {
   const mapContainerRef = useRef(null);
   const filters = useAppSelector((state) => state.global.filters);
-  const {
-    data: properties,
-    isLoading,
-    isError,
-  } = useGetPropertiesQuery(filters);
+  const { data: propertyData, isLoading, isError } = useGetPropertiesQuery(filters);
+  const properties = propertyData?.properties || [];
 
   useEffect(() => {
-    if (isLoading || isError || !properties) return;
+    if (isLoading || isError || !propertyData) return;
 
     const map = new mapboxgl.Map({
       container: mapContainerRef.current!,
-      style: "mapbox://styles/majesticglue/cm6u301pq008b01sl7yk1cnvb",
+      style: 'mapbox://styles/majesticglue/cm6u301pq008b01sl7yk1cnvb',
       center: filters.coordinates || [-74.5, 40],
       zoom: 9,
     });
@@ -31,7 +28,7 @@ const Map = () => {
       const marker = createPropertyMarker(property, map);
       const markerElement = marker.getElement();
       const path = markerElement.querySelector("path[fill='#3FB1CE']");
-      if (path) path.setAttribute("fill", "#000000");
+      if (path) path.setAttribute('fill', '#000000');
     });
 
     const resizeMap = () => {
@@ -40,10 +37,10 @@ const Map = () => {
     resizeMap();
 
     return () => map.remove();
-  }, [isLoading, isError, properties, filters.coordinates]);
+  }, [isLoading, isError, propertyData, filters.coordinates]);
 
   if (isLoading) return <>Loading...</>;
-  if (isError || !properties) return <div>Failed to fetch properties</div>;
+  if (isError || !propertyData) return <div>Failed to fetch properties</div>;
 
   return (
     <div className="basis-5/12 grow relative rounded-xl">
@@ -51,8 +48,8 @@ const Map = () => {
         className="map-container rounded-xl"
         ref={mapContainerRef}
         style={{
-          height: "100%",
-          width: "100%",
+          height: '100%',
+          width: '100%',
         }}
       />
     </div>
@@ -61,10 +58,7 @@ const Map = () => {
 
 const createPropertyMarker = (property: Property, map: mapboxgl.Map) => {
   const marker = new mapboxgl.Marker()
-    .setLngLat([
-      property.location.coordinates.longitude,
-      property.location.coordinates.latitude,
-    ])
+    .setLngLat([property.location.coordinates.longitude, property.location.coordinates.latitude])
     .setPopup(
       new mapboxgl.Popup().setHTML(
         `
@@ -78,8 +72,8 @@ const createPropertyMarker = (property: Property, map: mapboxgl.Map) => {
             </p>
           </div>
         </div>
-        `
-      )
+        `,
+      ),
     )
     .addTo(map);
   return marker;

--- a/client/src/components/Pagination.tsx
+++ b/client/src/components/Pagination.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+
+interface PaginationProps {
+  page: number;
+  pageSize: number;
+  total: number;
+  onPageChange: (page: number) => void;
+}
+
+const Pagination: React.FC<PaginationProps> = ({ page, pageSize, total, onPageChange }) => {
+  const totalPages = Math.ceil(total / pageSize);
+
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className="flex items-center justify-center gap-4 py-4">
+      <Button
+        variant="outline"
+        disabled={page <= 1}
+        onClick={() => onPageChange(page - 1)}
+        className="rounded-xl"
+      >
+        Previous
+      </Button>
+      <span>
+        Page {page} of {totalPages}
+      </span>
+      <Button
+        variant="outline"
+        disabled={page >= totalPages}
+        onClick={() => onPageChange(page + 1)}
+        className="rounded-xl"
+      >
+        Next
+      </Button>
+    </div>
+  );
+};
+
+export default Pagination;

--- a/client/src/state/api.ts
+++ b/client/src/state/api.ts
@@ -1,15 +1,8 @@
-import { cleanParams, createNewUserInDatabase, withToast } from "@/lib/utils";
-import {
-  Application,
-  Lease,
-  Manager,
-  Payment,
-  Property,
-  Tenant,
-} from "@/types/prismaTypes";
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
-import { fetchAuthSession, getCurrentUser } from "aws-amplify/auth";
-import { FiltersState } from ".";
+import { cleanParams, createNewUserInDatabase, withToast } from '@/lib/utils';
+import { Application, Lease, Manager, Payment, Property, Tenant } from '@/types/prismaTypes';
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { fetchAuthSession, getCurrentUser } from 'aws-amplify/auth';
+import { FiltersState } from '.';
 
 export const api = createApi({
   baseQuery: fetchBaseQuery({
@@ -18,20 +11,20 @@ export const api = createApi({
       const session = await fetchAuthSession();
       const { idToken } = session.tokens ?? {};
       if (idToken) {
-        headers.set("Authorization", `Bearer ${idToken}`);
+        headers.set('Authorization', `Bearer ${idToken}`);
       }
       return headers;
     },
   }),
-  reducerPath: "api",
+  reducerPath: 'api',
   tagTypes: [
-    "Managers",
-    "Tenants",
-    "Properties",
-    "PropertyDetails",
-    "Leases",
-    "Payments",
-    "Applications",
+    'Managers',
+    'Tenants',
+    'Properties',
+    'PropertyDetails',
+    'Leases',
+    'Payments',
+    'Applications',
   ],
   endpoints: (build) => ({
     getAuthUser: build.query<User, void>({
@@ -40,25 +33,20 @@ export const api = createApi({
           const session = await fetchAuthSession();
           const { idToken } = session.tokens ?? {};
           const user = await getCurrentUser();
-          const userRole = idToken?.payload["custom:role"] as string;
+          const userRole = idToken?.payload['custom:role'] as string;
 
           const endpoint =
-            userRole === "manager"
-              ? `/managers/${user.userId}`
-              : `/tenants/${user.userId}`;
+            userRole === 'manager' ? `/managers/${user.userId}` : `/tenants/${user.userId}`;
 
           let userDetailsResponse = await fetchWithBQ(endpoint);
 
           // if user doesn't exist, create new user
-          if (
-            userDetailsResponse.error &&
-            userDetailsResponse.error.status === 404
-          ) {
+          if (userDetailsResponse.error && userDetailsResponse.error.status === 404) {
             userDetailsResponse = await createNewUserInDatabase(
               user,
               idToken,
               userRole,
-              fetchWithBQ
+              fetchWithBQ,
             );
           }
 
@@ -70,14 +58,14 @@ export const api = createApi({
             },
           };
         } catch (error: any) {
-          return { error: error.message || "Could not fetch user data" };
+          return { error: error.message || 'Could not fetch user data' };
         }
       },
     }),
 
     // property related endpoints
     getProperties: build.query<
-      Property[],
+      { properties: Property[]; total: number },
       Partial<FiltersState> & { favoriteIds?: number[] }
     >({
       query: (filters) => {
@@ -90,35 +78,40 @@ export const api = createApi({
           propertyType: filters.propertyType,
           squareFeetMin: filters.squareFeet?.[0],
           squareFeetMax: filters.squareFeet?.[1],
-          amenities: filters.amenities?.join(","),
+          amenities: filters.amenities?.join(','),
           availableFrom: filters.availableFrom,
-          favoriteIds: filters.favoriteIds?.join(","),
+          favoriteIds: filters.favoriteIds?.join(','),
           latitude: filters.coordinates?.[1],
           longitude: filters.coordinates?.[0],
+          page: filters.page,
+          pageSize: filters.pageSize,
         });
 
-        return { url: "properties", params };
+        return { url: 'properties', params };
       },
       providesTags: (result) =>
         result
           ? [
-              ...result.map(({ id }) => ({ type: "Properties" as const, id })),
-              { type: "Properties", id: "LIST" },
+              ...result.properties.map(({ id }) => ({
+                type: 'Properties' as const,
+                id,
+              })),
+              { type: 'Properties', id: 'LIST' },
             ]
-          : [{ type: "Properties", id: "LIST" }],
+          : [{ type: 'Properties', id: 'LIST' }],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          error: "Failed to fetch properties.",
+          error: 'Failed to fetch properties.',
         });
       },
     }),
 
     getProperty: build.query<Property, number>({
       query: (id) => `properties/${id}`,
-      providesTags: (result, error, id) => [{ type: "PropertyDetails", id }],
+      providesTags: (result, error, id) => [{ type: 'PropertyDetails', id }],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          error: "Failed to load property details.",
+          error: 'Failed to load property details.',
         });
       },
     }),
@@ -126,10 +119,10 @@ export const api = createApi({
     // tenant related endpoints
     getTenant: build.query<Tenant, string>({
       query: (cognitoId) => `tenants/${cognitoId}`,
-      providesTags: (result) => [{ type: "Tenants", id: result?.id }],
+      providesTags: (result) => [{ type: 'Tenants', id: result?.id }],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          error: "Failed to load tenant profile.",
+          error: 'Failed to load tenant profile.',
         });
       },
     }),
@@ -139,71 +132,62 @@ export const api = createApi({
       providesTags: (result) =>
         result
           ? [
-              ...result.map(({ id }) => ({ type: "Properties" as const, id })),
-              { type: "Properties", id: "LIST" },
+              ...result.map(({ id }) => ({ type: 'Properties' as const, id })),
+              { type: 'Properties', id: 'LIST' },
             ]
-          : [{ type: "Properties", id: "LIST" }],
+          : [{ type: 'Properties', id: 'LIST' }],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          error: "Failed to fetch current residences.",
+          error: 'Failed to fetch current residences.',
         });
       },
     }),
 
-    updateTenantSettings: build.mutation<
-      Tenant,
-      { cognitoId: string } & Partial<Tenant>
-    >({
+    updateTenantSettings: build.mutation<Tenant, { cognitoId: string } & Partial<Tenant>>({
       query: ({ cognitoId, ...updatedTenant }) => ({
         url: `tenants/${cognitoId}`,
-        method: "PUT",
+        method: 'PUT',
         body: updatedTenant,
       }),
-      invalidatesTags: (result) => [{ type: "Tenants", id: result?.id }],
+      invalidatesTags: (result) => [{ type: 'Tenants', id: result?.id }],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          success: "Settings updated successfully!",
-          error: "Failed to update settings.",
+          success: 'Settings updated successfully!',
+          error: 'Failed to update settings.',
         });
       },
     }),
 
-    addFavoriteProperty: build.mutation<
-      Tenant,
-      { cognitoId: string; propertyId: number }
-    >({
+    addFavoriteProperty: build.mutation<Tenant, { cognitoId: string; propertyId: number }>({
       query: ({ cognitoId, propertyId }) => ({
         url: `tenants/${cognitoId}/favorites/${propertyId}`,
-        method: "POST",
+        method: 'POST',
       }),
       invalidatesTags: (result) => [
-        { type: "Tenants", id: result?.id },
-        { type: "Properties", id: "LIST" },
+        { type: 'Tenants', id: result?.id },
+        { type: 'Properties', id: 'LIST' },
       ],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          success: "Added to favorites!!",
-          error: "Failed to add to favorites",
+          success: 'Added to favorites!!',
+          error: 'Failed to add to favorites',
         });
       },
     }),
 
-    removeFavoriteProperty: build.mutation<
-      Tenant,
-      { cognitoId: string; propertyId: number }
-    >({
+    removeFavoriteProperty: build.mutation<Tenant, { cognitoId: string; propertyId: number }>({
       query: ({ cognitoId, propertyId }) => ({
         url: `tenants/${cognitoId}/favorites/${propertyId}`,
-        method: "DELETE",
+        method: 'DELETE',
       }),
       invalidatesTags: (result) => [
-        { type: "Tenants", id: result?.id },
-        { type: "Properties", id: "LIST" },
+        { type: 'Tenants', id: result?.id },
+        { type: 'Properties', id: 'LIST' },
       ],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          success: "Removed from favorites!",
-          error: "Failed to remove from favorites.",
+          success: 'Removed from favorites!',
+          error: 'Failed to remove from favorites.',
         });
       },
     }),
@@ -214,31 +198,28 @@ export const api = createApi({
       providesTags: (result) =>
         result
           ? [
-              ...result.map(({ id }) => ({ type: "Properties" as const, id })),
-              { type: "Properties", id: "LIST" },
+              ...result.map(({ id }) => ({ type: 'Properties' as const, id })),
+              { type: 'Properties', id: 'LIST' },
             ]
-          : [{ type: "Properties", id: "LIST" }],
+          : [{ type: 'Properties', id: 'LIST' }],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          error: "Failed to load manager profile.",
+          error: 'Failed to load manager profile.',
         });
       },
     }),
 
-    updateManagerSettings: build.mutation<
-      Manager,
-      { cognitoId: string } & Partial<Manager>
-    >({
+    updateManagerSettings: build.mutation<Manager, { cognitoId: string } & Partial<Manager>>({
       query: ({ cognitoId, ...updatedManager }) => ({
         url: `managers/${cognitoId}`,
-        method: "PUT",
+        method: 'PUT',
         body: updatedManager,
       }),
-      invalidatesTags: (result) => [{ type: "Managers", id: result?.id }],
+      invalidatesTags: (result) => [{ type: 'Managers', id: result?.id }],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          success: "Settings updated successfully!",
-          error: "Failed to update settings.",
+          success: 'Settings updated successfully!',
+          error: 'Failed to update settings.',
         });
       },
     }),
@@ -246,72 +227,69 @@ export const api = createApi({
     createProperty: build.mutation<Property, FormData>({
       query: (newProperty) => ({
         url: `properties`,
-        method: "POST",
+        method: 'POST',
         body: newProperty,
       }),
       invalidatesTags: (result) => [
-        { type: "Properties", id: "LIST" },
-        { type: "Managers", id: result?.manager?.id },
+        { type: 'Properties', id: 'LIST' },
+        { type: 'Managers', id: result?.manager?.id },
       ],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          success: "Property created successfully!",
-          error: "Failed to create property.",
+          success: 'Property created successfully!',
+          error: 'Failed to create property.',
         });
       },
     }),
 
     // lease related enpoints
     getLeases: build.query<Lease[], number>({
-      query: () => "leases",
-      providesTags: ["Leases"],
+      query: () => 'leases',
+      providesTags: ['Leases'],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          error: "Failed to fetch leases.",
+          error: 'Failed to fetch leases.',
         });
       },
     }),
 
     getPropertyLeases: build.query<Lease[], number>({
       query: (propertyId) => `properties/${propertyId}/leases`,
-      providesTags: ["Leases"],
+      providesTags: ['Leases'],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          error: "Failed to fetch property leases.",
+          error: 'Failed to fetch property leases.',
         });
       },
     }),
 
     getPayments: build.query<Payment[], number>({
       query: (leaseId) => `leases/${leaseId}/payments`,
-      providesTags: ["Payments"],
+      providesTags: ['Payments'],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          error: "Failed to fetch payment info.",
+          error: 'Failed to fetch payment info.',
         });
       },
     }),
 
     // application related endpoints
-    getApplications: build.query<
-      Application[],
-      { userId?: string; userType?: string }
-    >({
+    getApplications: build.query<Application[], { userId?: string; userType?: string }>({
       query: (params) => {
         const queryParams = new URLSearchParams();
         if (params.userId) {
-          queryParams.append("userId", params.userId.toString());
+          queryParams.append('userId', params.userId.toString());
         }
         if (params.userType) {
-          queryParams.append("userType", params.userType);
+          queryParams.append('userType', params.userType);
         }
 
         return `applications?${queryParams.toString()}`;
       },
-      providesTags: ["Applications"],
+      providesTags: ['Applications'],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          error: "Failed to fetch applications.",
+          error: 'Failed to fetch applications.',
         });
       },
     }),
@@ -322,14 +300,14 @@ export const api = createApi({
     >({
       query: ({ id, status }) => ({
         url: `applications/${id}/status`,
-        method: "PUT",
+        method: 'PUT',
         body: { status },
       }),
-      invalidatesTags: ["Applications", "Leases"],
+      invalidatesTags: ['Applications', 'Leases'],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          success: "Application status updated successfully!",
-          error: "Failed to update application settings.",
+          success: 'Application status updated successfully!',
+          error: 'Failed to update application settings.',
         });
       },
     }),
@@ -337,14 +315,14 @@ export const api = createApi({
     createApplication: build.mutation<Application, Partial<Application>>({
       query: (body) => ({
         url: `applications`,
-        method: "POST",
+        method: 'POST',
         body: body,
       }),
-      invalidatesTags: ["Applications"],
+      invalidatesTags: ['Applications'],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          success: "Application created successfully!",
-          error: "Failed to create applications.",
+          success: 'Application created successfully!',
+          error: 'Failed to create applications.',
         });
       },
     }),

--- a/client/src/state/index.ts
+++ b/client/src/state/index.ts
@@ -1,4 +1,4 @@
-import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 export interface FiltersState {
   location: string;
@@ -10,32 +10,36 @@ export interface FiltersState {
   priceRange: [number, number] | [null, null];
   squareFeet: [number, number] | [null, null];
   coordinates: [number, number];
+  page: number;
+  pageSize: number;
 }
 
 interface InitialStateTypes {
   filters: FiltersState;
   isFiltersFullOpen: boolean;
-  viewMode: "grid" | "list";
+  viewMode: 'grid' | 'list';
 }
 
 export const initialState: InitialStateTypes = {
   filters: {
-    location: "Los Angeles",
-    beds: "any",
-    baths: "any",
-    propertyType: "any",
+    location: 'Los Angeles',
+    beds: 'any',
+    baths: 'any',
+    propertyType: 'any',
     amenities: [],
-    availableFrom: "any",
+    availableFrom: 'any',
     priceRange: [null, null],
     squareFeet: [null, null],
     coordinates: [-118.25, 34.05],
+    page: 1,
+    pageSize: 10,
   },
   isFiltersFullOpen: false,
-  viewMode: "grid",
+  viewMode: 'grid',
 };
 
 export const globalSlice = createSlice({
-  name: "global",
+  name: 'global',
   initialState,
   reducers: {
     setFilters: (state, action: PayloadAction<Partial<FiltersState>>) => {
@@ -44,13 +48,12 @@ export const globalSlice = createSlice({
     toggleFiltersFullOpen: (state) => {
       state.isFiltersFullOpen = !state.isFiltersFullOpen;
     },
-    setViewMode: (state, action: PayloadAction<"grid" | "list">) => {
+    setViewMode: (state, action: PayloadAction<'grid' | 'list'>) => {
       state.viewMode = action.payload;
     },
   },
 });
 
-export const { setFilters, toggleFiltersFullOpen, setViewMode } =
-  globalSlice.actions;
+export const { setFilters, toggleFiltersFullOpen, setViewMode } = globalSlice.actions;
 
 export default globalSlice.reducer;

--- a/server/src/controllers/propertyControllers.ts
+++ b/server/src/controllers/propertyControllers.ts
@@ -1,11 +1,11 @@
-import { Request, Response, NextFunction } from "express";
-import { Prisma, Location } from "@prisma/client";
-import { buildPropertyFilters } from "../utils/buildPropertyFilters";
-import { formatLocation } from "../utils/formatLocation";
-import { uploadFilesToS3 } from "../utils/s3Upload";
-import { geocodeAddress } from "../utils/geocodeAddress";
-import { z } from "zod";
-import prisma from "../utils/prisma";
+import { Request, Response, NextFunction } from 'express';
+import { Prisma, Location } from '@prisma/client';
+import { buildPropertyFilters } from '../utils/buildPropertyFilters';
+import { formatLocation } from '../utils/formatLocation';
+import { uploadFilesToS3 } from '../utils/s3Upload';
+import { geocodeAddress } from '../utils/geocodeAddress';
+import { z } from 'zod';
+import prisma from '../utils/prisma';
 
 const createPropertySchema = z.object({
   address: z.string(),
@@ -31,7 +31,7 @@ const createPropertySchema = z.object({
 export const getProperties = async (
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ): Promise<void> => {
   try {
     const {
@@ -48,6 +48,8 @@ export const getProperties = async (
       latitude,
       longitude,
       q,
+      page,
+      pageSize,
     } = req.query;
 
     let locationIds: number[] | undefined;
@@ -82,10 +84,20 @@ export const getProperties = async (
       q: q as string | undefined,
     });
 
-    const properties = await prisma.property.findMany({
-      where: filters,
-      include: { location: true },
-    });
+    const pageNumber = page ? parseInt(page as string, 10) : 1;
+    const pageSizeNumber = pageSize ? parseInt(pageSize as string, 10) : 10;
+    const skip = (pageNumber - 1) * pageSizeNumber;
+    const take = pageSizeNumber;
+
+    const [total, properties] = await prisma.$transaction([
+      prisma.property.count({ where: filters }),
+      prisma.property.findMany({
+        where: filters,
+        include: { location: true },
+        skip,
+        take,
+      }),
+    ]);
 
     const locIds = properties.map((p) => p.locationId);
     let coordsMap = new Map<number, { longitude: number; latitude: number }>();
@@ -105,7 +117,7 @@ export const getProperties = async (
         coordsResults.map((c) => [
           c.id,
           { longitude: Number(c.longitude), latitude: Number(c.latitude) },
-        ])
+        ]),
       );
     }
 
@@ -116,7 +128,7 @@ export const getProperties = async (
         coordinates: coordsMap.get(p.locationId),
       },
     }));
-    res.json(propertiesWithCoordinates);
+    res.json({ properties: propertiesWithCoordinates, total });
   } catch (err) {
     next(err);
   }
@@ -125,7 +137,7 @@ export const getProperties = async (
 export const getProperty = async (
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ): Promise<void> => {
   try {
     const { id } = req.params;
@@ -137,9 +149,7 @@ export const getProperty = async (
     });
 
     if (property) {
-      const { longitude, latitude } = await formatLocation(
-        property.location.id
-      );
+      const { longitude, latitude } = await formatLocation(property.location.id);
 
       const propertyWithCoordinates = {
         ...property,
@@ -153,7 +163,7 @@ export const getProperty = async (
       };
       res.json(propertyWithCoordinates);
     } else {
-      res.status(404).json({ message: "Property not found" });
+      res.status(404).json({ message: 'Property not found' });
     }
   } catch (err) {
     next(err);
@@ -163,7 +173,7 @@ export const getProperty = async (
 export const createProperty = async (
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ): Promise<void> => {
   try {
     const files = req.files as Express.Multer.File[];
@@ -176,27 +186,15 @@ export const createProperty = async (
 
     const managerCognitoId = req.user?.id;
     if (!managerCognitoId) {
-      res.status(401).json({ message: "Unauthorized" });
+      res.status(401).json({ message: 'Unauthorized' });
       return;
     }
 
-    const {
-      address,
-      city,
-      state,
-      country,
-      postalCode,
-      ...propertyData
-    } = parsed.data;
+    const { address, city, state, country, postalCode, ...propertyData } = parsed.data;
 
     const photoUrls = await uploadFilesToS3(files);
 
-    const [longitude, latitude] = await geocodeAddress(
-      address,
-      city,
-      country,
-      postalCode,
-    );
+    const [longitude, latitude] = await geocodeAddress(address, city, country, postalCode);
 
     const newProperty = await prisma.$transaction(async (tx) => {
       const [location] = await tx.$queryRaw<Location[]>`
@@ -213,15 +211,11 @@ export const createProperty = async (
           locationId: location.id,
           managerCognitoId,
           amenities:
-            typeof propertyData.amenities === "string"
-              ? propertyData.amenities.split(",")
-              : [],
+            typeof propertyData.amenities === 'string' ? propertyData.amenities.split(',') : [],
           highlights:
-            typeof propertyData.highlights === "string"
-              ? propertyData.highlights.split(",")
-              : [],
-          isPetsAllowed: propertyData.isPetsAllowed === "true",
-          isParkingIncluded: propertyData.isParkingIncluded === "true",
+            typeof propertyData.highlights === 'string' ? propertyData.highlights.split(',') : [],
+          isPetsAllowed: propertyData.isPetsAllowed === 'true',
+          isParkingIncluded: propertyData.isParkingIncluded === 'true',
           pricePerMonth: propertyData.pricePerMonth,
           securityDeposit: propertyData.securityDeposit,
           applicationFee: propertyData.applicationFee,


### PR DESCRIPTION
## Summary
- paginate property queries by page and pageSize, returning a total count
- wire page and pageSize through client state and API
- add UI pagination controls for property listings

## Testing
- `cd server && npm test` (fails: SyntaxError: Declaration or statement expected)
- `cd client && npm test` (warnings: Code style issues found)


------
https://chatgpt.com/codex/tasks/task_e_689b8c1471348328b9027a9aad827c7c