### PR TITLE
feat: support configurable jwt algorithms

### DIFF
--- a/server/src/__tests__/auth-middleware.test.ts
+++ b/server/src/__tests__/auth-middleware.test.ts
@@ -78,4 +78,33 @@ describe('authMiddleware', () => {
 
     expect(res.status).toBe(200);
   });
+
+  it('prioritizes RS256 when both public key and secret are provided', async () => {
+    const { privateKey, publicKey } = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    setCommonEnv();
+    process.env.COGNITO_JWT_PUBLIC_KEY = publicKey;
+    process.env.JWT_SECRET = 'supersecret';
+
+    const { authMiddleware } = require('../middleware/auth-middleware');
+
+    const token = jwt.sign({ sub: 'user1', 'custom:role': 'admin' }, privateKey, {
+      algorithm: 'RS256',
+      audience: process.env.COGNITO_AUDIENCE,
+      issuer: process.env.COGNITO_ISSUER,
+    });
+
+    const app = express();
+    app.get('/protected', authMiddleware(['admin']), (_req, res) => {
+      res.json({ ok: true });
+    });
+
+    const res = await request(app).get('/protected').set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+  });
 });

--- a/server/src/middleware/auth-middleware.ts
+++ b/server/src/middleware/auth-middleware.ts
@@ -28,8 +28,18 @@ export const authMiddleware = (allowedRoles: string[]) => {
     }
 
     try {
-      const secretOrKey = COGNITO_JWT_PUBLIC_KEY || JWT_SECRET || '';
-      const algorithms = COGNITO_JWT_PUBLIC_KEY ? ['RS256'] : ['HS256'];
+      let secretOrKey: string;
+      let algorithms: jwt.Algorithm[];
+
+      if (COGNITO_JWT_PUBLIC_KEY) {
+        secretOrKey = COGNITO_JWT_PUBLIC_KEY;
+        algorithms = ['RS256'];
+      } else if (JWT_SECRET) {
+        secretOrKey = JWT_SECRET;
+        algorithms = ['HS256'];
+      } else {
+        throw new Error('Missing JWT configuration');
+      }
 
       const decoded = jwt.verify(token, secretOrKey, {
         algorithms,


### PR DESCRIPTION
## Summary
- select RS256 when a Cognito public key is configured and fall back to HS256 when using a shared secret
- add tests for RS256, HS256, and key precedence

## Testing
- `npx jest src/__tests__/auth-middleware.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689c2e206bf883288ba9da8b4a96512e