### PR TITLE
Enforce property photo upload limits

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -26,6 +26,7 @@ Production: https://your-domain.com
 Retrieve all properties with optional filtering.
 
 **Query Parameters:**
+
 - `location` (string): Filter by location
 - `priceMin` (number): Minimum price
 - `priceMax` (number): Maximum price
@@ -37,6 +38,7 @@ Retrieve all properties with optional filtering.
 - `longitude` (number): Longitude for location-based search
 
 **Response:**
+
 ```json
 {
   "properties": [
@@ -78,6 +80,7 @@ Retrieve all properties with optional filtering.
 Retrieve a specific property by ID.
 
 **Response:**
+
 ```json
 {
   "id": 1,
@@ -126,6 +129,7 @@ Retrieve a specific property by ID.
 Create a new property listing. Requires manager authentication.
 
 **Request Body:**
+
 ```json
 {
   "name": "New Property",
@@ -152,10 +156,12 @@ Create a new property listing. Requires manager authentication.
 
 **Photo Upload Limits**
 
-- Allowed MIME types: `image/jpeg`, `image/png`, `image/webp`
-- Maximum file size: 5 MB per file
+- Allowed MIME types: `image/jpeg`, `image/png`
+- Maximum file size: 5 MB per file
+- Files exceeding these limits are rejected before upload
 
 **Response:**
+
 ```json
 {
   "id": 1,
@@ -172,6 +178,7 @@ Update an existing property. Requires manager authentication.
 **Request Body:** Same as create property
 
 **Response:**
+
 ```json
 {
   "message": "Property updated successfully"
@@ -185,6 +192,7 @@ Update an existing property. Requires manager authentication.
 Delete a property. Requires manager authentication.
 
 **Response:**
+
 ```json
 {
   "message": "Property deleted successfully"
@@ -200,6 +208,7 @@ Delete a property. Requires manager authentication.
 Retrieve current user information.
 
 **Response:**
+
 ```json
 {
   "id": 1,
@@ -217,6 +226,7 @@ Retrieve current user information.
 Update user profile information.
 
 **Request Body:**
+
 ```json
 {
   "name": "John Doe",
@@ -226,6 +236,7 @@ Update user profile information.
 ```
 
 **Response:**
+
 ```json
 {
   "message": "Profile updated successfully"
@@ -241,10 +252,12 @@ Update user profile information.
 Retrieve applications. For tenants, returns their applications. For managers, returns applications for their properties.
 
 **Query Parameters:**
+
 - `status` (string): Filter by status (Pending, Approved, Denied)
 - `propertyId` (number): Filter by property ID
 
 **Response:**
+
 ```json
 {
   "applications": [
@@ -277,6 +290,7 @@ Retrieve applications. For tenants, returns their applications. For managers, re
 Submit a new application for a property.
 
 **Request Body:**
+
 ```json
 {
   "propertyId": 1,
@@ -288,6 +302,7 @@ Submit a new application for a property.
 ```
 
 **Response:**
+
 ```json
 {
   "id": 1,
@@ -302,6 +317,7 @@ Submit a new application for a property.
 Update application status. Requires manager authentication.
 
 **Request Body:**
+
 ```json
 {
   "status": "Approved"
@@ -309,6 +325,7 @@ Update application status. Requires manager authentication.
 ```
 
 **Response:**
+
 ```json
 {
   "message": "Application status updated successfully"
@@ -324,6 +341,7 @@ Update application status. Requires manager authentication.
 Retrieve leases. For tenants, returns their leases. For managers, returns leases for their properties.
 
 **Response:**
+
 ```json
 {
   "leases": [
@@ -353,6 +371,7 @@ Retrieve leases. For tenants, returns their leases. For managers, returns leases
 Create a new lease agreement. Requires manager authentication.
 
 **Request Body:**
+
 ```json
 {
   "propertyId": 1,
@@ -365,6 +384,7 @@ Create a new lease agreement. Requires manager authentication.
 ```
 
 **Response:**
+
 ```json
 {
   "id": 1,
@@ -381,10 +401,12 @@ Create a new lease agreement. Requires manager authentication.
 Retrieve payments for leases.
 
 **Query Parameters:**
+
 - `leaseId` (number): Filter by lease ID
 - `status` (string): Filter by payment status
 
 **Response:**
+
 ```json
 {
   "payments": [
@@ -413,6 +435,7 @@ Retrieve payments for leases.
 Create a new payment record.
 
 **Request Body:**
+
 ```json
 {
   "leaseId": 1,
@@ -425,6 +448,7 @@ Create a new payment record.
 ```
 
 **Response:**
+
 ```json
 {
   "id": 1,
@@ -441,6 +465,7 @@ Create a new payment record.
 Advanced property search with multiple filters.
 
 **Query Parameters:**
+
 - `location` (string): Location search
 - `priceMin` (number): Minimum price
 - `priceMax` (number): Maximum price
@@ -457,6 +482,7 @@ Advanced property search with multiple filters.
 - `radius` (number): Search radius in miles
 
 **Response:**
+
 ```json
 {
   "properties": [...],
@@ -475,6 +501,7 @@ Advanced property search with multiple filters.
 Get analytics data for property managers.
 
 **Response:**
+
 ```json
 {
   "totalProperties": 10,
@@ -512,6 +539,7 @@ Get analytics data for property managers.
 Convert address to coordinates.
 
 **Request Body:**
+
 ```json
 {
   "address": "123 Main St, Los Angeles, CA 90210"
@@ -519,6 +547,7 @@ Convert address to coordinates.
 ```
 
 **Response:**
+
 ```json
 {
   "latitude": 34.0522,
@@ -533,11 +562,13 @@ Convert address to coordinates.
 Find properties near a location.
 
 **Query Parameters:**
+
 - `latitude` (number): Latitude
 - `longitude` (number): Longitude
 - `radius` (number): Search radius in miles
 
 **Response:**
+
 ```json
 {
   "properties": [...],
@@ -554,6 +585,7 @@ Find properties near a location.
 Upload images for a property.
 
 **Request Body:**
+
 ```
 Content-Type: multipart/form-data
 
@@ -562,6 +594,7 @@ propertyId: 1
 ```
 
 **Response:**
+
 ```json
 {
   "urls": [
@@ -653,10 +686,12 @@ X-RateLimit-Reset: 1642234567
 List endpoints support pagination:
 
 **Query Parameters:**
+
 - `page` (number): Page number (default: 1)
 - `limit` (number): Items per page (default: 10, max: 100)
 
 **Response Headers:**
+
 ```
 X-Total-Count: 150
 X-Page-Count: 15
@@ -666,6 +701,7 @@ X-Current-Page: 1
 ## 📊 Data Types
 
 ### Property Types
+
 - `Rooms`
 - `Tinyhouse`
 - `Apartment`
@@ -674,17 +710,20 @@ X-Current-Page: 1
 - `Cottage`
 
 ### Application Status
+
 - `Pending`
 - `Approved`
 - `Denied`
 
 ### Payment Status
+
 - `Pending`
 - `Paid`
 - `PartiallyPaid`
 - `Overdue`
 
 ### Amenities
+
 - `WasherDryer`
 - `AirConditioning`
 - `Dishwasher`
@@ -700,6 +739,7 @@ X-Current-Page: 1
 - `WiFi`
 
 ### Highlights
+
 - `HighSpeedInternetAccess`
 - `WasherDryer`
 - `AirConditioning`
@@ -724,24 +764,24 @@ X-Current-Page: 1
 // Get properties
 const response = await fetch('/api/properties', {
   headers: {
-    'Authorization': `Bearer ${token}`
-  }
+    Authorization: `Bearer ${token}`,
+  },
 });
 
 // Create application
 const application = await fetch('/api/applications', {
   method: 'POST',
   headers: {
-    'Authorization': `Bearer ${token}`,
-    'Content-Type': 'application/json'
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
   },
   body: JSON.stringify({
     propertyId: 1,
     name: 'John Doe',
     email: 'john@example.com',
     phoneNumber: '+1234567890',
-    message: 'I\'m interested in this property'
-  })
+    message: "I'm interested in this property",
+  }),
 });
 ```
 
@@ -763,10 +803,11 @@ curl -X POST \
 ## 📞 Support
 
 For API support:
+
 - Check the error responses for specific issues
 - Review the request/response examples
 - Contact the development team for additional help
 
 ---
 
-**Note**: This API documentation is for version 1.0. All endpoints are subject to change in future versions. 
+**Note**: This API documentation is for version 1.0. All endpoints are subject to change in future versions.

--- a/server/src/routes/property-routes.ts
+++ b/server/src/routes/property-routes.ts
@@ -1,47 +1,34 @@
-import express from "express";
+import express from 'express';
 import {
   getProperties,
   getProperty,
   createProperty,
   updateProperty,
   deleteProperty,
-} from "../controllers/property-controllers";
-import multer from "multer";
-import { authMiddleware } from "../middleware/auth-middleware";
-import { ALLOWED_MIME_TYPES, MAX_FILE_SIZE } from "../utils/s3-upload";
+} from '../controllers/property-controllers';
+import multer from 'multer';
+import { authMiddleware } from '../middleware/auth-middleware';
+import { ALLOWED_MIME_TYPES, MAX_FILE_SIZE } from '../utils/s3-upload';
 
 const storage = multer.memoryStorage();
 const upload = multer({
-  storage: storage,
+  storage,
   limits: { fileSize: MAX_FILE_SIZE },
   fileFilter: (_req, file, cb) => {
     if (ALLOWED_MIME_TYPES.includes(file.mimetype)) {
       cb(null, true);
     } else {
-      cb(new Error("Invalid file type"));
+      cb(new Error(`Invalid file type: ${file.mimetype}`));
     }
   },
 });
 
 const router = express.Router();
 
-router.get("/", getProperties);
-router.get("/:id", getProperty);
-router.post(
-  "/",
-  authMiddleware(["manager"]),
-  upload.array("photos"),
-  createProperty
-);
-router.put(
-  "/:id",
-  authMiddleware(["manager"]),
-  updateProperty
-);
-router.delete(
-  "/:id",
-  authMiddleware(["manager"]),
-  deleteProperty
-);
+router.get('/', getProperties);
+router.get('/:id', getProperty);
+router.post('/', authMiddleware(['manager']), upload.array('photos'), createProperty);
+router.put('/:id', authMiddleware(['manager']), updateProperty);
+router.delete('/:id', authMiddleware(['manager']), deleteProperty);
 
 export default router;

--- a/server/src/utils/s3-upload.ts
+++ b/server/src/utils/s3-upload.ts
@@ -1,24 +1,15 @@
-import type { Express } from "express";
-import { S3Client } from "@aws-sdk/client-s3";
-import { Upload } from "@aws-sdk/lib-storage";
-import {
-  AWS_REGION,
-  S3_BUCKET_NAME,
-  AWS_ACCESS_KEY_ID,
-  AWS_SECRET_ACCESS_KEY,
-} from "../env";
+import type { Express } from 'express';
+import { S3Client } from '@aws-sdk/client-s3';
+import { Upload } from '@aws-sdk/lib-storage';
+import { AWS_REGION, S3_BUCKET_NAME, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY } from '../env';
 
-export const ALLOWED_MIME_TYPES = [
-  "image/jpeg",
-  "image/png",
-  "image/webp",
-];
+// Only allow common image formats to prevent unexpected data uploads
+export const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png'] as const;
 
-export const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+// 5MB per file
+export const MAX_FILE_SIZE = 5 * 1024 * 1024;
 
-export const uploadFilesToS3 = async (
-  files: Express.Multer.File[],
-): Promise<string[]> => {
+export const uploadFilesToS3 = async (files: Express.Multer.File[]): Promise<string[]> => {
   files.forEach((file) => {
     if (!ALLOWED_MIME_TYPES.includes(file.mimetype)) {
       throw new Error(`Unsupported file type: ${file.mimetype}`);
@@ -51,7 +42,7 @@ export const uploadFilesToS3 = async (
       }).done();
 
       return uploadResult.Location as string;
-    })
+    }),
   );
 };
 


### PR DESCRIPTION
## Summary
- restrict S3 uploads to JPEG/PNG images and 5MB max file size
- configure property routes to reject disallowed or oversized photos via Multer
- document allowed image types and size limit in API docs

## Testing
- `npm test` *(fails: SyntaxError in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_689c185fd5448328a71cd9b55c36d110