### PR TITLE
Remove duplicate imports in controllers

### DIFF
--- a/server/src/controllers/manager-controllers.ts
+++ b/server/src/controllers/manager-controllers.ts
@@ -2,8 +2,6 @@ import { Request, Response, NextFunction } from "express";
 import { createUserSchema, updateUserSchema } from "../validators/user-validators";
 import { formatLocation } from "../utils/format-location";
 import prisma from "../utils/prisma";
-import { createUserSchema, updateUserSchema } from "../validators/user-validators";
-import { formatLocation } from "../utils/format-location";
 
 
 export const getManager = async (

--- a/server/src/controllers/tenant-controllers.ts
+++ b/server/src/controllers/tenant-controllers.ts
@@ -2,8 +2,6 @@ import { Request, Response, NextFunction } from "express";
 import { createUserSchema, updateUserSchema } from "../validators/user-validators";
 import { formatLocation } from "../utils/format-location";
 import prisma from "../utils/prisma";
-import { createUserSchema, updateUserSchema } from "../validators/user-validators";
-import { formatLocation } from "../utils/format-location";
 
 
 export const getTenant = async (


### PR DESCRIPTION
## Summary
- remove repeated imports for user schema validators and location formatter in tenant and manager controllers

## Testing
- `npm test` *(fails: SyntaxError in property-search.test.ts and env.test.ts)*
- `npm run build` *(fails: TypeScript errors in test files)*

------
https://chatgpt.com/codex/tasks/task_e_689c889b7b28832891fef9f569e18ded