### PR TITLE
Defer lease creation until application approval

### DIFF
--- a/server/src/__tests__/application-controllers.test.ts
+++ b/server/src/__tests__/application-controllers.test.ts
@@ -11,7 +11,7 @@ jest.mock('../services/application-service', () => ({
 const mockPrisma = {
   application: { findMany: jest.fn(), create: jest.fn() },
   property: { findUnique: jest.fn() },
-  lease: { findFirst: jest.fn() },
+  lease: { findFirst: jest.fn(), create: jest.fn() },
   tenant: {},
   $disconnect: jest.fn(),
 };
@@ -66,11 +66,29 @@ describe('applicationControllers', () => {
     );
   });
 
+  it('creates application without creating lease', async () => {
+    mockPrisma.property.findUnique.mockResolvedValue({});
+    mockPrisma.application.create.mockResolvedValue({ id: 1 });
+    const req = {
+      body: {
+        applicationDate: new Date().toISOString(),
+        status: 'PENDING',
+        propertyId: 1,
+        tenantCognitoId: 't1',
+        name: 'n',
+        email: 'e@example.com',
+        phoneNumber: 'p',
+        message: 'm',
+      },
+    } as unknown as Request;
+    const res = createMockRes();
 
+    await createApplication(req, res, next);
 
-      await createApplication(req, res, next);
-
-
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({ id: 1 });
+    expect(mockPrisma.lease.create).not.toHaveBeenCalled();
+  });
 
   it('returns 404 when property missing', async () => {
     mockPrisma.property.findUnique.mockResolvedValue(null);

--- a/server/src/controllers/application-controllers.ts
+++ b/server/src/controllers/application-controllers.ts
@@ -144,7 +144,6 @@ export const createApplication = async (
       include: {
         property: true,
         tenant: true,
-        lease: true,
       },
     });
 

--- a/server/src/services/application-service.ts
+++ b/server/src/services/application-service.ts
@@ -13,30 +13,43 @@ export const updateApplicationStatus = async (id: number, status: ApplicationSta
   }
 
   return prisma.$transaction(async (tx) => {
+    if (
+      application.status !== ApplicationStatus.Approved &&
+      status === ApplicationStatus.Approved
+    ) {
+      const startDate = new Date();
+      const endDate = new Date(startDate);
+      endDate.setFullYear(endDate.getFullYear() + 1);
 
-
-        await tx.property.update({
-          where: { id: application.propertyId },
-          data: {
-            tenants: {
-              connect: { cognitoId: application.tenantCognitoId },
-            },
-          },
-        });
-
-        return tx.application.update({
-          where: { id },
-          data: { status, leaseId: lease.id },
-          include: { property: true, tenant: true, lease: true },
-        });
-      }
-
-      // For statuses other than transitioning to Approved, simply update the status
-      return tx.application.update({
-        where: { id },
-        data: { status },
-        include: { property: true, tenant: true, lease: true },
+      const lease = await tx.lease.create({
+        data: {
+          startDate,
+          endDate,
+          rent: application.property.pricePerMonth,
+          deposit: application.property.securityDeposit,
+          propertyId: application.propertyId,
+          tenantCognitoId: application.tenantCognitoId,
+        },
       });
 
+      await tx.property.update({
+        where: { id: application.propertyId },
+        data: {
+          tenants: { connect: { cognitoId: application.tenantCognitoId } },
+        },
+      });
+
+      return tx.application.update({
+        where: { id },
+        data: { status, leaseId: lease.id },
+        include: { property: true, tenant: true, lease: true },
+      });
+    }
+
+    return tx.application.update({
+      where: { id },
+      data: { status },
+      include: { property: true, tenant: true, lease: true },
     });
-  };
+  });
+};


### PR DESCRIPTION
## Summary
- remove lease association during application creation
- create leases only when application status transitions to Approved
- adjust controller tests for new lifecycle

## Testing
- `npm test` *(fails: SyntaxError: ',' expected)*
- `npx jest src/__tests__/application-controllers.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689cf3edc0a48328867284b3c18d3fba