### PR TITLE
feat: add payment creation and update flows

### DIFF
--- a/client/src/state/api.ts
+++ b/client/src/state/api.ts
@@ -309,7 +309,12 @@ export const api = createApi({
 
     createPayment: build.mutation<
       Payment,
-
+      { leaseId: number } & Pick<Payment, 'amountDue' | 'amountPaid'>
+    >({
+      query: ({ leaseId, ...payment }) => ({
+        url: `leases/${leaseId}/payments`,
+        method: 'POST',
+        body: payment,
       }),
       invalidatesTags: ['Payments'],
       async onQueryStarted(_, { queryFulfilled }) {
@@ -322,9 +327,12 @@ export const api = createApi({
 
     updatePayment: build.mutation<
       Payment,
-
-      
-      
+      { paymentId: number } & Partial<Pick<Payment, 'amountDue' | 'amountPaid'>>
+    >({
+      query: ({ paymentId, ...payment }) => ({
+        url: `payments/${paymentId}`,
+        method: 'PUT',
+        body: payment,
       }),
       invalidatesTags: ['Payments'],
       async onQueryStarted(_, { queryFulfilled }) {

--- a/server/src/__tests__/lease-controllers.test.ts
+++ b/server/src/__tests__/lease-controllers.test.ts
@@ -16,12 +16,7 @@ jest.mock("@prisma/client", () => ({
 }));
 
 import prisma from "../utils/prisma";
-import {
-  getLeases,
-  getLeasePayments,
-  createPayment,
-  updatePayment,
-} from "../controllers/lease-controllers";
+import { getLeases, getLeasePayments } from "../controllers/lease-controllers";
 
 const createMockRes = () => {
   const res: Partial<Response> = {};
@@ -81,35 +76,4 @@ describe("leaseControllers", () => {
 
     expect(localNext).toHaveBeenCalled();
   });
-
-
-    const res = createMockRes();
-
-    await createPayment(req, res, next);
-
-
-    } as unknown as Request;
-    const res = createMockRes();
-
-    await createPayment(req, res, next);
-
-    expect(res.status).toHaveBeenCalledWith(400);
-
-    } as unknown as Request;
-    const res = createMockRes();
-
-    await updatePayment(req, res, next);
-
-    expect(mockPrisma.payment.update).toHaveBeenCalledWith({
-      where: { id: 1 },
-
-    } as unknown as Request;
-    const res = createMockRes();
-
-    await updatePayment(req, res, next);
-
-    expect(res.status).toHaveBeenCalledWith(400);
-
-  });
 });
-

--- a/server/src/__tests__/payment.test.ts
+++ b/server/src/__tests__/payment.test.ts
@@ -1,0 +1,96 @@
+import { Request, Response, NextFunction } from "express";
+import { PaymentStatus } from "@prisma/client";
+
+const mockPrisma = {
+  payment: {
+    create: jest.fn(),
+    update: jest.fn(),
+    findUnique: jest.fn(),
+  },
+  $disconnect: jest.fn(),
+};
+
+jest.mock("@prisma/client", () => ({
+  PrismaClient: jest.fn(() => mockPrisma),
+  PaymentStatus: {
+    Paid: "Paid",
+    PartiallyPaid: "PartiallyPaid",
+    Pending: "Pending",
+  },
+}));
+
+import { createPayment, updatePayment } from "../controllers/lease-controllers";
+
+const createMockRes = () => {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res as Response;
+};
+
+describe("payment controllers", () => {
+  const next: NextFunction = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates a payment", async () => {
+    mockPrisma.payment.create.mockResolvedValue({ id: 1 });
+    const req = {
+      params: { id: "1" },
+      body: { amountDue: 1000, amountPaid: 500 },
+    } as unknown as Request;
+    const res = createMockRes();
+
+    await createPayment(req, res, next);
+
+    expect(mockPrisma.payment.create).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({ id: 1 });
+  });
+
+  it("returns 400 when creating payment with invalid data", async () => {
+    const req = {
+      params: { id: "1" },
+      body: { amountDue: "bad" },
+    } as unknown as Request;
+    const res = createMockRes();
+
+    await createPayment(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockPrisma.payment.create).not.toHaveBeenCalled();
+  });
+
+  it("updates a payment", async () => {
+    mockPrisma.payment.findUnique.mockResolvedValue({ amountDue: 1000, amountPaid: 0 });
+    mockPrisma.payment.update.mockResolvedValue({ id: 1 });
+    const req = {
+      params: { paymentId: "1" },
+      body: { amountPaid: 1000 },
+    } as unknown as Request;
+    const res = createMockRes();
+
+    await updatePayment(req, res, next);
+
+    expect(mockPrisma.payment.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: { amountPaid: 1000, paymentStatus: PaymentStatus.Paid },
+    });
+    expect(res.json).toHaveBeenCalledWith({ id: 1 });
+  });
+
+  it("returns 400 when updating payment with invalid data", async () => {
+    const req = {
+      params: { paymentId: "1" },
+      body: { amountPaid: "bad" },
+    } as unknown as Request;
+    const res = createMockRes();
+
+    await updatePayment(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockPrisma.payment.update).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/controllers/lease-controllers.ts
+++ b/server/src/controllers/lease-controllers.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import { z } from "zod";
+import { PaymentStatus } from "@prisma/client";
 import prisma from "../utils/prisma";
 
 export const getLeases = async (
@@ -53,6 +54,28 @@ export const createPayment = async (
     const { id } = req.params;
     const parsed = paymentSchema.safeParse(req.body);
     if (!parsed.success) {
+      res.status(400).json({ errors: parsed.error.flatten() });
+      return;
+    }
+
+    const { amountDue, amountPaid } = parsed.data;
+    const paymentStatus =
+      amountPaid >= amountDue
+        ? PaymentStatus.Paid
+        : amountPaid > 0
+          ? PaymentStatus.PartiallyPaid
+          : PaymentStatus.Pending;
+
+    const payment = await prisma.payment.create({
+      data: {
+        leaseId: Number(id),
+        amountDue,
+        amountPaid,
+        dueDate: new Date(),
+        paymentDate: new Date(),
+        paymentStatus,
+      },
+    });
 
     res.status(201).json(payment);
   } catch (error) {
@@ -69,7 +92,35 @@ export const updatePayment = async (
     const { paymentId } = req.params;
     const parsed = updatePaymentSchema.safeParse(req.body);
     if (!parsed.success) {
+      res.status(400).json({ errors: parsed.error.flatten() });
+      return;
+    }
 
+    const existing = await prisma.payment.findUnique({
+      where: { id: Number(paymentId) },
+    });
 
+    if (!existing) {
+      res.status(404).json({ message: "Payment not found" });
+      return;
+    }
+
+    const amountDue = parsed.data.amountDue ?? existing.amountDue;
+    const amountPaid = parsed.data.amountPaid ?? existing.amountPaid;
+    const paymentStatus =
+      amountPaid >= amountDue
+        ? PaymentStatus.Paid
+        : amountPaid > 0
+          ? PaymentStatus.PartiallyPaid
+          : PaymentStatus.Pending;
+
+    const payment = await prisma.payment.update({
+      where: { id: Number(paymentId) },
+      data: { ...parsed.data, paymentStatus },
+    });
+
+    res.json(payment);
+  } catch (error) {
+    next(error);
   }
 };


### PR DESCRIPTION
## Summary
- implement server-side payment creation and updates with validation and status logic
- add client RTK Query mutations for creating and updating payments
- cover payment flows with unit tests

## Testing
- `npx jest src/__tests__/payment.test.ts`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_689cc2c1131c8328bd664a3f23179be4