### PR TITLE
Add not-found middleware with 404 response and tests

### DIFF
--- a/server/src/__tests__/not-found.test.ts
+++ b/server/src/__tests__/not-found.test.ts
@@ -1,0 +1,20 @@
+import express from 'express';
+import request from 'supertest';
+import { notFound } from '../middleware/not-found';
+import { errorHandler } from '../middleware/error-handler';
+
+describe('notFound middleware', () => {
+  it('returns 404 for unknown routes', async () => {
+    const app = express();
+    app.get('/known', (_req, res) => {
+      res.json({ ok: true });
+    });
+    app.use(notFound);
+    app.use(errorHandler);
+
+    const res = await request(app).get('/unknown');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ message: 'Route not found' });
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,6 +4,7 @@ import helmet from "helmet";
 import morgan from "morgan";
 import { authMiddleware } from "./middleware/auth-middleware";
 import { errorHandler } from "./middleware/error-handler";
+import { notFound } from "./middleware/not-found";
 import env from "./env";
 /* ROUTE IMPORT */
 import tenantRoutes from "./routes/tenant-routes";
@@ -32,6 +33,7 @@ app.use("/leases", leaseRoutes);
 app.use("/tenants", authMiddleware(["tenant"]), tenantRoutes);
 app.use("/managers", authMiddleware(["manager"]), managerRoutes);
 
+app.use(notFound);
 app.use(errorHandler);
 
 /* SERVER */

--- a/server/src/middleware/not-found.ts
+++ b/server/src/middleware/not-found.ts
@@ -1,0 +1,11 @@
+import { Request, Response, NextFunction } from "express";
+
+export const notFound = (
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+): void => {
+  res.status(404).json({ message: "Route not found" });
+};
+
+export default notFound;


### PR DESCRIPTION
## Summary
- implement not-found middleware returning a 404 JSON payload
- register the middleware after routes and before error handler
- test that unknown routes return 404

## Testing
- `npm test` *(fails: SyntaxError: 'catch' or 'finally' expected in existing repository files)*
- `npx jest src/__tests__/not-found.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689d84b3f2c08328b308a373c20602bf