### PR TITLE
Add user schema and location imports to controllers

### DIFF
--- a/server/src/controllers/manager-controllers.ts
+++ b/server/src/controllers/manager-controllers.ts
@@ -1,5 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import prisma from "../utils/prisma";
+import { createUserSchema, updateUserSchema } from "../validators/user-validators";
+import { formatLocation } from "../utils/format-location";
 
 
 export const getManager = async (

--- a/server/src/controllers/tenant-controllers.ts
+++ b/server/src/controllers/tenant-controllers.ts
@@ -1,5 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import prisma from "../utils/prisma";
+import { createUserSchema, updateUserSchema } from "../validators/user-validators";
+import { formatLocation } from "../utils/format-location";
 
 
 export const getTenant = async (


### PR DESCRIPTION
## Summary
- import user validation schemas in tenant and manager controllers
- import helper to format location data for controllers

## Testing
- `npm test` (fails: Declaration or statement expected in src/__tests__/property-search.test.ts)
- `npm run build` (fails: Declaration or statement expected in property-search.test.ts)


------
https://chatgpt.com/codex/tasks/task_e_689c08d984d48328ad3363c8b900a78e