### PR TITLE
feat: restrict property photo uploads

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -150,6 +150,8 @@ Create a new property listing. Requires manager authentication.
 }
 ```
 
+**Photo Upload Limits:** Only `image/jpeg` and `image/png` files are accepted, and each file must be no larger than 5MB.
+
 **Response:**
 ```json
 {

--- a/server/src/routes/property-routes.ts
+++ b/server/src/routes/property-routes.ts
@@ -6,9 +6,21 @@ import {
 } from "../controllers/property-controllers";
 import multer from "multer";
 import { authMiddleware } from "../middleware/auth-middleware";
+import { ALLOWED_MIME_TYPES, MAX_FILE_SIZE } from "../utils/s3-upload";
 
 const storage = multer.memoryStorage();
-const upload = multer({ storage: storage });
+const fileFilter: multer.Options["fileFilter"] = (req, file, cb) => {
+  if (ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+    cb(null, true);
+  } else {
+    cb(new Error("Invalid file type"));
+  }
+};
+const upload = multer({
+  storage,
+  fileFilter,
+  limits: { fileSize: MAX_FILE_SIZE },
+});
 
 const router = express.Router();
 

--- a/server/src/utils/s3-upload.ts
+++ b/server/src/utils/s3-upload.ts
@@ -8,9 +8,21 @@ import {
   AWS_SECRET_ACCESS_KEY,
 } from "../env";
 
+export const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png"];
+export const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
 export const uploadFilesToS3 = async (
   files: Express.Multer.File[],
 ): Promise<string[]> => {
+  files.forEach((file) => {
+    if (!ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+      throw new Error(`Unsupported file type: ${file.mimetype}`);
+    }
+    if (file.size > MAX_FILE_SIZE) {
+      throw new Error(`File size exceeds limit of ${MAX_FILE_SIZE} bytes`);
+    }
+  });
+
   const s3Client = new S3Client({
     region: AWS_REGION,
     credentials: {


### PR DESCRIPTION
## Summary
- limit property photo uploads to JPEG/PNG files under 5MB
- validate file constraints before uploading to S3
- document photo upload limits in API docs

## Testing
- `npm test` *(fails: SyntaxError in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_689c08db54c08328ba1d406a6d571516