### PR TITLE
Clean up duplicate imports in server controllers

### DIFF
--- a/server/src/controllers/manager-controllers.ts
+++ b/server/src/controllers/manager-controllers.ts
@@ -1,15 +1,12 @@
-import { Request, Response, NextFunction } from "express";
-import { createUserSchema, updateUserSchema } from "../validators/user-validators";
-import { formatLocation } from "../utils/format-location";
-import prisma from "../utils/prisma";
-import { createUserSchema, updateUserSchema } from "../validators/user-validators";
-import { formatLocation } from "../utils/format-location";
-
+import { Request, Response, NextFunction } from 'express';
+import { createUserSchema, updateUserSchema } from '../validators/user-validators';
+import { formatLocation } from '../utils/format-location';
+import prisma from '../utils/prisma';
 
 export const getManager = async (
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ): Promise<void> => {
   try {
     const { cognitoId } = req.params;
@@ -20,7 +17,7 @@ export const getManager = async (
     if (manager) {
       res.json(manager);
     } else {
-      res.status(404).json({ message: "Manager not found" });
+      res.status(404).json({ message: 'Manager not found' });
     }
   } catch (error) {
     next(error);
@@ -30,7 +27,7 @@ export const getManager = async (
 export const createManager = async (
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ): Promise<void> => {
   try {
     const parsed = createUserSchema.safeParse(req.body);
@@ -58,7 +55,7 @@ export const createManager = async (
 export const updateManager = async (
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ): Promise<void> => {
   try {
     const { cognitoId } = req.params;
@@ -87,7 +84,7 @@ export const updateManager = async (
 export const getManagerProperties = async (
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ): Promise<void> => {
   try {
     const { cognitoId } = req.params;
@@ -100,9 +97,7 @@ export const getManagerProperties = async (
 
     const propertiesWithFormattedLocation = await Promise.all(
       properties.map(async (property) => {
-        const { longitude, latitude } = await formatLocation(
-          property.location.id
-        );
+        const { longitude, latitude } = await formatLocation(property.location.id);
 
         return {
           ...property,
@@ -114,7 +109,7 @@ export const getManagerProperties = async (
             },
           },
         };
-      })
+      }),
     );
 
     res.json(propertiesWithFormattedLocation);

--- a/server/src/controllers/tenant-controllers.ts
+++ b/server/src/controllers/tenant-controllers.ts
@@ -1,16 +1,9 @@
-import { Request, Response, NextFunction } from "express";
-import { createUserSchema, updateUserSchema } from "../validators/user-validators";
-import { formatLocation } from "../utils/format-location";
-import prisma from "../utils/prisma";
-import { createUserSchema, updateUserSchema } from "../validators/user-validators";
-import { formatLocation } from "../utils/format-location";
+import { Request, Response, NextFunction } from 'express';
+import { createUserSchema, updateUserSchema } from '../validators/user-validators';
+import { formatLocation } from '../utils/format-location';
+import prisma from '../utils/prisma';
 
-
-export const getTenant = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<void> => {
+export const getTenant = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
     const { cognitoId } = req.params;
     const tenant = await prisma.tenant.findUnique({
@@ -23,7 +16,7 @@ export const getTenant = async (
     if (tenant) {
       res.json(tenant);
     } else {
-      res.status(404).json({ message: "Tenant not found" });
+      res.status(404).json({ message: 'Tenant not found' });
     }
   } catch (error) {
     next(error);
@@ -33,7 +26,7 @@ export const getTenant = async (
 export const createTenant = async (
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ): Promise<void> => {
   try {
     const parsed = createUserSchema.safeParse(req.body);
@@ -61,7 +54,7 @@ export const createTenant = async (
 export const updateTenant = async (
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ): Promise<void> => {
   try {
     const { cognitoId } = req.params;
@@ -90,7 +83,7 @@ export const updateTenant = async (
 export const getCurrentResidences = async (
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ): Promise<void> => {
   try {
     const { cognitoId } = req.params;
@@ -103,9 +96,7 @@ export const getCurrentResidences = async (
 
     const residencesWithFormattedLocation = await Promise.all(
       properties.map(async (property) => {
-        const { longitude, latitude } = await formatLocation(
-          property.location.id
-        );
+        const { longitude, latitude } = await formatLocation(property.location.id);
 
         return {
           ...property,
@@ -117,7 +108,7 @@ export const getCurrentResidences = async (
             },
           },
         };
-      })
+      }),
     );
 
     res.json(residencesWithFormattedLocation);
@@ -129,7 +120,7 @@ export const getCurrentResidences = async (
 export const addFavoriteProperty = async (
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ): Promise<void> => {
   try {
     const { cognitoId, propertyId } = req.params;
@@ -139,7 +130,7 @@ export const addFavoriteProperty = async (
     });
 
     if (!tenant) {
-      res.status(404).json({ message: "Tenant not found" });
+      res.status(404).json({ message: 'Tenant not found' });
       return;
     }
 
@@ -158,7 +149,7 @@ export const addFavoriteProperty = async (
       });
       res.json(updatedTenant);
     } else {
-      res.status(409).json({ message: "Property already added as favorite" });
+      res.status(409).json({ message: 'Property already added as favorite' });
     }
   } catch (error) {
     next(error);
@@ -168,7 +159,7 @@ export const addFavoriteProperty = async (
 export const removeFavoriteProperty = async (
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ): Promise<void> => {
   try {
     const { cognitoId, propertyId } = req.params;


### PR DESCRIPTION
## Summary
- remove duplicate schema and utility imports from tenant controllers
- delete redundant imports from manager controllers

## Testing
- `npm test` *(fails: SyntaxError in src/__tests__/property-search.test.ts and src/utils/__tests__/env.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689c2e1ce4cc832896769bfb2d815dac