### PR TITLE
docs: add contributing guidelines and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,79 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at opensource@enterprise-garage-sale.app. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing
+
+Thank you for considering contributing to the Enterprise Garage Sale App! This document outlines the process for getting your changes into the project.
+
+## Branching
+
+- Start from the latest `main` branch.
+- Create a feature branch with a descriptive name:
+  ```bash
+  git checkout -b feature/short-description
+  ```
+- Keep your branch up to date by regularly rebasing or merging from `main`.
+
+## Commit Messages
+
+- Make small, focused commits.
+- Write clear, imperative commit messages, e.g. `feat: add property search filter`.
+- Reference related issues when applicable.
+
+## Testing
+
+Before opening a pull request, ensure all tests pass.
+
+```bash
+# Client tests
+cd client
+npm test
+npm run test:e2e
+
+# Server tests
+cd ../server
+npm test
+```
+
+Refer to [TESTING.md](TESTING.md) for more details on the testing strategy.
+
+## Pull Requests
+
+- Push your branch to your fork and open a pull request against `main`.
+- Provide a clear description of the problem and solution.
+- Ensure your code adheres to project conventions and passes all checks.
+
+We appreciate your contributions and thank you for helping to improve the project!

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ The server requires the following environment variables. Copy `.env.example` and
 
 The application is designed for AWS deployment using services such as Cognito for authentication and S3 for asset storage. Refer to [DEPLOYMENT.md](DEPLOYMENT.md) for step-by-step production guidance.
 
+## Contributing
+
+We welcome community contributions! Please read the [CONTRIBUTING.md](CONTRIBUTING.md) guide for information on branching, committing, and running tests. By participating in this project you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
 ## Further Reading
 
 - [API Documentation](API_DOCUMENTATION.md)


### PR DESCRIPTION
## Summary
- add CONTRIBUTING.md with branching, commit, and test instructions
- add CODE_OF_CONDUCT.md based on Contributor Covenant v2.1
- link contributing and conduct docs from README

## Testing
- `cd client && npm test` *(fails: src/state/api.ts syntax error)*
- `cd server && npm test` *(fails: syntax errors in tests and controllers)*

------
https://chatgpt.com/codex/tasks/task_e_689d7bbbbd7c83289400dc0cd7287e46