### PR TITLE
Handle lease creation on application approval

### DIFF
--- a/server/src/__tests__/application-controllers.test.ts
+++ b/server/src/__tests__/application-controllers.test.ts
@@ -130,24 +130,61 @@ describe('applicationControllers', () => {
     expect(mockPrisma.property.findUnique).not.toHaveBeenCalled();
   });
 
-  it('updates application status', async () => {
+  it('updates application status to Approved', async () => {
     (updateApplicationStatusService as jest.Mock).mockResolvedValue({ id: 1 });
-    const req = { params: { id: '1' }, body: { status: 'APPROVED' } } as unknown as Request;
+    const req = {
+      params: { id: '1' },
+      body: { status: 'Approved' },
+    } as unknown as Request;
     const res = createMockRes();
 
     await updateApplicationStatus(req, res, next);
 
+    expect(updateApplicationStatusService).toHaveBeenCalledWith(1, 'Approved');
     expect(res.json).toHaveBeenCalledWith({ id: 1 });
+  });
+
+  it('updates application status to non-Approved value', async () => {
+    (updateApplicationStatusService as jest.Mock).mockResolvedValue({ id: 2 });
+    const req = {
+      params: { id: '2' },
+      body: { status: 'Pending' },
+    } as unknown as Request;
+    const res = createMockRes();
+
+    await updateApplicationStatus(req, res, next);
+
+    expect(updateApplicationStatusService).toHaveBeenCalledWith(2, 'Pending');
+    expect(res.json).toHaveBeenCalledWith({ id: 2 });
   });
 
   it('returns 404 when updating missing application', async () => {
     (updateApplicationStatusService as jest.Mock).mockResolvedValue(null);
-    const req = { params: { id: '1' }, body: { status: 'APPROVED' } } as unknown as Request;
+    const req = {
+      params: { id: '1' },
+      body: { status: 'Approved' },
+    } as unknown as Request;
     const res = createMockRes();
 
     await updateApplicationStatus(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(404);
     expect(res.json).toHaveBeenCalledWith({ message: 'Application not found.' });
+  });
+
+  it('calls next on service error', async () => {
+    (updateApplicationStatusService as jest.Mock).mockRejectedValue(
+      new Error('db'),
+    );
+    const req = {
+      params: { id: '1' },
+      body: { status: 'Approved' },
+    } as unknown as Request;
+    const res = createMockRes();
+    const localNext = jest.fn();
+
+    await updateApplicationStatus(req, res, localNext);
+
+    expect(localNext).toHaveBeenCalled();
   });
 });

--- a/server/src/services/application-service.ts
+++ b/server/src/services/application-service.ts
@@ -1,8 +1,10 @@
 import { ApplicationStatus } from '@prisma/client';
 import prisma from '../utils/prisma';
 
-export const updateApplicationStatus = async (id: number, status: ApplicationStatus) => {
-  // Find application along with property and tenant details
+export const updateApplicationStatus = async (
+  id: number,
+  status: ApplicationStatus,
+) => {
   const application = await prisma.application.findUnique({
     where: { id },
     include: { property: true, tenant: true },
@@ -13,30 +15,41 @@ export const updateApplicationStatus = async (id: number, status: ApplicationSta
   }
 
   return prisma.$transaction(async (tx) => {
-
-
-        await tx.property.update({
-          where: { id: application.propertyId },
-          data: {
-            tenants: {
-              connect: { cognitoId: application.tenantCognitoId },
-            },
-          },
-        });
-
-        return tx.application.update({
-          where: { id },
-          data: { status, leaseId: lease.id },
-          include: { property: true, tenant: true, lease: true },
-        });
-      }
-
-      // For statuses other than transitioning to Approved, simply update the status
-      return tx.application.update({
-        where: { id },
-        data: { status },
-        include: { property: true, tenant: true, lease: true },
+    if (status === 'Approved') {
+      const lease = await tx.lease.create({
+        data: {
+          startDate: new Date(),
+          endDate: new Date(
+            new Date().setFullYear(new Date().getFullYear() + 1),
+          ),
+          rent: application.property.pricePerMonth,
+          deposit: application.property.securityDeposit,
+          property: { connect: { id: application.propertyId } },
+          tenant: { connect: { cognitoId: application.tenantCognitoId } },
+          application: { connect: { id: application.id } },
+        },
       });
 
+      await tx.property.update({
+        where: { id: application.propertyId },
+        data: {
+          tenants: {
+            connect: { cognitoId: application.tenantCognitoId },
+          },
+        },
+      });
+
+      return tx.application.update({
+        where: { id },
+        data: { status, leaseId: lease.id },
+        include: { property: true, tenant: true, lease: true },
+      });
+    }
+
+    return tx.application.update({
+      where: { id },
+      data: { status },
+      include: { property: true, tenant: true, lease: true },
     });
-  };
+  });
+};


### PR DESCRIPTION
## Summary
- Create lease and associate tenant & property when application status becomes Approved
- Update application controller tests to cover approval, non-approval, missing record, and error paths

## Testing
- `npm test` *(fails: SyntaxError in existing test files)*
- `npx jest src/__tests__/application-controllers.test.ts` *(fails: Unexpected token due to compilation issues)*

------
https://chatgpt.com/codex/tasks/task_e_689cf4acea188328a82e428de130f6d8