### PR TITLE
Add geocode caching using Prisma

### DIFF
--- a/server/prisma/migrations/20250222120000_add_geocode_cache/migration.sql
+++ b/server/prisma/migrations/20250222120000_add_geocode_cache/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "GeocodeCache" (
+    "id" SERIAL NOT NULL,
+    "address" TEXT NOT NULL,
+    "city" TEXT NOT NULL,
+    "postalCode" TEXT NOT NULL,
+    "latitude" DOUBLE PRECISION NOT NULL,
+    "longitude" DOUBLE PRECISION NOT NULL,
+
+    CONSTRAINT "GeocodeCache_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GeocodeCache_address_city_postalCode_key" ON "GeocodeCache"("address", "city", "postalCode");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -182,3 +182,14 @@ model Listing {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 }
+
+model GeocodeCache {
+  id         Int     @id @default(autoincrement())
+  address    String
+  city       String
+  postalCode String
+  latitude   Float
+  longitude  Float
+
+  @@unique([address, city, postalCode])
+}

--- a/server/src/services/geocode-cache.ts
+++ b/server/src/services/geocode-cache.ts
@@ -1,0 +1,37 @@
+import prisma from '../utils/prisma';
+
+export const getCachedGeocode = async (
+  address: string,
+  city: string,
+  postalCode: string,
+): Promise<[number, number] | null> => {
+  const cache = await prisma.geocodeCache.findUnique({
+    where: {
+      address_city_postalCode: { address, city, postalCode },
+    },
+  });
+
+  if (!cache) {
+    return null;
+  }
+
+  return [cache.longitude, cache.latitude];
+};
+
+export const saveGeocode = async (
+  address: string,
+  city: string,
+  postalCode: string,
+  longitude: number,
+  latitude: number,
+): Promise<void> => {
+  await prisma.geocodeCache.upsert({
+    where: {
+      address_city_postalCode: { address, city, postalCode },
+    },
+    update: { longitude, latitude },
+    create: { address, city, postalCode, longitude, latitude },
+  });
+};
+
+export default { getCachedGeocode, saveGeocode };

--- a/server/src/utils/geocode-address.ts
+++ b/server/src/utils/geocode-address.ts
@@ -1,5 +1,6 @@
-import axios from "axios";
-import { GEOCODE_USER_AGENT } from "../env";
+import axios from 'axios';
+import { GEOCODE_USER_AGENT } from '../env';
+import { getCachedGeocode, saveGeocode } from '../services/geocode-cache';
 
 export const geocodeAddress = async (
   address: string,
@@ -7,35 +8,40 @@ export const geocodeAddress = async (
   country: string,
   postalCode: string,
 ): Promise<[number, number]> => {
+  const cached = await getCachedGeocode(address, city, postalCode);
+  if (cached) {
+    return cached;
+  }
+
   const geocodingUrl = `https://nominatim.openstreetmap.org/search?${new URLSearchParams({
     street: address,
     city,
     country,
     postalcode: postalCode,
-    format: "json",
-    limit: "1",
+    format: 'json',
+    limit: '1',
   }).toString()}`;
 
   if (!GEOCODE_USER_AGENT) {
-    throw new Error(
-      "GEOCODE_USER_AGENT environment variable is required for geocoding requests",
-    );
+    throw new Error('GEOCODE_USER_AGENT environment variable is required for geocoding requests');
   }
 
   const geocodingResponse = await axios.get(geocodingUrl, {
     headers: {
-      "User-Agent": GEOCODE_USER_AGENT,
+      'User-Agent': GEOCODE_USER_AGENT,
     },
   });
 
   if (!geocodingResponse.data?.[0]) {
-    throw new Error("Geocoding failed");
+    throw new Error('Geocoding failed');
   }
 
-  return [
-    parseFloat(geocodingResponse.data[0].lon),
-    parseFloat(geocodingResponse.data[0].lat),
-  ];
+  const longitude = parseFloat(geocodingResponse.data[0].lon);
+  const latitude = parseFloat(geocodingResponse.data[0].lat);
+
+  await saveGeocode(address, city, postalCode, longitude, latitude);
+
+  return [longitude, latitude];
 };
 
 export default geocodeAddress;


### PR DESCRIPTION
## Summary
- add `GeocodeCache` table and migration for storing lat/lon lookups
- add geocode cache service backed by Prisma
- use cache in geocoding util to avoid redundant API requests

## Testing
- `npm test` *(fails: SyntaxError in existing test files)*

------
https://chatgpt.com/codex/tasks/task_e_689be782ccac8328b2ed200d4d0dc1b8