### PR TITLE
feat: add server-side validation for applications

### DIFF
--- a/server/src/__tests__/application-controllers.test.ts
+++ b/server/src/__tests__/application-controllers.test.ts
@@ -1,10 +1,10 @@
 import { Request, Response, NextFunction } from "express";
 
 // Mock external services
-jest.mock("../utils/s3Upload", () => ({ uploadFilesToS3: jest.fn() }));
-jest.mock("../utils/geocodeAddress", () => ({ geocodeAddress: jest.fn() }));
+jest.mock("../utils/s3-upload", () => ({ uploadFilesToS3: jest.fn() }));
+jest.mock("../utils/geocode-address", () => ({ geocodeAddress: jest.fn() }));
 
-jest.mock("../services/applicationService", () => ({
+jest.mock("../services/application-service", () => ({
   updateApplicationStatus: jest.fn(),
 }));
 
@@ -90,7 +90,7 @@ describe("applicationControllers", () => {
         propertyId: 1,
         tenantCognitoId: "t1",
         name: "n",
-        email: "e",
+        email: "e@example.com",
         phoneNumber: "p",
         message: "m",
       },
@@ -105,7 +105,17 @@ describe("applicationControllers", () => {
 
   it("returns 404 when property missing", async () => {
     mockPrisma.property.findUnique.mockResolvedValue(null);
-    const req = { body: { propertyId: 1 } } as unknown as Request;
+    const req = {
+      body: {
+        applicationDate: new Date().toISOString(),
+        status: "PENDING",
+        propertyId: 1,
+        tenantCognitoId: "t1",
+        name: "n",
+        email: "e@example.com",
+        phoneNumber: "p",
+      },
+    } as unknown as Request;
     const res = createMockRes();
 
     await createApplication(req, res, next);
@@ -116,13 +126,38 @@ describe("applicationControllers", () => {
 
   it("calls next on create error", async () => {
     mockPrisma.property.findUnique.mockRejectedValue(new Error("db"));
-    const req = { body: { propertyId: 1 } } as unknown as Request;
+    const req = {
+      body: {
+        applicationDate: new Date().toISOString(),
+        status: "PENDING",
+        propertyId: 1,
+        tenantCognitoId: "t1",
+        name: "n",
+        email: "e@example.com",
+        phoneNumber: "p",
+      },
+    } as unknown as Request;
     const res = createMockRes();
     const localNext = jest.fn();
 
     await createApplication(req, res, localNext);
 
     expect(localNext).toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid payload", async () => {
+    const req = {
+      body: {
+        // missing required fields
+        propertyId: 1,
+      },
+    } as unknown as Request;
+    const res = createMockRes();
+
+    await createApplication(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockPrisma.property.findUnique).not.toHaveBeenCalled();
   });
 
   it("updates application status", async () => {

--- a/server/src/controllers/application-controllers.ts
+++ b/server/src/controllers/application-controllers.ts
@@ -1,6 +1,18 @@
 import { Request, Response, NextFunction } from "express";
+import { z } from "zod";
 import prisma from "../utils/prisma";
 import { updateApplicationStatus as updateApplicationStatusService } from "../services/application-service";
+
+const createApplicationSchema = z.object({
+  applicationDate: z.string(),
+  status: z.string(),
+  propertyId: z.coerce.number(),
+  tenantCognitoId: z.string(),
+  name: z.string(),
+  email: z.string().email(),
+  phoneNumber: z.string(),
+  message: z.string().optional(),
+});
 
 export const listApplications = async (
   req: Request,
@@ -87,6 +99,12 @@ export const createApplication = async (
   next: NextFunction
 ): Promise<void> => {
   try {
+    const parsed = createApplicationSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ errors: parsed.error.flatten() });
+      return;
+    }
+
     const {
       applicationDate,
       status,
@@ -96,7 +114,7 @@ export const createApplication = async (
       email,
       phoneNumber,
       message,
-    } = req.body;
+    } = parsed.data;
 
     const property = await prisma.property.findUnique({
       where: { id: propertyId },


### PR DESCRIPTION
## Summary
- validate application creation payload using zod schema
- add unit tests for application controller validation failures

## Testing
- `npm test` *(fails: SyntaxError in existing tests)*
- `npx jest src/__tests__/application-controllers.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689c08dcfa10832888f6b1e44b937d51