### PR TITLE
Add authorization checks for property updates and deletions

### DIFF
--- a/server/src/__tests__/property.test.ts
+++ b/server/src/__tests__/property.test.ts
@@ -46,13 +46,20 @@ const prisma = require('../utils/prisma').default;
 
 const app = express();
 app.use(express.json());
-// custom route to bypass file upload middleware and simulate auth
+// custom routes to bypass file upload and auth middleware
 app.post('/properties', (req, res, next) => {
   (req as any).files = [];
   (req as any).user = { id: 'manager', role: 'manager' };
   createProperty(req, res, next);
 });
-
+app.put('/properties/:id', (req, res, next) => {
+  const userId = req.header('X-User-Id') || 'manager';
+  (req as any).user = { id: userId, role: 'manager' };
+  updateProperty(req, res, next);
+});
+app.delete('/properties/:id', (req, res, next) => {
+  const userId = req.header('X-User-Id') || 'manager';
+  (req as any).user = { id: userId, role: 'manager' };
   deleteProperty(req, res, next);
 });
 // other property routes
@@ -182,6 +189,17 @@ describe('Property API', () => {
     },
   );
 
+  it('updates property when authorized', async () => {
+    mockPrisma.property.findUnique.mockResolvedValue({
+      id: 1,
+      managerCognitoId: 'manager',
+    });
+    const updateMock = mockPrisma.property.update.mockResolvedValue({
+      id: 1,
+      name: 'Updated Property',
+    });
+
+    const res = await request(app).put('/properties/1').send({ name: 'Updated Property' });
     expect(res.status).toBe(200);
     expect(updateMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -191,25 +209,52 @@ describe('Property API', () => {
     );
   });
 
-    mockPrisma.property.findUnique.mockResolvedValue(null);
-
-    const res = await request(app).put('/properties/999').send({ name: 'Updated Property' });
-    expect(res.status).toBe(404);
-
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual({ message: 'Property deleted' });
-    expect(mockPrisma.property.delete).toHaveBeenCalledWith({
-      where: { id: 1 },
+  it('returns 403 when updating property not owned by manager', async () => {
+    mockPrisma.property.findUnique.mockResolvedValue({
+      id: 1,
+      managerCognitoId: 'manager',
     });
+
+    const res = await request(app)
+      .put('/properties/1')
+      .set('X-User-Id', 'other')
+      .send({ name: 'Updated Property' });
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ message: 'Forbidden' });
+    expect(mockPrisma.property.update).not.toHaveBeenCalled();
   });
 
+  it('deletes property when authorized', async () => {
+    mockPrisma.property.findUnique.mockResolvedValue({
+      id: 1,
+      managerCognitoId: 'manager',
+    });
 
+    const res = await request(app).delete('/properties/1');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ message: 'Property deleted' });
+    expect(mockPrisma.property.delete).toHaveBeenCalledWith({ where: { id: 1 } });
+  });
+
+  it('returns 403 when deleting property not owned by manager', async () => {
+    mockPrisma.property.findUnique.mockResolvedValue({
+      id: 1,
+      managerCognitoId: 'manager',
+    });
+
+    const res = await request(app)
+      .delete('/properties/1')
+      .set('X-User-Id', 'other');
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ message: 'Forbidden' });
+    expect(mockPrisma.property.delete).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when deleting missing property', async () => {
     mockPrisma.property.findUnique.mockResolvedValue(null);
 
     const res = await request(app).delete('/properties/999');
     expect(res.status).toBe(404);
-
-
     expect(mockPrisma.property.delete).not.toHaveBeenCalled();
   });
 });

--- a/server/src/controllers/property-controllers.ts
+++ b/server/src/controllers/property-controllers.ts
@@ -255,22 +255,36 @@ export const updateProperty = async (
       return;
     }
 
+    const property = await prisma.property.findUnique({ where: { id: Number(id) } });
+    if (!property) {
+      res.status(404).json({ message: 'Property not found' });
+      return;
+    }
+
+    if (property.managerCognitoId !== req.user?.id) {
+      res.status(403).json({ message: 'Forbidden' });
+      return;
+    }
+
     const data = parsed.data;
     const updatedProperty = await prisma.property.update({
       where: { id: Number(id) },
       data: {
         ...data,
-        amenities: typeof data.amenities === 'string' ? data.amenities.split(',') : data.amenities,
+        amenities:
+          typeof data.amenities === 'string' ? data.amenities.split(',') : data.amenities,
         highlights:
           typeof data.highlights === 'string' ? data.highlights.split(',') : data.highlights,
-        isPetsAllowed: data.isPetsAllowed === undefined ? undefined : data.isPetsAllowed === 'true',
+        isPetsAllowed:
+          data.isPetsAllowed === undefined ? undefined : data.isPetsAllowed === 'true',
         isParkingIncluded:
           data.isParkingIncluded === undefined ? undefined : data.isParkingIncluded === 'true',
       },
     });
 
     res.json(updatedProperty);
-
+  } catch (err) {
+    next(err);
   }
 };
 
@@ -282,15 +296,19 @@ export const deleteProperty = async (
   try {
     const { id } = req.params;
 
+    const property = await prisma.property.findUnique({ where: { id: Number(id) } });
+    if (!property) {
+      res.status(404).json({ message: 'Property not found' });
+      return;
     }
 
     if (property.managerCognitoId !== req.user?.id) {
-      res.status(403).json({ message: "Forbidden" });
+      res.status(403).json({ message: 'Forbidden' });
       return;
     }
 
     await prisma.property.delete({ where: { id: Number(id) } });
-    res.json({ message: "Property deleted" });
+    res.json({ message: 'Property deleted' });
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
## Summary
- enforce owner checks and error handling in property update and delete controllers
- add tests for unauthorized property updates and deletions

## Testing
- `npm test` *(fails: SyntaxError in unrelated lease-controllers.test.ts, property-search.test.ts, and others)*

------
https://chatgpt.com/codex/tasks/task_e_689cf4aaf22c8328875b398a0b7d6472