### PR TITLE
Support HS256 tokens in auth middleware

### DIFF
--- a/server/src/__tests__/auth-middleware.test.ts
+++ b/server/src/__tests__/auth-middleware.test.ts
@@ -1,0 +1,81 @@
+import express from 'express';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { generateKeyPairSync } from 'crypto';
+
+const setCommonEnv = () => {
+  process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/db';
+  process.env.GEOCODE_USER_AGENT = 'test-agent';
+  process.env.COGNITO_AUDIENCE = 'test-aud';
+  process.env.COGNITO_ISSUER = 'test-iss';
+  process.env.AWS_REGION = 'us-east-1';
+  process.env.S3_BUCKET_NAME = 'bucket';
+  process.env.AWS_ACCESS_KEY_ID = 'key';
+  process.env.AWS_SECRET_ACCESS_KEY = 'secret';
+};
+
+afterEach(() => {
+  delete process.env.COGNITO_JWT_PUBLIC_KEY;
+  delete process.env.JWT_SECRET;
+  delete process.env.DATABASE_URL;
+  delete process.env.GEOCODE_USER_AGENT;
+  delete process.env.COGNITO_AUDIENCE;
+  delete process.env.COGNITO_ISSUER;
+  delete process.env.AWS_REGION;
+  delete process.env.S3_BUCKET_NAME;
+  delete process.env.AWS_ACCESS_KEY_ID;
+  delete process.env.AWS_SECRET_ACCESS_KEY;
+  jest.resetModules();
+});
+
+describe('authMiddleware', () => {
+  it('verifies token using RS256 when public key is provided', async () => {
+    const { privateKey, publicKey } = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    setCommonEnv();
+    process.env.COGNITO_JWT_PUBLIC_KEY = publicKey;
+
+    const { authMiddleware } = require('../middleware/auth-middleware');
+
+    const token = jwt.sign({ sub: 'user1', 'custom:role': 'admin' }, privateKey, {
+      algorithm: 'RS256',
+      audience: process.env.COGNITO_AUDIENCE,
+      issuer: process.env.COGNITO_ISSUER,
+    });
+
+    const app = express();
+    app.get('/protected', authMiddleware(['admin']), (_req, res) => {
+      res.json({ ok: true });
+    });
+
+    const res = await request(app).get('/protected').set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+  });
+
+  it('verifies token using HS256 when secret is provided', async () => {
+    setCommonEnv();
+    process.env.JWT_SECRET = 'supersecret';
+
+    const { authMiddleware } = require('../middleware/auth-middleware');
+
+    const token = jwt.sign({ sub: 'user1', 'custom:role': 'admin' }, process.env.JWT_SECRET!, {
+      algorithm: 'HS256',
+      audience: process.env.COGNITO_AUDIENCE,
+      issuer: process.env.COGNITO_ISSUER,
+    });
+
+    const app = express();
+    app.get('/protected', authMiddleware(['admin']), (_req, res) => {
+      res.json({ ok: true });
+    });
+
+    const res = await request(app).get('/protected').set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/server/src/middleware/auth-middleware.ts
+++ b/server/src/middleware/auth-middleware.ts
@@ -1,15 +1,10 @@
-import { Request, Response, NextFunction } from "express";
-import jwt, { JwtPayload } from "jsonwebtoken";
-import {
-  COGNITO_JWT_PUBLIC_KEY,
-  JWT_SECRET,
-  COGNITO_AUDIENCE,
-  COGNITO_ISSUER,
-} from "../env";
+import { Request, Response, NextFunction } from 'express';
+import jwt, { JwtPayload } from 'jsonwebtoken';
+import { COGNITO_JWT_PUBLIC_KEY, JWT_SECRET, COGNITO_AUDIENCE, COGNITO_ISSUER } from '../env';
 
 interface DecodedToken extends JwtPayload {
   sub: string;
-  "custom:role"?: string;
+  'custom:role'?: string;
 }
 
 declare global {
@@ -25,25 +20,24 @@ declare global {
 
 export const authMiddleware = (allowedRoles: string[]) => {
   return (req: Request, res: Response, next: NextFunction): void => {
-    const token = req.headers.authorization?.split(" ")[1];
+    const token = req.headers.authorization?.split(' ')[1];
 
     if (!token) {
-      res.status(401).json({ message: "Unauthorized" });
+      res.status(401).json({ message: 'Unauthorized' });
       return;
     }
 
     try {
-      const decoded = jwt.verify(
-        token,
-        COGNITO_JWT_PUBLIC_KEY || JWT_SECRET || "",
-        {
-          algorithms: ["RS256"],
-          audience: COGNITO_AUDIENCE,
-          issuer: COGNITO_ISSUER,
-        }
-      ) as DecodedToken;
+      const secretOrKey = COGNITO_JWT_PUBLIC_KEY || JWT_SECRET || '';
+      const algorithms = COGNITO_JWT_PUBLIC_KEY ? ['RS256'] : ['HS256'];
 
-      const userRole = decoded["custom:role"] || "";
+      const decoded = jwt.verify(token, secretOrKey, {
+        algorithms,
+        audience: COGNITO_AUDIENCE,
+        issuer: COGNITO_ISSUER,
+      }) as DecodedToken;
+
+      const userRole = decoded['custom:role'] || '';
       req.user = {
         id: decoded.sub,
         role: userRole,
@@ -51,14 +45,14 @@ export const authMiddleware = (allowedRoles: string[]) => {
 
       const hasAccess = allowedRoles.includes(userRole.toLowerCase());
       if (!hasAccess) {
-        res.status(403).json({ message: "Access Denied" });
+        res.status(403).json({ message: 'Access Denied' });
         return;
       }
 
       next();
     } catch (err) {
-      console.error("Failed to verify token:", err);
-      res.status(401).json({ message: "Invalid or expired token" });
+      console.error('Failed to verify token:', err);
+      res.status(401).json({ message: 'Invalid or expired token' });
       return;
     }
   };


### PR DESCRIPTION
## Summary
- detect whether COGNITO_JWT_PUBLIC_KEY or JWT_SECRET is configured
- select RS256 or HS256 algorithms accordingly
- add tests for public-key and HMAC scenarios

## Testing
- `npm test` *(fails: SyntaxError in existing test files)*
- `npx jest src/__tests__/auth-middleware.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689be780f7e0832896292938c82c2e43