### PR TITLE
Enforce property ownership on updates and deletes

### DIFF
--- a/server/src/__tests__/property.test.ts
+++ b/server/src/__tests__/property.test.ts
@@ -1,15 +1,14 @@
-import request from "supertest";
-import express from "express";
+import request from 'supertest';
+import express from 'express';
 
 // mocks must be defined before imports that use them
-jest.mock("../utils/s3-upload", () => ({
+jest.mock('../utils/s3-upload', () => ({
   uploadFilesToS3: jest.fn().mockResolvedValue([]),
 }));
 
-jest.mock("../utils/geocode-address", () => ({
+jest.mock('../utils/geocode-address', () => ({
   geocodeAddress: jest.fn().mockResolvedValue([0, 0]),
 }));
-
 
 const mockPrisma = {
   property: {
@@ -22,49 +21,49 @@ const mockPrisma = {
   $disconnect: jest.fn(),
 };
 
-jest.mock("@prisma/client", () => ({
+jest.mock('@prisma/client', () => ({
   PrismaClient: jest.fn(() => mockPrisma),
   Prisma: { join: jest.fn() },
 }));
 
-process.env.DATABASE_URL = "postgres://test";
-process.env.GEOCODE_USER_AGENT = "test";
-process.env.COGNITO_AUDIENCE = "test";
-process.env.COGNITO_ISSUER = "test";
-process.env.AWS_REGION = "test";
-process.env.S3_BUCKET_NAME = "test";
-process.env.AWS_ACCESS_KEY_ID = "test";
-process.env.AWS_SECRET_ACCESS_KEY = "test";
-process.env.JWT_SECRET = "test";
+process.env.DATABASE_URL = 'postgres://test';
+process.env.GEOCODE_USER_AGENT = 'test';
+process.env.COGNITO_AUDIENCE = 'test';
+process.env.COGNITO_ISSUER = 'test';
+process.env.AWS_REGION = 'test';
+process.env.S3_BUCKET_NAME = 'test';
+process.env.AWS_ACCESS_KEY_ID = 'test';
+process.env.AWS_SECRET_ACCESS_KEY = 'test';
+process.env.JWT_SECRET = 'test';
 
-const propertyRoutes = require("../routes/property-routes").default;
+const propertyRoutes = require('../routes/property-routes').default;
 const {
   createProperty,
   updateProperty,
   deleteProperty,
-} = require("../controllers/property-controllers");
-const prisma = require("../utils/prisma").default;
+} = require('../controllers/property-controllers');
+const prisma = require('../utils/prisma').default;
 
 const app = express();
 app.use(express.json());
 // custom route to bypass file upload middleware and simulate auth
-app.post("/properties", (req, res, next) => {
+app.post('/properties', (req, res, next) => {
   (req as any).files = [];
-  (req as any).user = { id: "manager", role: "manager" };
+  (req as any).user = { id: 'manager', role: 'manager' };
   createProperty(req, res, next);
 });
-app.put("/properties/:id", (req, res, next) => {
-  (req as any).user = { id: "manager", role: "manager" };
+app.put('/properties/:id', (req, res, next) => {
+  (req as any).user = { id: 'manager', role: 'manager' };
   updateProperty(req, res, next);
 });
-app.delete("/properties/:id", (req, res, next) => {
-  (req as any).user = { id: "manager", role: "manager" };
+app.delete('/properties/:id', (req, res, next) => {
+  (req as any).user = { id: 'manager', role: 'manager' };
   deleteProperty(req, res, next);
 });
 // other property routes
-app.use("/properties", propertyRoutes);
+app.use('/properties', propertyRoutes);
 
-describe("Property API", () => {
+describe('Property API', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
     await prisma.property.deleteMany();
@@ -74,171 +73,192 @@ describe("Property API", () => {
     await prisma.$disconnect();
   });
 
-  it("returns 404 for missing property", async () => {
+  it('returns 404 for missing property', async () => {
     mockPrisma.property.findUnique.mockResolvedValue(null);
-    const res = await request(app).get("/properties/9999");
+    const res = await request(app).get('/properties/9999');
     expect(res.status).toBe(404);
-    expect(res.body).toEqual({ message: "Property not found" });
+    expect(res.body).toEqual({ message: 'Property not found' });
   });
 
-  it("creates property with valid payload", async () => {
+  it('creates property with valid payload', async () => {
     const propertyCreateMock = jest.fn().mockResolvedValue({
       id: 1,
-      name: "My Property",
+      name: 'My Property',
       locationId: 1,
-      managerCognitoId: "manager",
+      managerCognitoId: 'manager',
       location: {},
       manager: {},
     });
 
     mockPrisma.$transaction.mockImplementation(async (cb: any) => {
       const tx = {
-        $queryRaw: jest
-          .fn()
-          .mockResolvedValue([
-            {
-              id: 1,
-              address: "123",
-              city: "Town",
-              state: "ST",
-              country: "USA",
-              postalCode: "00000",
-              coordinates: "",
-            },
-          ]),
+        $queryRaw: jest.fn().mockResolvedValue([
+          {
+            id: 1,
+            address: '123',
+            city: 'Town',
+            state: 'ST',
+            country: 'USA',
+            postalCode: '00000',
+            coordinates: '',
+          },
+        ]),
         property: { create: propertyCreateMock },
       };
       return cb(tx);
     });
 
     const payload = {
-      address: "123 Main St",
-      city: "Townsville",
-      state: "TS",
-      country: "USA",
-      postalCode: "12345",
-      name: "My Property",
-      description: "Nice place",
-      pricePerMonth: "1000",
-      securityDeposit: "500",
-      applicationFee: "50",
-      beds: "2",
-      baths: "1",
-      squareFeet: "900",
-      propertyType: "Apartment",
+      address: '123 Main St',
+      city: 'Townsville',
+      state: 'TS',
+      country: 'USA',
+      postalCode: '12345',
+      name: 'My Property',
+      description: 'Nice place',
+      pricePerMonth: '1000',
+      securityDeposit: '500',
+      applicationFee: '50',
+      beds: '2',
+      baths: '1',
+      squareFeet: '900',
+      propertyType: 'Apartment',
     };
 
-    const res = await request(app).post("/properties").send(payload);
+    const res = await request(app).post('/properties').send(payload);
     expect(res.status).toBe(201);
     expect(mockPrisma.$transaction).toHaveBeenCalled();
     expect(propertyCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ managerCognitoId: "manager" }),
-      })
+        data: expect.objectContaining({ managerCognitoId: 'manager' }),
+      }),
     );
   });
 
-  it("returns 400 for invalid payload", async () => {
+  it('returns 400 for invalid payload', async () => {
     const invalidPayload = {
-      address: "123 Main St",
-      city: "Townsville",
-      state: "TS",
-      country: "USA",
-      postalCode: "12345",
+      address: '123 Main St',
+      city: 'Townsville',
+      state: 'TS',
+      country: 'USA',
+      postalCode: '12345',
       // name missing
-      description: "Nice place",
-      pricePerMonth: "1000",
-      securityDeposit: "500",
-      applicationFee: "50",
-      beds: "2",
-      baths: "1",
-      squareFeet: "900",
-      propertyType: "Apartment",
+      description: 'Nice place',
+      pricePerMonth: '1000',
+      securityDeposit: '500',
+      applicationFee: '50',
+      beds: '2',
+      baths: '1',
+      squareFeet: '900',
+      propertyType: 'Apartment',
     };
 
-    const res = await request(app).post("/properties").send(invalidPayload);
+    const res = await request(app).post('/properties').send(invalidPayload);
     expect(res.status).toBe(400);
     expect(mockPrisma.$transaction).not.toHaveBeenCalled();
   });
 
-  it.each([
-    "pricePerMonth",
-    "securityDeposit",
-    "applicationFee",
-    "beds",
-    "baths",
-    "squareFeet",
-  ])("returns 400 when %s is invalid", async (field) => {
-    const payload: any = {
-      address: "123 Main St",
-      city: "Townsville",
-      state: "TS",
-      country: "USA",
-      postalCode: "12345",
-      managerCognitoId: "manager",
-      name: "My Property",
-      description: "Nice place",
-      pricePerMonth: "1000",
-      securityDeposit: "500",
-      applicationFee: "50",
-      beds: "2",
-      baths: "1",
-      squareFeet: "900",
-      propertyType: "Apartment",
-    };
+  it.each(['pricePerMonth', 'securityDeposit', 'applicationFee', 'beds', 'baths', 'squareFeet'])(
+    'returns 400 when %s is invalid',
+    async (field) => {
+      const payload: any = {
+        address: '123 Main St',
+        city: 'Townsville',
+        state: 'TS',
+        country: 'USA',
+        postalCode: '12345',
+        managerCognitoId: 'manager',
+        name: 'My Property',
+        description: 'Nice place',
+        pricePerMonth: '1000',
+        securityDeposit: '500',
+        applicationFee: '50',
+        beds: '2',
+        baths: '1',
+        squareFeet: '900',
+        propertyType: 'Apartment',
+      };
 
-    payload[field] = "invalid";
+      payload[field] = 'invalid';
 
-    const res = await request(app).post("/properties").send(payload);
-    expect(res.status).toBe(400);
-    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
-  });
+      const res = await request(app).post('/properties').send(payload);
+      expect(res.status).toBe(400);
+      expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+    },
+  );
 
-  it("updates property with valid payload", async () => {
-    const updateMock = jest
-      .fn()
-      .mockResolvedValue({ id: 1, name: "Updated Property" });
+  it('updates property with valid payload', async () => {
+    mockPrisma.property.findUnique.mockResolvedValue({
+      id: 1,
+      managerCognitoId: 'manager',
+    });
+    const updateMock = jest.fn().mockResolvedValue({ id: 1, name: 'Updated Property' });
     mockPrisma.property.update.mockImplementation(updateMock);
 
-    const res = await request(app)
-      .put("/properties/1")
-      .send({ name: "Updated Property" });
+    const res = await request(app).put('/properties/1').send({ name: 'Updated Property' });
     expect(res.status).toBe(200);
     expect(updateMock).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { id: 1 },
-        data: expect.objectContaining({ name: "Updated Property" }),
-      })
+        data: expect.objectContaining({ name: 'Updated Property' }),
+      }),
     );
   });
 
-  it("returns 404 when updating missing property", async () => {
-    mockPrisma.property.update.mockRejectedValue({ code: "P2025" });
+  it('returns 403 when updating property not owned by user', async () => {
+    mockPrisma.property.findUnique.mockResolvedValue({
+      id: 1,
+      managerCognitoId: 'other',
+    });
 
-    const res = await request(app)
-      .put("/properties/999")
-      .send({ name: "Updated Property" });
-    expect(res.status).toBe(404);
-    expect(res.body).toEqual({ message: "Property not found" });
+    const res = await request(app).put('/properties/1').send({ name: 'Updated Property' });
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ message: 'Forbidden' });
+    expect(mockPrisma.property.update).not.toHaveBeenCalled();
   });
 
-  it("deletes property", async () => {
+  it('returns 404 when updating missing property', async () => {
+    mockPrisma.property.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).put('/properties/999').send({ name: 'Updated Property' });
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ message: 'Property not found' });
+    expect(mockPrisma.property.update).not.toHaveBeenCalled();
+  });
+
+  it('deletes property', async () => {
+    mockPrisma.property.findUnique.mockResolvedValue({
+      id: 1,
+      managerCognitoId: 'manager',
+    });
     mockPrisma.property.delete.mockResolvedValue({});
 
-    const res = await request(app).delete("/properties/1");
+    const res = await request(app).delete('/properties/1');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ message: "Property deleted" });
+    expect(res.body).toEqual({ message: 'Property deleted' });
     expect(mockPrisma.property.delete).toHaveBeenCalledWith({
       where: { id: 1 },
     });
   });
 
-  it("returns 404 when deleting missing property", async () => {
-    mockPrisma.property.delete.mockRejectedValue({ code: "P2025" });
+  it('returns 403 when deleting property not owned by user', async () => {
+    mockPrisma.property.findUnique.mockResolvedValue({
+      id: 1,
+      managerCognitoId: 'other',
+    });
 
-    const res = await request(app).delete("/properties/999");
+    const res = await request(app).delete('/properties/1');
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ message: 'Forbidden' });
+    expect(mockPrisma.property.delete).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when deleting missing property', async () => {
+    mockPrisma.property.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).delete('/properties/999');
     expect(res.status).toBe(404);
-    expect(res.body).toEqual({ message: "Property not found" });
+    expect(res.body).toEqual({ message: 'Property not found' });
+    expect(mockPrisma.property.delete).not.toHaveBeenCalled();
   });
 });
-

--- a/server/src/controllers/property-controllers.ts
+++ b/server/src/controllers/property-controllers.ts
@@ -1,11 +1,11 @@
-import { Request, Response, NextFunction } from "express";
-import { Prisma, Location } from "@prisma/client";
-import { buildPropertyFilters } from "../utils/build-property-filters";
-import { formatLocation } from "../utils/format-location";
-import { uploadFilesToS3 } from "../utils/s3-upload";
-import { geocodeAddress } from "../utils/geocode-address";
-import { z } from "zod";
-import prisma from "../utils/prisma";
+import { Request, Response, NextFunction } from 'express';
+import { Prisma, Location } from '@prisma/client';
+import { buildPropertyFilters } from '../utils/build-property-filters';
+import { formatLocation } from '../utils/format-location';
+import { uploadFilesToS3 } from '../utils/s3-upload';
+import { geocodeAddress } from '../utils/geocode-address';
+import { z } from 'zod';
+import prisma from '../utils/prisma';
 
 const createPropertySchema = z.object({
   address: z.string(),
@@ -48,7 +48,7 @@ const updatePropertySchema = z.object({
 export const getProperties = async (
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ): Promise<void> => {
   try {
     const {
@@ -122,7 +122,7 @@ export const getProperties = async (
         coordsResults.map((c) => [
           c.id,
           { longitude: Number(c.longitude), latitude: Number(c.latitude) },
-        ])
+        ]),
       );
     }
 
@@ -142,7 +142,7 @@ export const getProperties = async (
 export const getProperty = async (
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ): Promise<void> => {
   try {
     const { id } = req.params;
@@ -154,9 +154,7 @@ export const getProperty = async (
     });
 
     if (property) {
-      const { longitude, latitude } = await formatLocation(
-        property.location.id
-      );
+      const { longitude, latitude } = await formatLocation(property.location.id);
 
       const propertyWithCoordinates = {
         ...property,
@@ -170,7 +168,7 @@ export const getProperty = async (
       };
       res.json(propertyWithCoordinates);
     } else {
-      res.status(404).json({ message: "Property not found" });
+      res.status(404).json({ message: 'Property not found' });
     }
   } catch (err) {
     next(err);
@@ -180,7 +178,7 @@ export const getProperty = async (
 export const createProperty = async (
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ): Promise<void> => {
   try {
     const files = req.files as Express.Multer.File[];
@@ -193,27 +191,15 @@ export const createProperty = async (
 
     const managerCognitoId = req.user?.id;
     if (!managerCognitoId) {
-      res.status(401).json({ message: "Unauthorized" });
+      res.status(401).json({ message: 'Unauthorized' });
       return;
     }
 
-    const {
-      address,
-      city,
-      state,
-      country,
-      postalCode,
-      ...propertyData
-    } = parsed.data;
+    const { address, city, state, country, postalCode, ...propertyData } = parsed.data;
 
     const photoUrls = await uploadFilesToS3(files);
 
-    const [longitude, latitude] = await geocodeAddress(
-      address,
-      city,
-      country,
-      postalCode,
-    );
+    const [longitude, latitude] = await geocodeAddress(address, city, country, postalCode);
 
     const newProperty = await prisma.$transaction(async (tx) => {
       const [location] = await tx.$queryRaw<Location[]>`
@@ -230,15 +216,11 @@ export const createProperty = async (
           locationId: location.id,
           managerCognitoId,
           amenities:
-            typeof propertyData.amenities === "string"
-              ? propertyData.amenities.split(",")
-              : [],
+            typeof propertyData.amenities === 'string' ? propertyData.amenities.split(',') : [],
           highlights:
-            typeof propertyData.highlights === "string"
-              ? propertyData.highlights.split(",")
-              : [],
-          isPetsAllowed: propertyData.isPetsAllowed === "true",
-          isParkingIncluded: propertyData.isParkingIncluded === "true",
+            typeof propertyData.highlights === 'string' ? propertyData.highlights.split(',') : [],
+          isPetsAllowed: propertyData.isPetsAllowed === 'true',
+          isParkingIncluded: propertyData.isParkingIncluded === 'true',
           pricePerMonth: propertyData.pricePerMonth,
           securityDeposit: propertyData.securityDeposit,
           applicationFee: propertyData.applicationFee,
@@ -262,10 +244,21 @@ export const createProperty = async (
 export const updateProperty = async (
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ): Promise<void> => {
   try {
     const { id } = req.params;
+    const property = await prisma.property.findUnique({
+      where: { id: Number(id) },
+    });
+    if (!property) {
+      res.status(404).json({ message: 'Property not found' });
+      return;
+    }
+    if (property.managerCognitoId !== req.user?.id) {
+      res.status(403).json({ message: 'Forbidden' });
+      return;
+    }
     const parsed = updatePropertySchema.safeParse(req.body);
     if (!parsed.success) {
       res.status(400).json({ errors: parsed.error.flatten() });
@@ -277,29 +270,19 @@ export const updateProperty = async (
       where: { id: Number(id) },
       data: {
         ...data,
-        amenities:
-          typeof data.amenities === "string"
-            ? data.amenities.split(",")
-            : data.amenities,
+        amenities: typeof data.amenities === 'string' ? data.amenities.split(',') : data.amenities,
         highlights:
-          typeof data.highlights === "string"
-            ? data.highlights.split(",")
-            : data.highlights,
-        isPetsAllowed:
-          data.isPetsAllowed === undefined
-            ? undefined
-            : data.isPetsAllowed === "true",
+          typeof data.highlights === 'string' ? data.highlights.split(',') : data.highlights,
+        isPetsAllowed: data.isPetsAllowed === undefined ? undefined : data.isPetsAllowed === 'true',
         isParkingIncluded:
-          data.isParkingIncluded === undefined
-            ? undefined
-            : data.isParkingIncluded === "true",
+          data.isParkingIncluded === undefined ? undefined : data.isParkingIncluded === 'true',
       },
     });
 
     res.json(updatedProperty);
   } catch (err: any) {
-    if (err?.code === "P2025") {
-      res.status(404).json({ message: "Property not found" });
+    if (err?.code === 'P2025') {
+      res.status(404).json({ message: 'Property not found' });
     } else {
       next(err);
     }
@@ -309,15 +292,26 @@ export const updateProperty = async (
 export const deleteProperty = async (
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ): Promise<void> => {
   try {
     const { id } = req.params;
+    const property = await prisma.property.findUnique({
+      where: { id: Number(id) },
+    });
+    if (!property) {
+      res.status(404).json({ message: 'Property not found' });
+      return;
+    }
+    if (property.managerCognitoId !== req.user?.id) {
+      res.status(403).json({ message: 'Forbidden' });
+      return;
+    }
     await prisma.property.delete({ where: { id: Number(id) } });
-    res.json({ message: "Property deleted" });
+    res.json({ message: 'Property deleted' });
   } catch (err: any) {
-    if (err?.code === "P2025") {
-      res.status(404).json({ message: "Property not found" });
+    if (err?.code === 'P2025') {
+      res.status(404).json({ message: 'Property not found' });
     } else {
       next(err);
     }


### PR DESCRIPTION
## Summary
- require property manager match authenticated user before updating or deleting
- test that non-owners receive 403 on update/delete

## Testing
- `npm test` *(fails: Prettier parse errors in existing tests)*
- `npx jest src/__tests__/property.test.ts`
- `npx prettier --check src/controllers/property-controllers.ts src/__tests__/property.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689c889bde9c83288c5283159fefa9f4