### PR TITLE
Add update and delete property endpoints and client hooks

### DIFF
--- a/client/src/state/api.ts
+++ b/client/src/state/api.ts
@@ -261,6 +261,44 @@ export const api = createApi({
       },
     }),
 
+    updateProperty: build.mutation<
+      Property,
+      { id: number } & Partial<Property>
+    >({
+      query: ({ id, ...updatedProperty }) => ({
+        url: `properties/${id}`,
+        method: "PUT",
+        body: updatedProperty,
+      }),
+      invalidatesTags: (result, error, { id }) => [
+        { type: "Properties", id: "LIST" },
+        { type: "PropertyDetails", id },
+      ],
+      async onQueryStarted(_, { queryFulfilled }) {
+        await withToast(queryFulfilled, {
+          success: "Property updated successfully!",
+          error: "Failed to update property.",
+        });
+      },
+    }),
+
+    deleteProperty: build.mutation<void, number>({
+      query: (id) => ({
+        url: `properties/${id}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: (result, error, id) => [
+        { type: "Properties", id: "LIST" },
+        { type: "PropertyDetails", id },
+      ],
+      async onQueryStarted(_, { queryFulfilled }) {
+        await withToast(queryFulfilled, {
+          success: "Property deleted successfully!",
+          error: "Failed to delete property.",
+        });
+      },
+    }),
+
     // lease related enpoints
     getLeases: build.query<Lease[], number>({
       query: () => "leases",
@@ -360,6 +398,8 @@ export const {
   useGetCurrentResidencesQuery,
   useGetManagerPropertiesQuery,
   useCreatePropertyMutation,
+  useUpdatePropertyMutation,
+  useDeletePropertyMutation,
   useGetTenantQuery,
   useAddFavoritePropertyMutation,
   useRemoveFavoritePropertyMutation,

--- a/server/src/__tests__/property.test.ts
+++ b/server/src/__tests__/property.test.ts
@@ -2,19 +2,31 @@ import request from "supertest";
 import express from "express";
 
 // mocks must be defined before imports that use them
-jest.mock("../utils/s3Upload", () => ({
+jest.mock("../utils/s3-upload", () => ({
   uploadFilesToS3: jest.fn().mockResolvedValue([]),
 }));
 
-jest.mock("../utils/geocodeAddress", () => ({
+jest.mock("../utils/geocode-address", () => ({
   geocodeAddress: jest.fn().mockResolvedValue([0, 0]),
 }));
+
+process.env.DATABASE_URL="https://example.com";
+process.env.GEOCODE_USER_AGENT="test";
+process.env.COGNITO_AUDIENCE="test";
+process.env.COGNITO_ISSUER="test";
+process.env.AWS_REGION="test";
+process.env.S3_BUCKET_NAME="test";
+process.env.AWS_ACCESS_KEY_ID="test";
+process.env.AWS_SECRET_ACCESS_KEY="test";
+process.env.JWT_SECRET="test";
 
 
 const mockPrisma = {
   property: {
     deleteMany: jest.fn(),
     findUnique: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
   },
   $transaction: jest.fn(),
   $disconnect: jest.fn(),
@@ -26,7 +38,11 @@ jest.mock("@prisma/client", () => ({
 }));
 
 import propertyRoutes from "../routes/property-routes";
-import { createProperty } from "../controllers/property-controllers";
+import {
+  createProperty,
+  updateProperty,
+  deleteProperty,
+} from "../controllers/property-controllers";
 import prisma from "../utils/prisma";
 
 const app = express();
@@ -36,6 +52,14 @@ app.post("/properties", (req, res, next) => {
   (req as any).files = [];
   (req as any).user = { id: "manager", role: "manager" };
   createProperty(req, res, next);
+});
+app.put("/properties/:id", (req, res, next) => {
+  (req as any).user = { id: "manager", role: "manager" };
+  updateProperty(req, res, next);
+});
+app.delete("/properties/:id", (req, res, next) => {
+  (req as any).user = { id: "manager", role: "manager" };
+  deleteProperty(req, res, next);
 });
 // other property routes
 app.use("/properties", propertyRoutes);
@@ -168,6 +192,48 @@ describe("Property API", () => {
     const res = await request(app).post("/properties").send(payload);
     expect(res.status).toBe(400);
     expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("updates property with valid payload", async () => {
+    mockPrisma.property.findUnique.mockResolvedValue({ id: 1 });
+    mockPrisma.property.update.mockResolvedValue({ id: 1, name: "Updated" });
+
+    const res = await request(app)
+      .put("/properties/1")
+      .send({ name: "Updated" });
+
+    expect(res.status).toBe(200);
+    expect(mockPrisma.property.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 1 },
+      })
+    );
+  });
+
+  it("returns 404 when updating missing property", async () => {
+    mockPrisma.property.findUnique.mockResolvedValue(null);
+    const res = await request(app).put("/properties/1").send({ name: "Nope" });
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ message: "Property not found" });
+    expect(mockPrisma.property.update).not.toHaveBeenCalled();
+  });
+
+  it("deletes property with valid id", async () => {
+    mockPrisma.property.findUnique.mockResolvedValue({ id: 1 });
+    mockPrisma.property.delete.mockResolvedValue({});
+    const res = await request(app).delete("/properties/1");
+    expect(res.status).toBe(204);
+    expect(mockPrisma.property.delete).toHaveBeenCalledWith({
+      where: { id: 1 },
+    });
+  });
+
+  it("returns 404 when deleting missing property", async () => {
+    mockPrisma.property.findUnique.mockResolvedValue(null);
+    const res = await request(app).delete("/properties/1");
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ message: "Property not found" });
+    expect(mockPrisma.property.delete).not.toHaveBeenCalled();
   });
 });
 

--- a/server/src/controllers/property-controllers.ts
+++ b/server/src/controllers/property-controllers.ts
@@ -28,6 +28,8 @@ const createPropertySchema = z.object({
   isParkingIncluded: z.string().optional(),
 });
 
+const updatePropertySchema = createPropertySchema.partial();
+
 export const getProperties = async (
   req: Request,
   res: Response,
@@ -237,6 +239,96 @@ export const createProperty = async (
     });
 
     res.status(201).json(newProperty);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const updateProperty = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const parsed = updatePropertySchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ errors: parsed.error.flatten() });
+      return;
+    }
+
+    const existing = await prisma.property.findUnique({
+      where: { id: Number(id) },
+    });
+
+    if (!existing) {
+      res.status(404).json({ message: "Property not found" });
+      return;
+    }
+
+    const {
+      amenities,
+      highlights,
+      isPetsAllowed,
+      isParkingIncluded,
+      pricePerMonth,
+      securityDeposit,
+      applicationFee,
+      beds,
+      baths,
+      squareFeet,
+      ...rest
+    } = parsed.data;
+
+    const updatedProperty = await prisma.property.update({
+      where: { id: Number(id) },
+      data: {
+        ...rest,
+        amenities:
+          typeof amenities === "string" ? amenities.split(",") : amenities,
+        highlights:
+          typeof highlights === "string" ? highlights.split(",") : highlights,
+        isPetsAllowed:
+          isPetsAllowed !== undefined ? isPetsAllowed === "true" : undefined,
+        isParkingIncluded:
+          isParkingIncluded !== undefined
+            ? isParkingIncluded === "true"
+            : undefined,
+        pricePerMonth,
+        securityDeposit,
+        applicationFee,
+        beds,
+        baths,
+        squareFeet,
+      },
+      include: { location: true, manager: true },
+    });
+
+    res.json(updatedProperty);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const deleteProperty = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const { id } = req.params;
+
+    const existing = await prisma.property.findUnique({
+      where: { id: Number(id) },
+    });
+
+    if (!existing) {
+      res.status(404).json({ message: "Property not found" });
+      return;
+    }
+
+    await prisma.property.delete({ where: { id: Number(id) } });
+    res.status(204).send();
   } catch (err) {
     next(err);
   }

--- a/server/src/routes/property-routes.ts
+++ b/server/src/routes/property-routes.ts
@@ -3,6 +3,8 @@ import {
   getProperties,
   getProperty,
   createProperty,
+  updateProperty,
+  deleteProperty,
 } from "../controllers/property-controllers";
 import multer from "multer";
 import { authMiddleware } from "../middleware/auth-middleware";
@@ -20,5 +22,7 @@ router.post(
   upload.array("photos"),
   createProperty
 );
+router.put("/:id", authMiddleware(["manager"]), updateProperty);
+router.delete("/:id", authMiddleware(["manager"]), deleteProperty);
 
 export default router;


### PR DESCRIPTION
## Summary
- add controller logic for updating and deleting properties
- expose PUT and DELETE property routes with manager auth
- add RTK Query mutations and hooks for updating and deleting properties
- test property update and delete flows

## Testing
- `npm test` *(fails: Code style issues found in 110 files. Run Prettier with --write to fix.)*
- `npx jest src/__tests__/property.test.ts`
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_689c08dc8cec83289f46705a939e6c6a