### PR TITLE
Create lease on approved application

### DIFF
--- a/server/src/__tests__/application-controllers.test.ts
+++ b/server/src/__tests__/application-controllers.test.ts
@@ -11,7 +11,7 @@ jest.mock('../services/application-service', () => ({
 const mockPrisma = {
   application: { findMany: jest.fn(), create: jest.fn() },
   property: { findUnique: jest.fn() },
-  lease: { findFirst: jest.fn() },
+  lease: { findFirst: jest.fn(), create: jest.fn() },
   tenant: {},
   $disconnect: jest.fn(),
 };
@@ -66,11 +66,35 @@ describe('applicationControllers', () => {
     );
   });
 
+  it('creates application without creating a lease', async () => {
+    mockPrisma.property.findUnique.mockResolvedValue({});
+    mockPrisma.application.create.mockResolvedValue({
+      id: 1,
+      applicationDate: new Date('2023-01-01'),
+      status: 'PENDING',
+      property: {},
+      tenant: {},
+    });
 
+    const req = {
+      body: {
+        applicationDate: new Date('2023-01-01').toISOString(),
+        status: 'PENDING',
+        propertyId: 1,
+        tenantCognitoId: 't1',
+        name: 'n',
+        email: 'e@example.com',
+        phoneNumber: 'p',
+      },
+    } as unknown as Request;
+    const res = createMockRes();
 
-      await createApplication(req, res, next);
+    await createApplication(req, res, next);
 
-
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(mockPrisma.application.create).toHaveBeenCalled();
+    expect(mockPrisma.lease.create).not.toHaveBeenCalled();
+  });
 
   it('returns 404 when property missing', async () => {
     mockPrisma.property.findUnique.mockResolvedValue(null);

--- a/server/src/controllers/application-controllers.ts
+++ b/server/src/controllers/application-controllers.ts
@@ -144,7 +144,6 @@ export const createApplication = async (
       include: {
         property: true,
         tenant: true,
-        lease: true,
       },
     });
 

--- a/server/src/services/application-service.ts
+++ b/server/src/services/application-service.ts
@@ -1,11 +1,18 @@
 import { ApplicationStatus } from '@prisma/client';
 import prisma from '../utils/prisma';
 
-export const updateApplicationStatus = async (id: number, status: ApplicationStatus) => {
-  // Find application along with property and tenant details
+/**
+ * Update an application's status. When transitioning to Approved a lease is created
+ * and the tenant is connected to the property. For any other status change the
+ * application is simply updated.
+ */
+export const updateApplicationStatus = async (
+  id: number,
+  status: ApplicationStatus,
+) => {
   const application = await prisma.application.findUnique({
     where: { id },
-    include: { property: true, tenant: true },
+    include: { property: true, tenant: true, lease: true },
   });
 
   if (!application) {
@@ -13,30 +20,42 @@ export const updateApplicationStatus = async (id: number, status: ApplicationSta
   }
 
   return prisma.$transaction(async (tx) => {
+    let leaseId = application.leaseId ?? undefined;
 
+    if (
+      status === ApplicationStatus.Approved &&
+      application.status !== ApplicationStatus.Approved
+    ) {
+      const startDate = new Date();
+      const endDate = new Date(startDate);
+      endDate.setFullYear(endDate.getFullYear() + 1);
 
-        await tx.property.update({
-          where: { id: application.propertyId },
-          data: {
-            tenants: {
-              connect: { cognitoId: application.tenantCognitoId },
-            },
-          },
-        });
-
-        return tx.application.update({
-          where: { id },
-          data: { status, leaseId: lease.id },
-          include: { property: true, tenant: true, lease: true },
-        });
-      }
-
-      // For statuses other than transitioning to Approved, simply update the status
-      return tx.application.update({
-        where: { id },
-        data: { status },
-        include: { property: true, tenant: true, lease: true },
+      const lease = await tx.lease.create({
+        data: {
+          startDate,
+          endDate,
+          rent: application.property.pricePerMonth,
+          deposit: application.property.securityDeposit,
+          property: { connect: { id: application.propertyId } },
+          tenant: { connect: { cognitoId: application.tenantCognitoId } },
+        },
       });
 
+      leaseId = lease.id;
+
+      await tx.property.update({
+        where: { id: application.propertyId },
+        data: {
+          tenants: { connect: { cognitoId: application.tenantCognitoId } },
+        },
+      });
+    }
+
+    return tx.application.update({
+      where: { id },
+      data: { status, leaseId },
+      include: { property: true, tenant: true, lease: true },
     });
-  };
+  });
+};
+


### PR DESCRIPTION
## Summary
- defer lease creation from application creation, returning only property and tenant
- generate lease when application status transitions to Approved
- update controller tests for new approval lifecycle

## Testing
- `npm test` *(fails: SyntaxError in unrelated files)*
- `npx jest src/__tests__/application-controllers.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689cc2c1790c8328937d2429398392b0