### PR TITLE
chore: add dependabot config and documentation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /client
+    schedule:
+      interval: daily
+    versioning-strategy: increase
+    open-pull-requests-limit: 10
+  - package-ecosystem: npm
+    directory: /server
+    schedule:
+      interval: daily
+    versioning-strategy: increase
+    open-pull-requests-limit: 10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+Thank you for your interest in contributing to this project!
+
+## Dependabot
+
+We use [Dependabot](https://docs.github.com/github/administering-a-repository/about-dependabot-version-updates) to keep dependencies up to date.
+
+- **Scope**: Dependabot monitors the `client` and `server` directories for npm dependencies.
+- **Schedule**: Checks run daily and open pull requests when updates are available.
+- **Versioning strategy**: The configuration uses `increase`, allowing minor and major version upgrades.
+- **Open PR limit**: Dependabot limits itself to ten open pull requests at a time.
+
+Please review and merge Dependabot pull requests regularly. If an update causes issues, feel free to push commits to the PR or adjust the configuration in `.github/dependabot.yml`.


### PR DESCRIPTION
## Summary
- configure Dependabot for client and server with daily npm checks
- document Dependabot usage in CONTRIBUTING guidelines

## Testing
- `cd server && npm test` *(fails: Error occurred when checking code style in 3 files)*
- `cd client && npm test` *(fails: Error occurred when checking code style in the above file)*

------
https://chatgpt.com/codex/tasks/task_e_689d84b6dfa88328a88a9be60f297b65