### PR TITLE
Add dependency lint jobs to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,24 @@ jobs:
           cd client
           npm test
 
+  client-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: client/package-lock.json
+      - name: Install dependencies
+        run: |
+          cd client
+          npm ci
+      - name: Lint client dependencies
+        run: |
+          cd client
+          npm run lint:deps
+
   server-lint:
     runs-on: ubuntu-latest
     steps:
@@ -84,6 +102,24 @@ jobs:
           cd server
           npm test
 
+  server-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: server/package-lock.json
+      - name: Install dependencies
+        run: |
+          cd server
+          npm ci
+      - name: Lint server dependencies
+        run: |
+          cd server
+          npm run lint:deps
+
   e2e:
     runs-on: ubuntu-latest
     steps:
@@ -115,7 +151,7 @@ jobs:
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: [client-lint, client-test, server-lint, server-test, e2e]
+    needs: [client-lint, client-test, client-deps, server-lint, server-test, server-deps, e2e]
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary
- add client-deps job to run `npm run lint:deps`
- add server-deps job to run `npm run lint:deps`
- require dependency lint jobs before deploy

## Testing
- `npm ci` (client)
- `npm run lint:deps` (client)
- `npm run lint:deps` (server, expected failure: Missing script)`

------
https://chatgpt.com/codex/tasks/task_e_689d77a9cbf4832892ea8380df008a44