### PR TITLE
chore: use unified API URL env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,6 @@ AWS_REGION=us-east-1
 S3_BUCKET_NAME=your-s3-bucket
 AWS_ACCESS_KEY_ID=your-access-key
 AWS_SECRET_ACCESS_KEY=your-secret-key
+
+# Client configuration
+NEXT_PUBLIC_API_URL=http://localhost:3001

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -113,12 +113,12 @@ Add this CORS configuration to your bucket:
 
 ```json
 [
-    {
-        "AllowedHeaders": ["*"],
-        "AllowedMethods": ["GET", "POST", "PUT", "DELETE"],
-        "AllowedOrigins": ["*"],
-        "ExposeHeaders": []
-    }
+  {
+    "AllowedHeaders": ["*"],
+    "AllowedMethods": ["GET", "POST", "PUT", "DELETE"],
+    "AllowedOrigins": ["*"],
+    "ExposeHeaders": []
+  }
 ]
 ```
 
@@ -175,22 +175,26 @@ npm install -g pm2
 ### 4.4 Deploy Backend Code
 
 1. Clone your repository:
+
    ```bash
    git clone <your-repo-url>
    cd real-estate-prod-master/server
    ```
 
 2. Install dependencies:
+
    ```bash
    npm install
    ```
 
 3. Create environment file:
+
    ```bash
    nano .env
    ```
 
 4. Add environment variables:
+
    ```env
    DATABASE_URL="postgresql://username:password@your-rds-endpoint:5432/rentiful"
    PORT=3002
@@ -201,6 +205,7 @@ npm install -g pm2
    ```
 
 5. Set up database:
+
    ```bash
    npx prisma generate
    npx prisma db push
@@ -223,7 +228,7 @@ npm install -g pm2
 3. Import your repository
 4. Configure environment variables:
    ```
-   NEXT_PUBLIC_API_BASE_URL=https://your-ec2-ip:3002
+   NEXT_PUBLIC_API_URL=https://your-ec2-ip:3002
    NEXT_PUBLIC_AWS_COGNITO_USER_POOL_ID=your_user_pool_id
    NEXT_PUBLIC_AWS_COGNITO_USER_POOL_CLIENT_ID=your_client_id
    NEXT_PUBLIC_MAPBOX_TOKEN=your_mapbox_token
@@ -385,6 +390,7 @@ df -h
 ## 📞 Support
 
 For issues and questions:
+
 - Check AWS documentation
 - Review application logs
 - Monitor CloudWatch metrics
@@ -392,4 +398,4 @@ For issues and questions:
 
 ---
 
-**Note**: This deployment guide assumes a production-ready setup. For development, you can use simpler configurations and free tier services. 
+**Note**: This deployment guide assumes a production-ready setup. For development, you can use simpler configurations and free tier services.

--- a/README.md
+++ b/README.md
@@ -1,43 +1,54 @@
 # Enterprise Garage Sale App
 
 ## Overview
+
 This repository contains an enterprise-grade real estate marketplace that lets users list and browse properties. It is split into a **Next.js** client for the user interface and an **Express** API backed by **PostgreSQL** via **Prisma**.
 
 ## Tech Stack
+
 - **Client:** Next.js (React + TypeScript) styled with Tailwind CSS
 - **Server:** Node.js, Express, and Prisma ORM (TypeScript)
 - **Database:** PostgreSQL
 - **Storage & Auth:** AWS S3 for media, JWT tokens via AWS Cognito
 
 ## Architecture
+
 Users interact with the Next.js client, which makes REST calls to the Express server. The server applies business logic, reads and writes data through Prisma, and stores media assets in S3. See [System Architecture](docs/SYSTEM_ARCHITECTURE.md) for more details.
 
 ## Quick Start
+
 ### Prerequisites
+
 - Node.js 18+
 - npm
 - PostgreSQL
 - Required environment variables (see [Setup Guide](SETUP_GUIDE.md))
 
 ### Client
+
 ```bash
 cd client
 npm install
 npm run dev
 ```
+
 Open <http://localhost:3000> in your browser.
 
 The client reads the API URL from the `NEXT_PUBLIC_API_URL` environment variable. If not set, it defaults to `http://localhost:3001`.
+Set this variable in `.env.local` or your deployment environment.
 
 ### Server
+
 ```bash
 cd server
 npm install
 npm run dev
 ```
+
 The API will run on <http://localhost:3001> by default.
 
 ### Required Environment Variables
+
 The server requires the following environment variables. Copy `.env.example` and adjust values as needed.
 
 - `PORT` – Port for the Express API.
@@ -52,6 +63,7 @@ The server requires the following environment variables. Copy `.env.example` and
 - `AWS_SECRET_ACCESS_KEY` – AWS secret key.
 
 ## Testing
+
 - **Client:**
   ```bash
   cd client
@@ -63,12 +75,13 @@ The server requires the following environment variables. Copy `.env.example` and
   cd server
   npm test
   ```
-For detailed testing strategies, see [TESTING.md](TESTING.md).
+  For detailed testing strategies, see [TESTING.md](TESTING.md).
 
 ## Deployment Notes
+
 The application is designed for AWS deployment using services such as Cognito for authentication and S3 for asset storage. Refer to [DEPLOYMENT.md](DEPLOYMENT.md) for step-by-step production guidance.
 
 ## Further Reading
+
 - [API Documentation](API_DOCUMENTATION.md)
 - [Setup Guide](SETUP_GUIDE.md)
-

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -3,6 +3,7 @@
 This guide provides step-by-step instructions to set up and test the real estate application locally and on AWS.
 
 ## Table of Contents
+
 1. [Prerequisites](#prerequisites)
 2. [Local Development Setup](#local-development-setup)
 3. [AWS Services Setup](#aws-services-setup)
@@ -15,6 +16,7 @@ This guide provides step-by-step instructions to set up and test the real estate
 ## Prerequisites
 
 ### Required Software
+
 - **Node.js** (v18 or higher)
 - **npm** or **yarn**
 - **Git**
@@ -22,6 +24,7 @@ This guide provides step-by-step instructions to set up and test the real estate
 - **AWS CLI** (for AWS deployment)
 
 ### AWS Account Requirements
+
 - AWS Account with appropriate permissions
 - Access to AWS Console
 - AWS CLI configured with credentials
@@ -69,8 +72,9 @@ CREATE EXTENSION IF NOT EXISTS postgis;
 Create the following environment files:
 
 **`client/.env.local`:**
+
 ```env
-NEXT_PUBLIC_API_URL=http://localhost:3001
+NEXT_PUBLIC_API_URL=http://localhost:3001 # base URL for the API
 NEXT_PUBLIC_AWS_REGION=us-east-1
 NEXT_PUBLIC_USER_POOLS_WEB_CLIENT_ID=your_cognito_client_id
 NEXT_PUBLIC_USER_POOL_ID=your_cognito_user_pool_id
@@ -79,6 +83,7 @@ NEXT_PUBLIC_MAPBOX_TOKEN=your_mapbox_token
 ```
 
 **`server/.env`:**
+
 ```env
 # Database
 DATABASE_URL="postgresql://postgres:password@localhost:5432/real_estate_dev"
@@ -147,11 +152,7 @@ GEOCODE_USER_AGENT=your_app_name (contact@example.com)
        "Statement": [
          {
            "Effect": "Allow",
-           "Action": [
-             "s3:GetObject",
-             "s3:PutObject",
-             "s3:DeleteObject"
-           ],
+           "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
            "Resource": "arn:aws:s3:::your-s3-bucket-name/*"
          }
        ]
@@ -208,13 +209,14 @@ GEOCODE_USER_AGENT=your_app_name (contact@example.com)
    - Create database
 
 2. **Install PostGIS Extension:**
+
    ```sql
    -- Connect to your RDS instance
    psql -h your-rds-endpoint -U postgres -d postgres
-   
+
    -- Create PostGIS extension
    CREATE EXTENSION IF NOT EXISTS postgis;
-   
+
    -- Verify installation
    SELECT PostGIS_Version();
    ```
@@ -224,8 +226,9 @@ GEOCODE_USER_AGENT=your_app_name (contact@example.com)
 After setting up AWS services, update your environment files with the actual values:
 
 **`client/.env.local`:**
+
 ```env
-NEXT_PUBLIC_API_URL=http://localhost:3001
+NEXT_PUBLIC_API_URL=http://localhost:3001 # base URL for the API
 NEXT_PUBLIC_AWS_REGION=us-east-1
 NEXT_PUBLIC_USER_POOLS_WEB_CLIENT_ID=your_actual_client_id
 NEXT_PUBLIC_USER_POOL_ID=your_actual_user_pool_id
@@ -234,6 +237,7 @@ NEXT_PUBLIC_MAPBOX_TOKEN=your_mapbox_token
 ```
 
 **`server/.env`:**
+
 ```env
 # Database (use RDS endpoint for production)
 DATABASE_URL="postgresql://postgres:your_password@your-rds-endpoint:5432/postgres"
@@ -374,6 +378,7 @@ npm run test:e2e:ui
 ### Step 4: Manual Testing Checklist
 
 #### Authentication Testing
+
 - [ ] User registration with email verification
 - [ ] User login with email/password
 - [ ] Password reset functionality
@@ -381,6 +386,7 @@ npm run test:e2e:ui
 - [ ] Role-based access (tenant vs manager)
 
 #### Property Management Testing
+
 - [ ] View property listings
 - [ ] Search and filter properties
 - [ ] View property details
@@ -388,18 +394,21 @@ npm run test:e2e:ui
 - [ ] Create/edit properties (managers)
 
 #### Application Management Testing
+
 - [ ] Submit rental applications
 - [ ] View application status
 - [ ] Process applications (managers)
 - [ ] Accept/reject applications
 
 #### Payment System Testing
+
 - [ ] View payment history
 - [ ] Track upcoming payments
 - [ ] Mark payments as paid
 - [ ] Generate payment reports
 
 #### Analytics Testing
+
 - [ ] View manager dashboard
 - [ ] Check revenue analytics
 - [ ] View occupancy rates
@@ -423,6 +432,7 @@ curl -w "@curl-format.txt" -o /dev/null -s "http://localhost:3001/api/properties
 ### Common Issues and Solutions
 
 #### 1. Database Connection Issues
+
 ```bash
 # Check if PostgreSQL is running
 # Windows: Check Services
@@ -434,6 +444,7 @@ psql -h localhost -U postgres -d real_estate_dev
 ```
 
 #### 2. AWS Credentials Issues
+
 ```bash
 # Configure AWS CLI
 aws configure
@@ -443,21 +454,25 @@ aws sts get-caller-identity
 ```
 
 #### 3. CORS Issues
+
 - Ensure your server CORS configuration includes `http://localhost:3000`
 - Check browser console for CORS errors
 - Verify API endpoints are accessible
 
 #### 4. Authentication Issues
+
 - Verify Cognito configuration in environment variables
 - Check browser console for authentication errors
 - Ensure user pool and identity pool are properly configured
 
 #### 5. S3 Upload Issues
+
 - Verify S3 bucket permissions
 - Check CORS configuration
 - Ensure AWS credentials have S3 access
 
 #### 6. Environment Variable Issues
+
 ```bash
 # Check environment variables are loaded
 # Frontend
@@ -470,12 +485,14 @@ echo $DATABASE_URL
 ### Debug Mode
 
 #### Frontend Debug
+
 ```bash
 # Start with debug logging
 NODE_ENV=development DEBUG=* npm run dev
 ```
 
 #### Backend Debug
+
 ```bash
 # Start with debug logging
 DEBUG=* npm run dev
@@ -484,6 +501,7 @@ DEBUG=* npm run dev
 ### Logs and Monitoring
 
 #### Check Application Logs
+
 ```bash
 # Frontend logs (browser console)
 # Backend logs (terminal where server is running)
@@ -491,6 +509,7 @@ DEBUG=* npm run dev
 ```
 
 #### Monitor Performance
+
 ```bash
 # Check memory usage
 top -p $(pgrep node)
@@ -505,6 +524,7 @@ netstat -an | grep :3001
 ## Next Steps
 
 ### Production Deployment
+
 1. Set up production AWS services
 2. Configure domain and SSL certificates
 3. Set up CI/CD pipeline
@@ -512,6 +532,7 @@ netstat -an | grep :3001
 5. Set up backup and disaster recovery
 
 ### Scaling Considerations
+
 1. Implement caching (Redis)
 2. Set up CDN for static assets
 3. Configure auto-scaling groups
@@ -519,6 +540,7 @@ netstat -an | grep :3001
 5. Set up load balancing
 
 ### Security Hardening
+
 1. Implement rate limiting
 2. Set up WAF (Web Application Firewall)
 3. Configure security groups properly
@@ -536,7 +558,8 @@ If you encounter issues during setup or testing:
 5. Test each component individually
 
 For additional help, refer to:
+
 - [API Documentation](API_DOCUMENTATION.md)
 - [Deployment Guide](DEPLOYMENT.md)
 - [Testing Guide](TESTING.md)
-- [README](README.md) 
+- [README](README.md)

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -1,27 +1,27 @@
-import axios from "axios";
-import { Property } from "@/types/prismaTypes";
+import axios from 'axios';
+import { Property } from '@/types/prismaTypes';
 
 const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001",
+  baseURL: process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001',
 });
 
 export const fetchListings = async (search?: string): Promise<Property[]> => {
-  const response = await api.get("/properties", { params: { q: search } });
+  const response = await api.get('/properties', { params: { q: search } });
   return response.data as Property[];
 };
 
 export const createListing = async (data: any) => {
   const formData = new FormData();
   Object.entries(data).forEach(([key, value]) => {
-    if (key === "photos" && Array.isArray(value)) {
-      value.forEach((file) => formData.append("photos", file as any));
+    if (key === 'photos' && Array.isArray(value)) {
+      value.forEach((file) => formData.append('photos', file as any));
     } else {
       formData.append(key, String(value));
     }
   });
 
-  const response = await api.post("/properties", formData, {
-    headers: { "Content-Type": "multipart/form-data" },
+  const response = await api.post('/properties', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
   });
   return response.data;
 };

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,27 +1,27 @@
-import axios from "axios";
-import { Property } from "@/types/prisma-types";
+import axios from 'axios';
+import { Property } from '@/types/prisma-types';
 
 const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001",
+  baseURL: process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001',
 });
 
 export const fetchListings = async (search?: string): Promise<Property[]> => {
-  const response = await api.get("/properties", { params: { q: search } });
+  const response = await api.get('/properties', { params: { q: search } });
   return response.data as Property[];
 };
 
 export const createListing = async (data: any) => {
   const formData = new FormData();
   Object.entries(data).forEach(([key, value]) => {
-    if (key === "photos" && Array.isArray(value)) {
-      value.forEach((file) => formData.append("photos", file as any));
+    if (key === 'photos' && Array.isArray(value)) {
+      value.forEach((file) => formData.append('photos', file as any));
     } else {
       formData.append(key, String(value));
     }
   });
 
-  const response = await api.post("/properties", formData, {
-    headers: { "Content-Type": "multipart/form-data" },
+  const response = await api.post('/properties', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
   });
   return response.data;
 };

--- a/client/src/state/api.ts
+++ b/client/src/state/api.ts
@@ -1,37 +1,30 @@
-import { cleanParams, createNewUserInDatabase, withToast } from "@/lib/utils";
-import {
-  Application,
-  Lease,
-  Manager,
-  Payment,
-  Property,
-  Tenant,
-} from "@/types/prisma-types";
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
-import { fetchAuthSession, getCurrentUser } from "aws-amplify/auth";
-import { FiltersState } from ".";
+import { cleanParams, createNewUserInDatabase, withToast } from '@/lib/utils';
+import { Application, Lease, Manager, Payment, Property, Tenant } from '@/types/prisma-types';
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { fetchAuthSession, getCurrentUser } from 'aws-amplify/auth';
+import { FiltersState } from '.';
 
 export const api = createApi({
   baseQuery: fetchBaseQuery({
-    baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL,
+    baseUrl: process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001',
     prepareHeaders: async (headers) => {
       const session = await fetchAuthSession();
       const { idToken } = session.tokens ?? {};
       if (idToken) {
-        headers.set("Authorization", `Bearer ${idToken}`);
+        headers.set('Authorization', `Bearer ${idToken}`);
       }
       return headers;
     },
   }),
-  reducerPath: "api",
+  reducerPath: 'api',
   tagTypes: [
-    "Managers",
-    "Tenants",
-    "Properties",
-    "PropertyDetails",
-    "Leases",
-    "Payments",
-    "Applications",
+    'Managers',
+    'Tenants',
+    'Properties',
+    'PropertyDetails',
+    'Leases',
+    'Payments',
+    'Applications',
   ],
   endpoints: (build) => ({
     getAuthUser: build.query<User, void>({
@@ -40,25 +33,20 @@ export const api = createApi({
           const session = await fetchAuthSession();
           const { idToken } = session.tokens ?? {};
           const user = await getCurrentUser();
-          const userRole = idToken?.payload["custom:role"] as string;
+          const userRole = idToken?.payload['custom:role'] as string;
 
           const endpoint =
-            userRole === "manager"
-              ? `/managers/${user.userId}`
-              : `/tenants/${user.userId}`;
+            userRole === 'manager' ? `/managers/${user.userId}` : `/tenants/${user.userId}`;
 
           let userDetailsResponse = await fetchWithBQ(endpoint);
 
           // if user doesn't exist, create new user
-          if (
-            userDetailsResponse.error &&
-            userDetailsResponse.error.status === 404
-          ) {
+          if (userDetailsResponse.error && userDetailsResponse.error.status === 404) {
             userDetailsResponse = await createNewUserInDatabase(
               user,
               idToken,
               userRole,
-              fetchWithBQ
+              fetchWithBQ,
             );
           }
 
@@ -70,16 +58,13 @@ export const api = createApi({
             },
           };
         } catch (error: any) {
-          return { error: error.message || "Could not fetch user data" };
+          return { error: error.message || 'Could not fetch user data' };
         }
       },
     }),
 
     // property related endpoints
-    getProperties: build.query<
-      Property[],
-      Partial<FiltersState> & { favoriteIds?: number[] }
-    >({
+    getProperties: build.query<Property[], Partial<FiltersState> & { favoriteIds?: number[] }>({
       query: (filters) => {
         const params = cleanParams({
           location: filters.location,
@@ -90,35 +75,35 @@ export const api = createApi({
           propertyType: filters.propertyType,
           squareFeetMin: filters.squareFeet?.[0],
           squareFeetMax: filters.squareFeet?.[1],
-          amenities: filters.amenities?.join(","),
+          amenities: filters.amenities?.join(','),
           availableFrom: filters.availableFrom,
-          favoriteIds: filters.favoriteIds?.join(","),
+          favoriteIds: filters.favoriteIds?.join(','),
           latitude: filters.coordinates?.[1],
           longitude: filters.coordinates?.[0],
         });
 
-        return { url: "properties", params };
+        return { url: 'properties', params };
       },
       providesTags: (result) =>
         result
           ? [
-              ...result.map(({ id }) => ({ type: "Properties" as const, id })),
-              { type: "Properties", id: "LIST" },
+              ...result.map(({ id }) => ({ type: 'Properties' as const, id })),
+              { type: 'Properties', id: 'LIST' },
             ]
-          : [{ type: "Properties", id: "LIST" }],
+          : [{ type: 'Properties', id: 'LIST' }],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          error: "Failed to fetch properties.",
+          error: 'Failed to fetch properties.',
         });
       },
     }),
 
     getProperty: build.query<Property, number>({
       query: (id) => `properties/${id}`,
-      providesTags: (result, error, id) => [{ type: "PropertyDetails", id }],
+      providesTags: (result, error, id) => [{ type: 'PropertyDetails', id }],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          error: "Failed to load property details.",
+          error: 'Failed to load property details.',
         });
       },
     }),
@@ -126,10 +111,10 @@ export const api = createApi({
     // tenant related endpoints
     getTenant: build.query<Tenant, string>({
       query: (cognitoId) => `tenants/${cognitoId}`,
-      providesTags: (result) => [{ type: "Tenants", id: result?.id }],
+      providesTags: (result) => [{ type: 'Tenants', id: result?.id }],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          error: "Failed to load tenant profile.",
+          error: 'Failed to load tenant profile.',
         });
       },
     }),
@@ -139,71 +124,62 @@ export const api = createApi({
       providesTags: (result) =>
         result
           ? [
-              ...result.map(({ id }) => ({ type: "Properties" as const, id })),
-              { type: "Properties", id: "LIST" },
+              ...result.map(({ id }) => ({ type: 'Properties' as const, id })),
+              { type: 'Properties', id: 'LIST' },
             ]
-          : [{ type: "Properties", id: "LIST" }],
+          : [{ type: 'Properties', id: 'LIST' }],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          error: "Failed to fetch current residences.",
+          error: 'Failed to fetch current residences.',
         });
       },
     }),
 
-    updateTenantSettings: build.mutation<
-      Tenant,
-      { cognitoId: string } & Partial<Tenant>
-    >({
+    updateTenantSettings: build.mutation<Tenant, { cognitoId: string } & Partial<Tenant>>({
       query: ({ cognitoId, ...updatedTenant }) => ({
         url: `tenants/${cognitoId}`,
-        method: "PUT",
+        method: 'PUT',
         body: updatedTenant,
       }),
-      invalidatesTags: (result) => [{ type: "Tenants", id: result?.id }],
+      invalidatesTags: (result) => [{ type: 'Tenants', id: result?.id }],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          success: "Settings updated successfully!",
-          error: "Failed to update settings.",
+          success: 'Settings updated successfully!',
+          error: 'Failed to update settings.',
         });
       },
     }),
 
-    addFavoriteProperty: build.mutation<
-      Tenant,
-      { cognitoId: string; propertyId: number }
-    >({
+    addFavoriteProperty: build.mutation<Tenant, { cognitoId: string; propertyId: number }>({
       query: ({ cognitoId, propertyId }) => ({
         url: `tenants/${cognitoId}/favorites/${propertyId}`,
-        method: "POST",
+        method: 'POST',
       }),
       invalidatesTags: (result) => [
-        { type: "Tenants", id: result?.id },
-        { type: "Properties", id: "LIST" },
+        { type: 'Tenants', id: result?.id },
+        { type: 'Properties', id: 'LIST' },
       ],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          success: "Added to favorites!!",
-          error: "Failed to add to favorites",
+          success: 'Added to favorites!!',
+          error: 'Failed to add to favorites',
         });
       },
     }),
 
-    removeFavoriteProperty: build.mutation<
-      Tenant,
-      { cognitoId: string; propertyId: number }
-    >({
+    removeFavoriteProperty: build.mutation<Tenant, { cognitoId: string; propertyId: number }>({
       query: ({ cognitoId, propertyId }) => ({
         url: `tenants/${cognitoId}/favorites/${propertyId}`,
-        method: "DELETE",
+        method: 'DELETE',
       }),
       invalidatesTags: (result) => [
-        { type: "Tenants", id: result?.id },
-        { type: "Properties", id: "LIST" },
+        { type: 'Tenants', id: result?.id },
+        { type: 'Properties', id: 'LIST' },
       ],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          success: "Removed from favorites!",
-          error: "Failed to remove from favorites.",
+          success: 'Removed from favorites!',
+          error: 'Failed to remove from favorites.',
         });
       },
     }),
@@ -214,31 +190,28 @@ export const api = createApi({
       providesTags: (result) =>
         result
           ? [
-              ...result.map(({ id }) => ({ type: "Properties" as const, id })),
-              { type: "Properties", id: "LIST" },
+              ...result.map(({ id }) => ({ type: 'Properties' as const, id })),
+              { type: 'Properties', id: 'LIST' },
             ]
-          : [{ type: "Properties", id: "LIST" }],
+          : [{ type: 'Properties', id: 'LIST' }],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          error: "Failed to load manager profile.",
+          error: 'Failed to load manager profile.',
         });
       },
     }),
 
-    updateManagerSettings: build.mutation<
-      Manager,
-      { cognitoId: string } & Partial<Manager>
-    >({
+    updateManagerSettings: build.mutation<Manager, { cognitoId: string } & Partial<Manager>>({
       query: ({ cognitoId, ...updatedManager }) => ({
         url: `managers/${cognitoId}`,
-        method: "PUT",
+        method: 'PUT',
         body: updatedManager,
       }),
-      invalidatesTags: (result) => [{ type: "Managers", id: result?.id }],
+      invalidatesTags: (result) => [{ type: 'Managers', id: result?.id }],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          success: "Settings updated successfully!",
-          error: "Failed to update settings.",
+          success: 'Settings updated successfully!',
+          error: 'Failed to update settings.',
         });
       },
     }),
@@ -246,72 +219,69 @@ export const api = createApi({
     createProperty: build.mutation<Property, FormData>({
       query: (newProperty) => ({
         url: `properties`,
-        method: "POST",
+        method: 'POST',
         body: newProperty,
       }),
       invalidatesTags: (result) => [
-        { type: "Properties", id: "LIST" },
-        { type: "Managers", id: result?.manager?.id },
+        { type: 'Properties', id: 'LIST' },
+        { type: 'Managers', id: result?.manager?.id },
       ],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          success: "Property created successfully!",
-          error: "Failed to create property.",
+          success: 'Property created successfully!',
+          error: 'Failed to create property.',
         });
       },
     }),
 
     // lease related enpoints
     getLeases: build.query<Lease[], number>({
-      query: () => "leases",
-      providesTags: ["Leases"],
+      query: () => 'leases',
+      providesTags: ['Leases'],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          error: "Failed to fetch leases.",
+          error: 'Failed to fetch leases.',
         });
       },
     }),
 
     getPropertyLeases: build.query<Lease[], number>({
       query: (propertyId) => `properties/${propertyId}/leases`,
-      providesTags: ["Leases"],
+      providesTags: ['Leases'],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          error: "Failed to fetch property leases.",
+          error: 'Failed to fetch property leases.',
         });
       },
     }),
 
     getPayments: build.query<Payment[], number>({
       query: (leaseId) => `leases/${leaseId}/payments`,
-      providesTags: ["Payments"],
+      providesTags: ['Payments'],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          error: "Failed to fetch payment info.",
+          error: 'Failed to fetch payment info.',
         });
       },
     }),
 
     // application related endpoints
-    getApplications: build.query<
-      Application[],
-      { userId?: string; userType?: string }
-    >({
+    getApplications: build.query<Application[], { userId?: string; userType?: string }>({
       query: (params) => {
         const queryParams = new URLSearchParams();
         if (params.userId) {
-          queryParams.append("userId", params.userId.toString());
+          queryParams.append('userId', params.userId.toString());
         }
         if (params.userType) {
-          queryParams.append("userType", params.userType);
+          queryParams.append('userType', params.userType);
         }
 
         return `applications?${queryParams.toString()}`;
       },
-      providesTags: ["Applications"],
+      providesTags: ['Applications'],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          error: "Failed to fetch applications.",
+          error: 'Failed to fetch applications.',
         });
       },
     }),
@@ -322,14 +292,14 @@ export const api = createApi({
     >({
       query: ({ id, status }) => ({
         url: `applications/${id}/status`,
-        method: "PUT",
+        method: 'PUT',
         body: { status },
       }),
-      invalidatesTags: ["Applications", "Leases"],
+      invalidatesTags: ['Applications', 'Leases'],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          success: "Application status updated successfully!",
-          error: "Failed to update application settings.",
+          success: 'Application status updated successfully!',
+          error: 'Failed to update application settings.',
         });
       },
     }),
@@ -337,14 +307,14 @@ export const api = createApi({
     createApplication: build.mutation<Application, Partial<Application>>({
       query: (body) => ({
         url: `applications`,
-        method: "POST",
+        method: 'POST',
         body: body,
       }),
-      invalidatesTags: ["Applications"],
+      invalidatesTags: ['Applications'],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          success: "Application created successfully!",
-          error: "Failed to create applications.",
+          success: 'Application created successfully!',
+          error: 'Failed to create applications.',
         });
       },
     }),

--- a/client/state/api.ts
+++ b/client/state/api.ts
@@ -1,10 +1,10 @@
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
 export const api = createApi({
   baseQuery: fetchBaseQuery({
-    baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL,
+    baseUrl: process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001',
   }),
-  reducerPath: "api",
+  reducerPath: 'api',
   tagTypes: [],
   endpoints: (build) => ({}),
 });


### PR DESCRIPTION
## Summary
- standardize client API env var to NEXT_PUBLIC_API_URL
- document the variable across setup and deployment guides
- add example NEXT_PUBLIC_API_URL entry to `.env.example`

## Testing
- `npm test` (client) *(fails: Code style issues found in 110 files)*
- `npm test` (server) *(fails: Code style issues found in 2 files; syntax error)*
- `NEXT_PUBLIC_API_URL=http://localhost:3001 npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_689be77ef95c83289f4acc255961648a