### PR TITLE
test: add placeholder listing creation test

### DIFF
--- a/client/tests/e2e/specs/listing-creation.spec.ts
+++ b/client/tests/e2e/specs/listing-creation.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Listing creation flow', () => {
-
+  test('placeholder', async () => {
+    expect(true).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- fix listing creation spec to have valid Playwright syntax

## Testing
- `act -j e2e` (fails: Couldn't get a valid docker connection)


------
https://chatgpt.com/codex/tasks/task_e_689d4fe7550883288d6309fd3c5034dc