### PR TITLE
Add property update/delete endpoints with client mutations

### DIFF
--- a/client/src/state/api.ts
+++ b/client/src/state/api.ts
@@ -261,6 +261,46 @@ export const api = createApi({
       },
     }),
 
+    updateProperty: build.mutation<
+      Property,
+      { id: number } & Partial<Property>
+    >({
+      query: ({ id, ...updated }) => ({
+        url: `properties/${id}`,
+        method: "PUT",
+        body: updated,
+      }),
+      invalidatesTags: (result, error, { id }) => [
+        { type: "Properties", id },
+        { type: "PropertyDetails", id },
+        { type: "Properties", id: "LIST" },
+      ],
+      async onQueryStarted(_, { queryFulfilled }) {
+        await withToast(queryFulfilled, {
+          success: "Property updated successfully!",
+          error: "Failed to update property.",
+        });
+      },
+    }),
+
+    deleteProperty: build.mutation<{ message: string }, number>({
+      query: (id) => ({
+        url: `properties/${id}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: (result, error, id) => [
+        { type: "Properties", id },
+        { type: "PropertyDetails", id },
+        { type: "Properties", id: "LIST" },
+      ],
+      async onQueryStarted(_, { queryFulfilled }) {
+        await withToast(queryFulfilled, {
+          success: "Property deleted successfully!",
+          error: "Failed to delete property.",
+        });
+      },
+    }),
+
     // lease related enpoints
     getLeases: build.query<Lease[], number>({
       query: () => "leases",
@@ -360,6 +400,8 @@ export const {
   useGetCurrentResidencesQuery,
   useGetManagerPropertiesQuery,
   useCreatePropertyMutation,
+  useUpdatePropertyMutation,
+  useDeletePropertyMutation,
   useGetTenantQuery,
   useAddFavoritePropertyMutation,
   useRemoveFavoritePropertyMutation,

--- a/server/src/__tests__/property.test.ts
+++ b/server/src/__tests__/property.test.ts
@@ -2,11 +2,11 @@ import request from "supertest";
 import express from "express";
 
 // mocks must be defined before imports that use them
-jest.mock("../utils/s3Upload", () => ({
+jest.mock("../utils/s3-upload", () => ({
   uploadFilesToS3: jest.fn().mockResolvedValue([]),
 }));
 
-jest.mock("../utils/geocodeAddress", () => ({
+jest.mock("../utils/geocode-address", () => ({
   geocodeAddress: jest.fn().mockResolvedValue([0, 0]),
 }));
 
@@ -15,6 +15,8 @@ const mockPrisma = {
   property: {
     deleteMany: jest.fn(),
     findUnique: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
   },
   $transaction: jest.fn(),
   $disconnect: jest.fn(),
@@ -25,9 +27,23 @@ jest.mock("@prisma/client", () => ({
   Prisma: { join: jest.fn() },
 }));
 
-import propertyRoutes from "../routes/property-routes";
-import { createProperty } from "../controllers/property-controllers";
-import prisma from "../utils/prisma";
+process.env.DATABASE_URL = "postgres://test";
+process.env.GEOCODE_USER_AGENT = "test";
+process.env.COGNITO_AUDIENCE = "test";
+process.env.COGNITO_ISSUER = "test";
+process.env.AWS_REGION = "test";
+process.env.S3_BUCKET_NAME = "test";
+process.env.AWS_ACCESS_KEY_ID = "test";
+process.env.AWS_SECRET_ACCESS_KEY = "test";
+process.env.JWT_SECRET = "test";
+
+const propertyRoutes = require("../routes/property-routes").default;
+const {
+  createProperty,
+  updateProperty,
+  deleteProperty,
+} = require("../controllers/property-controllers");
+const prisma = require("../utils/prisma").default;
 
 const app = express();
 app.use(express.json());
@@ -36,6 +52,14 @@ app.post("/properties", (req, res, next) => {
   (req as any).files = [];
   (req as any).user = { id: "manager", role: "manager" };
   createProperty(req, res, next);
+});
+app.put("/properties/:id", (req, res, next) => {
+  (req as any).user = { id: "manager", role: "manager" };
+  updateProperty(req, res, next);
+});
+app.delete("/properties/:id", (req, res, next) => {
+  (req as any).user = { id: "manager", role: "manager" };
+  deleteProperty(req, res, next);
 });
 // other property routes
 app.use("/properties", propertyRoutes);
@@ -168,6 +192,53 @@ describe("Property API", () => {
     const res = await request(app).post("/properties").send(payload);
     expect(res.status).toBe(400);
     expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("updates property with valid payload", async () => {
+    const updateMock = jest
+      .fn()
+      .mockResolvedValue({ id: 1, name: "Updated Property" });
+    mockPrisma.property.update.mockImplementation(updateMock);
+
+    const res = await request(app)
+      .put("/properties/1")
+      .send({ name: "Updated Property" });
+    expect(res.status).toBe(200);
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 1 },
+        data: expect.objectContaining({ name: "Updated Property" }),
+      })
+    );
+  });
+
+  it("returns 404 when updating missing property", async () => {
+    mockPrisma.property.update.mockRejectedValue({ code: "P2025" });
+
+    const res = await request(app)
+      .put("/properties/999")
+      .send({ name: "Updated Property" });
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ message: "Property not found" });
+  });
+
+  it("deletes property", async () => {
+    mockPrisma.property.delete.mockResolvedValue({});
+
+    const res = await request(app).delete("/properties/1");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ message: "Property deleted" });
+    expect(mockPrisma.property.delete).toHaveBeenCalledWith({
+      where: { id: 1 },
+    });
+  });
+
+  it("returns 404 when deleting missing property", async () => {
+    mockPrisma.property.delete.mockRejectedValue({ code: "P2025" });
+
+    const res = await request(app).delete("/properties/999");
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ message: "Property not found" });
   });
 });
 

--- a/server/src/controllers/property-controllers.ts
+++ b/server/src/controllers/property-controllers.ts
@@ -28,6 +28,23 @@ const createPropertySchema = z.object({
   isParkingIncluded: z.string().optional(),
 });
 
+const updatePropertySchema = z.object({
+  name: z.string().optional(),
+  description: z.string().optional(),
+  pricePerMonth: z.coerce.number().optional(),
+  securityDeposit: z.coerce.number().optional(),
+  applicationFee: z.coerce.number().optional(),
+  beds: z.coerce.number().optional(),
+  baths: z.coerce.number().optional(),
+  squareFeet: z.coerce.number().optional(),
+  propertyType: z.string().optional(),
+  amenities: z.string().optional(),
+  highlights: z.string().optional(),
+  isPetsAllowed: z.string().optional(),
+  isParkingIncluded: z.string().optional(),
+  photoUrls: z.array(z.string()).optional(),
+});
+
 export const getProperties = async (
   req: Request,
   res: Response,
@@ -239,5 +256,70 @@ export const createProperty = async (
     res.status(201).json(newProperty);
   } catch (err) {
     next(err);
+  }
+};
+
+export const updateProperty = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const parsed = updatePropertySchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ errors: parsed.error.flatten() });
+      return;
+    }
+
+    const data = parsed.data;
+    const updatedProperty = await prisma.property.update({
+      where: { id: Number(id) },
+      data: {
+        ...data,
+        amenities:
+          typeof data.amenities === "string"
+            ? data.amenities.split(",")
+            : data.amenities,
+        highlights:
+          typeof data.highlights === "string"
+            ? data.highlights.split(",")
+            : data.highlights,
+        isPetsAllowed:
+          data.isPetsAllowed === undefined
+            ? undefined
+            : data.isPetsAllowed === "true",
+        isParkingIncluded:
+          data.isParkingIncluded === undefined
+            ? undefined
+            : data.isParkingIncluded === "true",
+      },
+    });
+
+    res.json(updatedProperty);
+  } catch (err: any) {
+    if (err?.code === "P2025") {
+      res.status(404).json({ message: "Property not found" });
+    } else {
+      next(err);
+    }
+  }
+};
+
+export const deleteProperty = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const { id } = req.params;
+    await prisma.property.delete({ where: { id: Number(id) } });
+    res.json({ message: "Property deleted" });
+  } catch (err: any) {
+    if (err?.code === "P2025") {
+      res.status(404).json({ message: "Property not found" });
+    } else {
+      next(err);
+    }
   }
 };

--- a/server/src/routes/property-routes.ts
+++ b/server/src/routes/property-routes.ts
@@ -3,6 +3,8 @@ import {
   getProperties,
   getProperty,
   createProperty,
+  updateProperty,
+  deleteProperty,
 } from "../controllers/property-controllers";
 import multer from "multer";
 import { authMiddleware } from "../middleware/auth-middleware";
@@ -19,6 +21,16 @@ router.post(
   authMiddleware(["manager"]),
   upload.array("photos"),
   createProperty
+);
+router.put(
+  "/:id",
+  authMiddleware(["manager"]),
+  updateProperty
+);
+router.delete(
+  "/:id",
+  authMiddleware(["manager"]),
+  deleteProperty
 );
 
 export default router;


### PR DESCRIPTION
## Summary
- implement updateProperty and deleteProperty controllers
- add routes with manager auth for property updates and deletions
- extend RTK Query API with update and delete mutations
- test property update and delete endpoints

## Testing
- `npm test` *(fails: SyntaxError in unrelated tests)*
- `npx jest src/__tests__/property.test.ts`
- `npm test` *(client: Prettier reported style issues)*

------
https://chatgpt.com/codex/tasks/task_e_689be783497c8328ab9d7af7f1e75e1d