### PR TITLE
feat: configure JWT algorithms dynamically

### DIFF
--- a/server/src/__tests__/auth-middleware.test.ts
+++ b/server/src/__tests__/auth-middleware.test.ts
@@ -1,0 +1,63 @@
+import express from 'express';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { generateKeyPairSync } from 'crypto';
+
+describe('auth middleware', () => {
+  const baseEnv = {
+    DATABASE_URL: 'https://example.com',
+    GEOCODE_USER_AGENT: 'test-agent',
+    COGNITO_AUDIENCE: 'test-audience',
+    COGNITO_ISSUER: 'test-issuer',
+    AWS_REGION: 'us-east-1',
+    S3_BUCKET_NAME: 'bucket',
+    AWS_ACCESS_KEY_ID: 'key',
+    AWS_SECRET_ACCESS_KEY: 'secret',
+  };
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...baseEnv };
+  });
+
+  it('allows access with RS256 token when public key is provided', async () => {
+    const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+    });
+    process.env.COGNITO_JWT_PUBLIC_KEY = publicKey
+      .export({ type: 'pkcs1', format: 'pem' })
+      .toString();
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { authMiddleware } = require('../middleware/auth-middleware');
+    const app = express();
+    app.get('/', authMiddleware(['tenant']), (_req, res) => res.status(200).json({ ok: true }));
+
+    const token = jwt.sign({ sub: 'user', 'custom:role': 'tenant' }, privateKey, {
+      algorithm: 'RS256',
+      audience: baseEnv.COGNITO_AUDIENCE,
+      issuer: baseEnv.COGNITO_ISSUER,
+    });
+
+    const res = await request(app).get('/').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+  });
+
+  it('allows access with HS256 token when secret is provided', async () => {
+    process.env.JWT_SECRET = 'shhh';
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { authMiddleware } = require('../middleware/auth-middleware');
+    const app = express();
+    app.get('/', authMiddleware(['tenant']), (_req, res) => res.status(200).json({ ok: true }));
+
+    const token = jwt.sign({ sub: 'user', 'custom:role': 'tenant' }, process.env.JWT_SECRET, {
+      algorithm: 'HS256',
+      audience: baseEnv.COGNITO_AUDIENCE,
+      issuer: baseEnv.COGNITO_ISSUER,
+    });
+
+    const res = await request(app).get('/').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+  });
+});

--- a/server/src/middleware/auth-middleware.ts
+++ b/server/src/middleware/auth-middleware.ts
@@ -1,15 +1,10 @@
-import { Request, Response, NextFunction } from "express";
-import jwt, { JwtPayload } from "jsonwebtoken";
-import {
-  COGNITO_JWT_PUBLIC_KEY,
-  JWT_SECRET,
-  COGNITO_AUDIENCE,
-  COGNITO_ISSUER,
-} from "../env";
+import { Request, Response, NextFunction } from 'express';
+import jwt, { JwtPayload } from 'jsonwebtoken';
+import { COGNITO_JWT_PUBLIC_KEY, JWT_SECRET, COGNITO_AUDIENCE, COGNITO_ISSUER } from '../env';
 
 interface DecodedToken extends JwtPayload {
   sub: string;
-  "custom:role"?: string;
+  'custom:role'?: string;
 }
 
 declare global {
@@ -25,25 +20,24 @@ declare global {
 
 export const authMiddleware = (allowedRoles: string[]) => {
   return (req: Request, res: Response, next: NextFunction): void => {
-    const token = req.headers.authorization?.split(" ")[1];
+    const token = req.headers.authorization?.split(' ')[1];
 
     if (!token) {
-      res.status(401).json({ message: "Unauthorized" });
+      res.status(401).json({ message: 'Unauthorized' });
       return;
     }
 
     try {
-      const decoded = jwt.verify(
-        token,
-        COGNITO_JWT_PUBLIC_KEY || JWT_SECRET || "",
-        {
-          algorithms: ["RS256"],
-          audience: COGNITO_AUDIENCE,
-          issuer: COGNITO_ISSUER,
-        }
-      ) as DecodedToken;
+      const key = COGNITO_JWT_PUBLIC_KEY || JWT_SECRET || '';
+      const algorithms = COGNITO_JWT_PUBLIC_KEY ? ['RS256'] : ['HS256'];
 
-      const userRole = decoded["custom:role"] || "";
+      const decoded = jwt.verify(token, key, {
+        algorithms,
+        audience: COGNITO_AUDIENCE,
+        issuer: COGNITO_ISSUER,
+      }) as DecodedToken;
+
+      const userRole = decoded['custom:role'] || '';
       req.user = {
         id: decoded.sub,
         role: userRole,
@@ -51,14 +45,14 @@ export const authMiddleware = (allowedRoles: string[]) => {
 
       const hasAccess = allowedRoles.includes(userRole.toLowerCase());
       if (!hasAccess) {
-        res.status(403).json({ message: "Access Denied" });
+        res.status(403).json({ message: 'Access Denied' });
         return;
       }
 
       next();
     } catch (err) {
-      console.error("Failed to verify token:", err);
-      res.status(401).json({ message: "Invalid or expired token" });
+      console.error('Failed to verify token:', err);
+      res.status(401).json({ message: 'Invalid or expired token' });
       return;
     }
   };


### PR DESCRIPTION
## Summary
- detect whether a public key or shared secret is configured
- verify RS256 tokens when a Cognito public key is supplied
- test HS256 and RS256 flows in auth middleware

## Testing
- `npx jest src/__tests__/auth-middleware.test.ts`
- `npm test` *(fails: SyntaxError in existing test files)*

------
https://chatgpt.com/codex/tasks/task_e_689c08db01908328ab2a7a7df29784f1