### PR TITLE
feat: select jwt algorithm based on config

### DIFF
--- a/server/src/__tests__/auth-middleware.test.ts
+++ b/server/src/__tests__/auth-middleware.test.ts
@@ -57,6 +57,34 @@ describe('authMiddleware', () => {
     expect(res.status).toBe(200);
   });
 
+  it('rejects HS256 token when public key is provided', async () => {
+    const { publicKey } = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    setCommonEnv();
+    process.env.COGNITO_JWT_PUBLIC_KEY = publicKey;
+
+    const { authMiddleware } = require('../middleware/auth-middleware');
+
+    const token = jwt.sign({ sub: 'user1', 'custom:role': 'admin' }, 'wrong-secret', {
+      algorithm: 'HS256',
+      audience: process.env.COGNITO_AUDIENCE,
+      issuer: process.env.COGNITO_ISSUER,
+    });
+
+    const app = express();
+    app.get('/protected', authMiddleware(['admin']), (_req, res) => {
+      res.json({ ok: true });
+    });
+
+    const res = await request(app).get('/protected').set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(401);
+  });
+
   it('verifies token using HS256 when secret is provided', async () => {
     setCommonEnv();
     process.env.JWT_SECRET = 'supersecret';
@@ -77,5 +105,33 @@ describe('authMiddleware', () => {
     const res = await request(app).get('/protected').set('Authorization', `Bearer ${token}`);
 
     expect(res.status).toBe(200);
+  });
+
+  it('rejects RS256 token when secret is provided', async () => {
+    const { privateKey } = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    setCommonEnv();
+    process.env.JWT_SECRET = 'supersecret';
+
+    const { authMiddleware } = require('../middleware/auth-middleware');
+
+    const token = jwt.sign({ sub: 'user1', 'custom:role': 'admin' }, privateKey, {
+      algorithm: 'RS256',
+      audience: process.env.COGNITO_AUDIENCE,
+      issuer: process.env.COGNITO_ISSUER,
+    });
+
+    const app = express();
+    app.get('/protected', authMiddleware(['admin']), (_req, res) => {
+      res.json({ ok: true });
+    });
+
+    const res = await request(app).get('/protected').set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(401);
   });
 });

--- a/server/src/middleware/auth-middleware.ts
+++ b/server/src/middleware/auth-middleware.ts
@@ -28,10 +28,11 @@ export const authMiddleware = (allowedRoles: string[]) => {
     }
 
     try {
-      const secretOrKey = COGNITO_JWT_PUBLIC_KEY || JWT_SECRET || '';
-      const algorithms = COGNITO_JWT_PUBLIC_KEY ? ['RS256'] : ['HS256'];
+      const hasPublicKey = Boolean(COGNITO_JWT_PUBLIC_KEY);
+      const secretOrKey = hasPublicKey ? COGNITO_JWT_PUBLIC_KEY : JWT_SECRET;
+      const algorithms = hasPublicKey ? ['RS256'] : ['HS256'];
 
-      const decoded = jwt.verify(token, secretOrKey, {
+      const decoded = jwt.verify(token, secretOrKey as string, {
         algorithms,
         audience: COGNITO_AUDIENCE,
         issuer: COGNITO_ISSUER,


### PR DESCRIPTION
## Summary
- Choose RS256 when `COGNITO_JWT_PUBLIC_KEY` is set, otherwise use HS256
- Cover RS256 and HS256 verification paths, including invalid algorithm cases

## Testing
- `npx prettier src/middleware/auth-middleware.ts src/__tests__/auth-middleware.test.ts --check`
- `npx jest src/__tests__/auth-middleware.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689c185f32388328a2c71c2482e1c0c3