### PR TITLE
refactor: centralize API URL configuration

### DIFF
--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -1,0 +1,1 @@
+export const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,7 +1,6 @@
 import axios from 'axios';
 import { Property } from '@/types/prisma-types';
-
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+import { API_URL } from '@/config';
 
 const api = axios.create({
   baseURL: API_URL,

--- a/client/src/state/api.ts
+++ b/client/src/state/api.ts
@@ -3,8 +3,7 @@ import { Application, Lease, Manager, Payment, Property, Tenant } from '@/types/
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { fetchAuthSession, getCurrentUser } from 'aws-amplify/auth';
 import { FiltersState } from '.';
-
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+import { API_URL } from '@/config';
 
 export const api = createApi({
   baseQuery: fetchBaseQuery({

--- a/client/tests/payments.mutations.test.ts
+++ b/client/tests/payments.mutations.test.ts
@@ -18,8 +18,7 @@ jest.mock('@/lib/utils', () => ({
 
 const { api } = require('@/state/api');
 const { withToast } = require('@/lib/utils');
-
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+const { API_URL } = require('@/config');
 
 const setupStore = () =>
   configureStore({


### PR DESCRIPTION
## Summary
- centralize API_URL constant in `client/src/config.ts`
- import shared API_URL in client lib, state modules, and payments mutation tests

## Testing
- `npm test` *(fails: src/state/api.ts:325:7 - error TS1005: '>' expected)*

------
https://chatgpt.com/codex/tasks/task_e_689d77a56c8c83289cc63db33046cbad