### PR TITLE
Enforce photo upload size and type limits

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -150,6 +150,11 @@ Create a new property listing. Requires manager authentication.
 }
 ```
 
+**Photo Upload Limits**
+
+- Allowed MIME types: `image/jpeg`, `image/png`, `image/webp`
+- Maximum file size: 5 MB per file
+
 **Response:**
 ```json
 {

--- a/server/src/routes/property-routes.ts
+++ b/server/src/routes/property-routes.ts
@@ -6,9 +6,20 @@ import {
 } from "../controllers/property-controllers";
 import multer from "multer";
 import { authMiddleware } from "../middleware/auth-middleware";
+import { ALLOWED_MIME_TYPES, MAX_FILE_SIZE } from "../utils/s3-upload";
 
 const storage = multer.memoryStorage();
-const upload = multer({ storage: storage });
+const upload = multer({
+  storage: storage,
+  limits: { fileSize: MAX_FILE_SIZE },
+  fileFilter: (_req, file, cb) => {
+    if (ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error("Invalid file type"));
+    }
+  },
+});
 
 const router = express.Router();
 

--- a/server/src/utils/s3-upload.ts
+++ b/server/src/utils/s3-upload.ts
@@ -8,9 +8,27 @@ import {
   AWS_SECRET_ACCESS_KEY,
 } from "../env";
 
+export const ALLOWED_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+];
+
+export const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
 export const uploadFilesToS3 = async (
   files: Express.Multer.File[],
 ): Promise<string[]> => {
+  files.forEach((file) => {
+    if (!ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+      throw new Error(`Unsupported file type: ${file.mimetype}`);
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      throw new Error(`File too large: ${file.originalname}`);
+    }
+  });
+
   const s3Client = new S3Client({
     region: AWS_REGION,
     credentials: {


### PR DESCRIPTION
## Summary
- validate MIME types and file sizes before uploading files to S3
- configure property routes with Multer limits for photos
- document photo upload restrictions in API documentation

## Testing
- `npm test` *(fails: SyntaxError in prettier for property-search.test.ts and env.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689be78237208328a4787ecf6f05dfad