### PR TITLE
feat: add payment management endpoints

### DIFF
--- a/client/src/state/api.ts
+++ b/client/src/state/api.ts
@@ -305,6 +305,52 @@ export const api = createApi({
       },
     }),
 
+    createPayment: build.mutation<
+      Payment,
+      { leaseId: number } & {
+        amountDue: number;
+        amountPaid: number;
+        dueDate: string | Date;
+        paymentStatus: string;
+      }
+    >({
+      query: ({ leaseId, ...body }) => ({
+        url: `leases/${leaseId}/payments`,
+        method: 'POST',
+        body,
+      }),
+      invalidatesTags: ['Payments'],
+      async onQueryStarted(_, { queryFulfilled }) {
+        await withToast(queryFulfilled, {
+          success: 'Payment created successfully!',
+          error: 'Failed to create payment.',
+        });
+      },
+    }),
+
+    updatePayment: build.mutation<
+      Payment,
+      { paymentId: number } & Partial<{
+        amountDue: number;
+        amountPaid: number;
+        dueDate: string | Date;
+        paymentStatus: string;
+      }>
+    >({
+      query: ({ paymentId, ...body }) => ({
+        url: `leases/payments/${paymentId}`,
+        method: 'PUT',
+        body,
+      }),
+      invalidatesTags: ['Payments'],
+      async onQueryStarted(_, { queryFulfilled }) {
+        await withToast(queryFulfilled, {
+          success: 'Payment updated successfully!',
+          error: 'Failed to update payment.',
+        });
+      },
+    }),
+
     // application related endpoints
     getApplications: build.query<Application[], { userId?: string; userType?: string }>({
       query: (params) => {
@@ -378,6 +424,8 @@ export const {
   useGetLeasesQuery,
   useGetPropertyLeasesQuery,
   useGetPaymentsQuery,
+  useCreatePaymentMutation,
+  useUpdatePaymentMutation,
   useGetApplicationsQuery,
   useUpdateApplicationStatusMutation,
   useCreateApplicationMutation,

--- a/server/src/__tests__/lease-controllers.test.ts
+++ b/server/src/__tests__/lease-controllers.test.ts
@@ -6,7 +6,7 @@ jest.mock("../utils/geocodeAddress", () => ({ geocodeAddress: jest.fn() }));
 
 const mockPrisma = {
   lease: { findMany: jest.fn() },
-  payment: { findMany: jest.fn() },
+  payment: { findMany: jest.fn(), create: jest.fn(), update: jest.fn() },
   $disconnect: jest.fn(),
 };
 
@@ -16,7 +16,12 @@ jest.mock("@prisma/client", () => ({
 }));
 
 import prisma from "../utils/prisma";
-import { getLeases, getLeasePayments } from "../controllers/lease-controllers";
+import {
+  getLeases,
+  getLeasePayments,
+  createPayment,
+  updatePayment,
+} from "../controllers/lease-controllers";
 
 const createMockRes = () => {
   const res: Partial<Response> = {};
@@ -73,6 +78,111 @@ describe("leaseControllers", () => {
     const localNext = jest.fn();
 
     await getLeasePayments(req, res, localNext);
+
+    expect(localNext).toHaveBeenCalled();
+  });
+
+  it("creates payment with valid payload", async () => {
+    mockPrisma.payment.create.mockResolvedValue({ id: 1 });
+    const req = {
+      params: { id: "1" },
+      body: {
+        amountDue: 1000,
+        amountPaid: 500,
+        dueDate: "2024-05-01",
+        paymentStatus: "Pending",
+      },
+    } as unknown as Request;
+    const res = createMockRes();
+
+    await createPayment(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(mockPrisma.payment.create).toHaveBeenCalledWith({
+      data: {
+        amountDue: 1000,
+        amountPaid: 500,
+        dueDate: new Date("2024-05-01"),
+        paymentStatus: "Pending",
+        paymentDate: expect.any(Date),
+        leaseId: 1,
+      },
+    });
+    expect(res.json).toHaveBeenCalledWith({ id: 1 });
+  });
+
+  it("returns 400 for invalid payment payload", async () => {
+    const req = {
+      params: { id: "1" },
+      body: { amountDue: "abc" },
+    } as unknown as Request;
+    const res = createMockRes();
+
+    await createPayment(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockPrisma.payment.create).not.toHaveBeenCalled();
+  });
+
+  it("calls next on create payment error", async () => {
+    mockPrisma.payment.create.mockRejectedValue(new Error("db"));
+    const req = {
+      params: { id: "1" },
+      body: {
+        amountDue: 1000,
+        amountPaid: 500,
+        dueDate: "2024-05-01",
+        paymentStatus: "Pending",
+      },
+    } as unknown as Request;
+    const res = createMockRes();
+    const localNext = jest.fn();
+
+    await createPayment(req, res, localNext);
+
+    expect(localNext).toHaveBeenCalled();
+  });
+
+  it("updates payment with valid payload", async () => {
+    mockPrisma.payment.update.mockResolvedValue({ id: 1 });
+    const req = {
+      params: { paymentId: "1" },
+      body: { amountPaid: 800 },
+    } as unknown as Request;
+    const res = createMockRes();
+
+    await updatePayment(req, res, next);
+
+    expect(mockPrisma.payment.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: { amountPaid: 800 },
+    });
+    expect(res.json).toHaveBeenCalledWith({ id: 1 });
+  });
+
+  it("returns 400 for invalid payment update", async () => {
+    const req = {
+      params: { paymentId: "1" },
+      body: { amountPaid: "abc" },
+    } as unknown as Request;
+    const res = createMockRes();
+
+    await updatePayment(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockPrisma.payment.update).not.toHaveBeenCalled();
+  });
+
+  it("calls next on update payment error", async () => {
+    mockPrisma.payment.update.mockRejectedValue(new Error("db"));
+    const req = {
+      params: { paymentId: "1" },
+      body: { amountPaid: 800 },
+    } as unknown as Request;
+    const res = createMockRes();
+    const localNext = jest.fn();
+
+    await updatePayment(req, res, localNext);
 
     expect(localNext).toHaveBeenCalled();
   });

--- a/server/src/controllers/lease-controllers.ts
+++ b/server/src/controllers/lease-controllers.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from "express";
+import { z } from "zod";
 import prisma from "../utils/prisma";
 
 export const getLeases = async (
@@ -30,6 +31,66 @@ export const getLeasePayments = async (
       where: { leaseId: Number(id) },
     });
     res.json(payments);
+  } catch (error) {
+    next(error);
+  }
+};
+
+const paymentSchema = z.object({
+  amountDue: z.coerce.number(),
+  amountPaid: z.coerce.number(),
+  dueDate: z.coerce.date(),
+  paymentStatus: z.enum(["Pending", "Paid", "PartiallyPaid", "Overdue"]),
+});
+
+const updatePaymentSchema = paymentSchema.partial();
+
+export const createPayment = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const parsed = paymentSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ errors: parsed.error.errors });
+      return;
+    }
+    const { amountDue, amountPaid, dueDate, paymentStatus } = parsed.data;
+    const payment = await prisma.payment.create({
+      data: {
+        amountDue,
+        amountPaid,
+        dueDate,
+        paymentStatus,
+        paymentDate: new Date(),
+        leaseId: Number(id),
+      },
+    });
+    res.status(201).json(payment);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const updatePayment = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const { paymentId } = req.params;
+    const parsed = updatePaymentSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ errors: parsed.error.errors });
+      return;
+    }
+    const updatedPayment = await prisma.payment.update({
+      where: { id: Number(paymentId) },
+      data: parsed.data,
+    });
+    res.json(updatedPayment);
   } catch (error) {
     next(error);
   }

--- a/server/src/routes/lease-routes.ts
+++ b/server/src/routes/lease-routes.ts
@@ -1,6 +1,11 @@
 import express from "express";
 import { authMiddleware } from "../middleware/auth-middleware";
-import { getLeasePayments, getLeases } from "../controllers/lease-controllers";
+import {
+  getLeasePayments,
+  getLeases,
+  createPayment,
+  updatePayment,
+} from "../controllers/lease-controllers";
 
 const router = express.Router();
 
@@ -9,6 +14,16 @@ router.get(
   "/:id/payments",
   authMiddleware(["manager", "tenant"]),
   getLeasePayments
+);
+router.post(
+  "/:id/payments",
+  authMiddleware(["manager"]),
+  createPayment
+);
+router.put(
+  "/payments/:paymentId",
+  authMiddleware(["manager"]),
+  updatePayment
 );
 
 export default router;


### PR DESCRIPTION
## Summary
- add controller logic for creating and updating payments with zod validation
- expose manager-only endpoints for payment creation and update
- add client-side mutations and hooks for payment APIs
- test payment creation and update flows

## Testing
- `npm test` (fails: SyntaxError in src/__tests__/property-search.test.ts, src/utils/__tests__/env.test.ts)
- `npm test` in client (fails: Code style issues found in 107 files. Run Prettier with --write to fix.)

------
https://chatgpt.com/codex/tasks/task_e_689c2e20198083288e033a63e3b6e48a