### PR TITLE
Ensure property ownership on updates and deletes

### DIFF
--- a/server/src/__tests__/property.test.ts
+++ b/server/src/__tests__/property.test.ts
@@ -199,6 +199,10 @@ describe("Property API", () => {
       .fn()
       .mockResolvedValue({ id: 1, name: "Updated Property" });
     mockPrisma.property.update.mockImplementation(updateMock);
+    mockPrisma.property.findUnique.mockResolvedValue({
+      id: 1,
+      managerCognitoId: "manager",
+    });
 
     const res = await request(app)
       .put("/properties/1")
@@ -213,16 +217,36 @@ describe("Property API", () => {
   });
 
   it("returns 404 when updating missing property", async () => {
-    mockPrisma.property.update.mockRejectedValue({ code: "P2025" });
+    mockPrisma.property.findUnique.mockResolvedValue(null);
+    mockPrisma.property.update.mockImplementation(jest.fn());
 
     const res = await request(app)
       .put("/properties/999")
       .send({ name: "Updated Property" });
     expect(res.status).toBe(404);
     expect(res.body).toEqual({ message: "Property not found" });
+    expect(mockPrisma.property.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when updating property not owned by user", async () => {
+    mockPrisma.property.findUnique.mockResolvedValue({
+      id: 1,
+      managerCognitoId: "other",
+    });
+
+    const res = await request(app)
+      .put("/properties/1")
+      .send({ name: "Updated Property" });
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ message: "Forbidden" });
+    expect(mockPrisma.property.update).not.toHaveBeenCalled();
   });
 
   it("deletes property", async () => {
+    mockPrisma.property.findUnique.mockResolvedValue({
+      id: 1,
+      managerCognitoId: "manager",
+    });
     mockPrisma.property.delete.mockResolvedValue({});
 
     const res = await request(app).delete("/properties/1");
@@ -234,11 +258,25 @@ describe("Property API", () => {
   });
 
   it("returns 404 when deleting missing property", async () => {
-    mockPrisma.property.delete.mockRejectedValue({ code: "P2025" });
+    mockPrisma.property.findUnique.mockResolvedValue(null);
+    mockPrisma.property.delete.mockImplementation(jest.fn());
 
     const res = await request(app).delete("/properties/999");
     expect(res.status).toBe(404);
     expect(res.body).toEqual({ message: "Property not found" });
+    expect(mockPrisma.property.delete).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when deleting property not owned by user", async () => {
+    mockPrisma.property.findUnique.mockResolvedValue({
+      id: 1,
+      managerCognitoId: "other",
+    });
+
+    const res = await request(app).delete("/properties/1");
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ message: "Forbidden" });
+    expect(mockPrisma.property.delete).not.toHaveBeenCalled();
   });
 });
 

--- a/server/src/controllers/property-controllers.ts
+++ b/server/src/controllers/property-controllers.ts
@@ -272,6 +272,26 @@ export const updateProperty = async (
       return;
     }
 
+    const managerCognitoId = req.user?.id;
+    if (!managerCognitoId) {
+      res.status(401).json({ message: "Unauthorized" });
+      return;
+    }
+
+    const property = await prisma.property.findUnique({
+      where: { id: Number(id) },
+    });
+
+    if (!property) {
+      res.status(404).json({ message: "Property not found" });
+      return;
+    }
+
+    if (property.managerCognitoId !== managerCognitoId) {
+      res.status(403).json({ message: "Forbidden" });
+      return;
+    }
+
     const data = parsed.data;
     const updatedProperty = await prisma.property.update({
       where: { id: Number(id) },
@@ -313,6 +333,26 @@ export const deleteProperty = async (
 ): Promise<void> => {
   try {
     const { id } = req.params;
+    const managerCognitoId = req.user?.id;
+    if (!managerCognitoId) {
+      res.status(401).json({ message: "Unauthorized" });
+      return;
+    }
+
+    const property = await prisma.property.findUnique({
+      where: { id: Number(id) },
+    });
+
+    if (!property) {
+      res.status(404).json({ message: "Property not found" });
+      return;
+    }
+
+    if (property.managerCognitoId !== managerCognitoId) {
+      res.status(403).json({ message: "Forbidden" });
+      return;
+    }
+
     await prisma.property.delete({ where: { id: Number(id) } });
     res.json({ message: "Property deleted" });
   } catch (err: any) {


### PR DESCRIPTION
## Summary
- verify property manager matches authenticated user before updating or deleting
- add unit tests for unauthorized update/delete requests

## Testing
- `npm test` *(fails: src/__tests__/property-search.test.ts SyntaxError: Declaration or statement expected, src/utils/__tests__/env.test.ts SyntaxError: ',' expected)*

------
https://chatgpt.com/codex/tasks/task_e_689c2e1fcf448328a8a1d973fb0307df