### PR TITLE
feat: implement lease payment endpoints and tests

### DIFF
--- a/server/src/__tests__/payment.test.ts
+++ b/server/src/__tests__/payment.test.ts
@@ -1,0 +1,102 @@
+import request from 'supertest';
+import express from 'express';
+
+const mockPrisma = {
+  payment: {
+    deleteMany: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  },
+  $disconnect: jest.fn(),
+};
+
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn(() => mockPrisma),
+  Prisma: { join: jest.fn() },
+}));
+
+const prisma = require('../utils/prisma').default;
+const { createPayment, updatePayment } = require('../controllers/lease-controllers');
+
+const app = express();
+app.use(express.json());
+
+app.post('/leases/:id/payments', (req, res, next) => {
+  (req as any).user = { id: 'manager', role: 'manager' };
+  createPayment(req, res, next);
+});
+
+app.put('/leases/payments/:paymentId', (req, res, next) => {
+  (req as any).user = { id: 'manager', role: 'manager' };
+  updatePayment(req, res, next);
+});
+
+describe('Payment API', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await prisma.payment.deleteMany();
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it('creates payment with valid payload', async () => {
+    mockPrisma.payment.create.mockResolvedValue({
+      id: 1,
+      amountDue: 100,
+      amountPaid: 50,
+      leaseId: 1,
+    });
+
+    const res = await request(app)
+      .post('/leases/1/payments')
+      .send({ amountDue: 100, amountPaid: 50 });
+
+    expect(res.status).toBe(201);
+    expect(mockPrisma.payment.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        leaseId: 1,
+        amountDue: 100,
+        amountPaid: 50,
+      }),
+    });
+  });
+
+  it('returns 400 when create payload invalid', async () => {
+    const res = await request(app).post('/leases/1/payments').send({ amountDue: 'bad' });
+
+    expect(res.status).toBe(400);
+    expect(mockPrisma.payment.create).not.toHaveBeenCalled();
+  });
+
+  it('updates payment with valid payload', async () => {
+    mockPrisma.payment.update.mockResolvedValue({
+      id: 1,
+      amountDue: 100,
+      amountPaid: 75,
+      leaseId: 1,
+    });
+
+    const res = await request(app).put('/leases/payments/1').send({ amountPaid: 75 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      id: 1,
+      amountDue: 100,
+      amountPaid: 75,
+      leaseId: 1,
+    });
+    expect(mockPrisma.payment.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: { amountPaid: 75 },
+    });
+  });
+
+  it('returns 400 when update payload invalid', async () => {
+    const res = await request(app).put('/leases/payments/1').send({ amountPaid: 'bad' });
+
+    expect(res.status).toBe(400);
+    expect(mockPrisma.payment.update).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/controllers/lease-controllers.ts
+++ b/server/src/controllers/lease-controllers.ts
@@ -1,12 +1,8 @@
-import { Request, Response, NextFunction } from "express";
-import { z } from "zod";
-import prisma from "../utils/prisma";
+import { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import prisma from '../utils/prisma';
 
-export const getLeases = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<void> => {
+export const getLeases = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
     const leases = await prisma.lease.findMany({
       include: {
@@ -23,7 +19,7 @@ export const getLeases = async (
 export const getLeasePayments = async (
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ): Promise<void> => {
   try {
     const { id } = req.params;
@@ -39,7 +35,6 @@ export const getLeasePayments = async (
 const paymentSchema = z.object({
   amountDue: z.coerce.number(),
   amountPaid: z.coerce.number(),
-
 });
 
 const updatePaymentSchema = paymentSchema.partial();
@@ -47,12 +42,30 @@ const updatePaymentSchema = paymentSchema.partial();
 export const createPayment = async (
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ): Promise<void> => {
   try {
     const { id } = req.params;
     const parsed = paymentSchema.safeParse(req.body);
     if (!parsed.success) {
+      res.status(400).json({ errors: parsed.error.errors });
+      return;
+    }
+
+    const { amountDue, amountPaid } = parsed.data;
+    const paymentStatus =
+      amountPaid >= amountDue ? 'Paid' : amountPaid > 0 ? 'PartiallyPaid' : 'Pending';
+
+    const payment = await prisma.payment.create({
+      data: {
+        leaseId: Number(id),
+        amountDue,
+        amountPaid,
+        dueDate: new Date(),
+        paymentDate: new Date(),
+        paymentStatus,
+      },
+    });
 
     res.status(201).json(payment);
   } catch (error) {
@@ -63,13 +76,23 @@ export const createPayment = async (
 export const updatePayment = async (
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ): Promise<void> => {
   try {
     const { paymentId } = req.params;
     const parsed = updatePaymentSchema.safeParse(req.body);
     if (!parsed.success) {
+      res.status(400).json({ errors: parsed.error.errors });
+      return;
+    }
 
+    const payment = await prisma.payment.update({
+      where: { id: Number(paymentId) },
+      data: parsed.data,
+    });
 
+    res.json(payment);
+  } catch (error) {
+    res.status(400).json({ message: 'Failed to update payment' });
   }
 };


### PR DESCRIPTION
## Summary
- implement payment creation with validation for leases
- add payment update handler with validation and error handling
- add route tests for creating and updating lease payments

## Testing
- `npx jest src/__tests__/payment.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689d3f310dc08328a17f965a0956ba91