### PR TITLE
refactor application workflow

### DIFF
--- a/server/src/__tests__/application-controllers.test.ts
+++ b/server/src/__tests__/application-controllers.test.ts
@@ -67,41 +67,36 @@ describe("applicationControllers", () => {
     );
   });
 
-  it("creates application when property exists", async () => {
-    mockPrisma.property.findUnique.mockResolvedValue({
-      pricePerMonth: 1000,
-      securityDeposit: 500,
-    });
+    it("creates application when property exists", async () => {
+      mockPrisma.property.findUnique.mockResolvedValue({ id: 1 });
+      mockPrisma.application.create.mockResolvedValue({
+        id: 1,
+        property: {},
+        tenant: {},
+        lease: null,
+      });
 
-    mockPrisma.$transaction.mockImplementation(async (cb: any) => {
-      const tx = {
-        lease: { create: jest.fn().mockResolvedValue({ id: 1 }) },
-        application: {
-          create: jest.fn().mockResolvedValue({ id: 1, property: {}, tenant: {}, lease: {} }),
+      const req = {
+        body: {
+          applicationDate: new Date().toISOString(),
+          status: "PENDING",
+          propertyId: 1,
+          tenantCognitoId: "t1",
+          name: "n",
+          email: "e@example.com",
+          phoneNumber: "p",
+          message: "m",
         },
-      };
-      return cb(tx);
+      } as unknown as Request;
+      const res = createMockRes();
+
+      await createApplication(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalled();
+      expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+      expect(mockPrisma.lease.create).not.toHaveBeenCalled();
     });
-
-    const req = {
-      body: {
-        applicationDate: new Date().toISOString(),
-        status: "PENDING",
-        propertyId: 1,
-        tenantCognitoId: "t1",
-        name: "n",
-        email: "e@example.com",
-        phoneNumber: "p",
-        message: "m",
-      },
-    } as unknown as Request;
-    const res = createMockRes();
-
-    await createApplication(req, res, next);
-
-    expect(res.status).toHaveBeenCalledWith(201);
-    expect(res.json).toHaveBeenCalled();
-  });
 
   it("returns 404 when property missing", async () => {
     mockPrisma.property.findUnique.mockResolvedValue(null);

--- a/server/src/controllers/application-controllers.ts
+++ b/server/src/controllers/application-controllers.ts
@@ -118,7 +118,7 @@ export const createApplication = async (
 
     const property = await prisma.property.findUnique({
       where: { id: propertyId },
-      select: { pricePerMonth: true, securityDeposit: true },
+      select: { id: true },
     });
 
     if (!property) {
@@ -126,52 +126,26 @@ export const createApplication = async (
       return;
     }
 
-    const newApplication = await prisma.$transaction(async (prisma) => {
-      // Create lease first
-      const lease = await prisma.lease.create({
-        data: {
-          startDate: new Date(), // Today
-          endDate: new Date(
-            new Date().setFullYear(new Date().getFullYear() + 1)
-          ), // 1 year from today
-          rent: property.pricePerMonth,
-          deposit: property.securityDeposit,
-          property: {
-            connect: { id: propertyId },
-          },
-          tenant: {
-            connect: { cognitoId: tenantCognitoId },
-          },
+    const newApplication = await prisma.application.create({
+      data: {
+        applicationDate: new Date(applicationDate),
+        status,
+        name,
+        email,
+        phoneNumber,
+        message,
+        property: {
+          connect: { id: propertyId },
         },
-      });
-
-      // Then create application with lease connection
-      const application = await prisma.application.create({
-        data: {
-          applicationDate: new Date(applicationDate),
-          status,
-          name,
-          email,
-          phoneNumber,
-          message,
-          property: {
-            connect: { id: propertyId },
-          },
-          tenant: {
-            connect: { cognitoId: tenantCognitoId },
-          },
-          lease: {
-            connect: { id: lease.id },
-          },
+        tenant: {
+          connect: { cognitoId: tenantCognitoId },
         },
-        include: {
-          property: true,
-          tenant: true,
-          lease: true,
-        },
-      });
-
-      return application;
+      },
+      include: {
+        property: true,
+        tenant: true,
+        lease: true,
+      },
     });
 
     res.status(201).json(newApplication);

--- a/server/src/services/application-service.ts
+++ b/server/src/services/application-service.ts
@@ -16,39 +16,41 @@ export const updateApplicationStatus = async (
   }
 
   return prisma.$transaction(async (tx) => {
-    if (status === "Approved") {
-      const lease = await tx.lease.create({
-        data: {
-          startDate: new Date(),
-          endDate: new Date(new Date().setFullYear(new Date().getFullYear() + 1)),
-          rent: application.property.pricePerMonth,
-          deposit: application.property.securityDeposit,
-          propertyId: application.propertyId,
-          tenantCognitoId: application.tenantCognitoId,
-        },
-      });
-
-      await tx.property.update({
-        where: { id: application.propertyId },
-        data: {
-          tenants: {
-            connect: { cognitoId: application.tenantCognitoId },
+      if (status === "Approved" && application.status !== "Approved") {
+        const lease = await tx.lease.create({
+          data: {
+            startDate: new Date(),
+            endDate: new Date(
+              new Date().setFullYear(new Date().getFullYear() + 1)
+            ),
+            rent: application.property.pricePerMonth,
+            deposit: application.property.securityDeposit,
+            propertyId: application.propertyId,
+            tenantCognitoId: application.tenantCognitoId,
           },
-        },
-      });
+        });
 
+        await tx.property.update({
+          where: { id: application.propertyId },
+          data: {
+            tenants: {
+              connect: { cognitoId: application.tenantCognitoId },
+            },
+          },
+        });
+
+        return tx.application.update({
+          where: { id },
+          data: { status, leaseId: lease.id },
+          include: { property: true, tenant: true, lease: true },
+        });
+      }
+
+      // For statuses other than transitioning to Approved, simply update the status
       return tx.application.update({
         where: { id },
-        data: { status, leaseId: lease.id },
+        data: { status },
         include: { property: true, tenant: true, lease: true },
       });
-    }
-
-    // For statuses other than Approved, simply update the status
-    return tx.application.update({
-      where: { id },
-      data: { status },
-      include: { property: true, tenant: true, lease: true },
     });
-  });
-};
+  };


### PR DESCRIPTION
## Summary
- persist applications without creating leases upfront
- create lease only when application status transitions to Approved
- adjust controller tests for updated workflow

## Testing
- `npm test` *(fails: SyntaxError in property-search.test.ts, env.test.ts)*
- `npx jest src/__tests__/application-controllers.test.ts --runTestsByPath`

------
https://chatgpt.com/codex/tasks/task_e_689c889cba348328a6021c6502053df9