### PR TITLE
feat: centralize client env configuration

### DIFF
--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import "./src/env";
 
 const nextConfig: NextConfig = {
   images: {

--- a/client/src/app/(auth)/auth-provider.tsx
+++ b/client/src/app/(auth)/auth-provider.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect } from "react";
 import { Amplify } from "aws-amplify";
+import { env } from "@/env";
 import {
   Authenticator,
   Heading,
@@ -17,9 +18,8 @@ import { useRouter, usePathname } from "next/navigation";
 Amplify.configure({
   Auth: {
     Cognito: {
-      userPoolId: process.env.NEXT_PUBLIC_AWS_COGNITO_USER_POOL_ID!,
-      userPoolClientId:
-        process.env.NEXT_PUBLIC_AWS_COGNITO_USER_POOL_CLIENT_ID!,
+      userPoolId: env.NEXT_PUBLIC_AWS_COGNITO_USER_POOL_ID,
+      userPoolClientId: env.NEXT_PUBLIC_AWS_COGNITO_USER_POOL_CLIENT_ID,
     },
   },
 });

--- a/client/src/app/(nondashboard)/landing/hero-section.tsx
+++ b/client/src/app/(nondashboard)/landing/hero-section.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { useDispatch } from "react-redux";
 import { useRouter } from "next/navigation";
 import { setFilters } from "@/state";
+import { env } from "@/env";
 
 const HeroSection = () => {
   const dispatch = useDispatch();
@@ -22,9 +23,7 @@ const HeroSection = () => {
       const response = await fetch(
         `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(
           trimmedQuery
-        )}.json?access_token=${
-          process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
-        }&fuzzyMatch=true`
+        )}.json?access_token=${env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN}&fuzzyMatch=true`
       );
       const data = await response.json();
       if (data.features && data.features.length > 0) {

--- a/client/src/app/(nondashboard)/search/[id]/property-location.tsx
+++ b/client/src/app/(nondashboard)/search/[id]/property-location.tsx
@@ -3,8 +3,9 @@ import { Compass, MapPin } from "lucide-react";
 import mapboxgl from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
 import React, { useEffect, useRef } from "react";
+import { env } from "@/env";
 
-mapboxgl.accessToken = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN as string;
+mapboxgl.accessToken = env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN as string;
 
 const PropertyLocation = ({ propertyId }: PropertyDetailsProps) => {
   const {

--- a/client/src/app/(nondashboard)/search/filters-bar.tsx
+++ b/client/src/app/(nondashboard)/search/filters-bar.tsx
@@ -21,6 +21,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { PropertyTypeIcons } from "@/lib/constants";
+import { env } from "@/env";
 
 const FiltersBar = () => {
   const dispatch = useDispatch();
@@ -77,9 +78,7 @@ const FiltersBar = () => {
       const response = await fetch(
         `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(
           searchInput
-        )}.json?access_token=${
-          process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
-        }&fuzzyMatch=true`
+        )}.json?access_token=${env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN}&fuzzyMatch=true`
       );
       const data = await response.json();
       if (data.features && data.features.length > 0) {

--- a/client/src/app/(nondashboard)/search/filters-full.tsx
+++ b/client/src/app/(nondashboard)/search/filters-full.tsx
@@ -18,6 +18,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Label } from "@/components/ui/label";
+import { env } from "@/env";
 
 const FiltersFull = () => {
   const dispatch = useDispatch();
@@ -68,9 +69,7 @@ const FiltersFull = () => {
       const response = await fetch(
         `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(
           localFilters.location
-        )}.json?access_token=${
-          process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
-        }&fuzzyMatch=true`
+        )}.json?access_token=${env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN}&fuzzyMatch=true`
       );
       const data = await response.json();
       if (data.features && data.features.length > 0) {

--- a/client/src/app/(nondashboard)/search/map.tsx
+++ b/client/src/app/(nondashboard)/search/map.tsx
@@ -5,8 +5,9 @@ import "mapbox-gl/dist/mapbox-gl.css";
 import { useAppSelector } from "@/state/redux";
 import { useGetPropertiesQuery } from "@/state/api";
 import { Property } from "@/types/prisma-types";
+import { env } from "@/env";
 
-mapboxgl.accessToken = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN as string;
+mapboxgl.accessToken = env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN as string;
 
 const Map = () => {
   const mapContainerRef = useRef(null);

--- a/client/src/env.ts
+++ b/client/src/env.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const envSchema = z.object({
+  NEXT_PUBLIC_API_URL: z.string().url(),
+  NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN: z.string().min(1),
+  NEXT_PUBLIC_AWS_COGNITO_USER_POOL_ID: z.string().min(1),
+  NEXT_PUBLIC_AWS_COGNITO_USER_POOL_CLIENT_ID: z.string().min(1),
+});
+
+export const env = envSchema.parse({
+  NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
+  NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN: process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN,
+  NEXT_PUBLIC_AWS_COGNITO_USER_POOL_ID: process.env.NEXT_PUBLIC_AWS_COGNITO_USER_POOL_ID,
+  NEXT_PUBLIC_AWS_COGNITO_USER_POOL_CLIENT_ID: process.env.NEXT_PUBLIC_AWS_COGNITO_USER_POOL_CLIENT_ID,
+});
+
+export type Env = z.infer<typeof envSchema>;

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,7 +1,8 @@
 import axios from 'axios';
 import { Property } from '@/types/prisma-types';
+import { env } from '@/env';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+const API_URL = env.NEXT_PUBLIC_API_URL;
 
 const api = axios.create({
   baseURL: API_URL,

--- a/client/src/state/api.ts
+++ b/client/src/state/api.ts
@@ -3,8 +3,9 @@ import { Application, Lease, Manager, Payment, Property, Tenant } from '@/types/
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { fetchAuthSession, getCurrentUser } from 'aws-amplify/auth';
 import { FiltersState } from '.';
+import { env } from '@/env';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+const API_URL = env.NEXT_PUBLIC_API_URL;
 
 export const api = createApi({
   baseQuery: fetchBaseQuery({

--- a/client/tests/payments.mutations.test.ts
+++ b/client/tests/payments.mutations.test.ts
@@ -1,4 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit';
+import { env } from '@/env';
 
 (global as any).fetch = () => Promise.resolve({});
 (global as any).Request = function (url: string, init: any = {}) {
@@ -19,7 +20,7 @@ jest.mock('@/lib/utils', () => ({
 const { api } = require('@/state/api');
 const { withToast } = require('@/lib/utils');
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+const API_URL = env.NEXT_PUBLIC_API_URL;
 
 const setupStore = () =>
   configureStore({


### PR DESCRIPTION
## Summary
- add typed env schema for client variables
- use validated env object instead of `process.env`
- import env in Next config so missing vars break the build

## Testing
- `npm test` *(fails: src/state/api.ts SyntaxError: '>' expected)*
- `npm run lint` *(fails: src/state/api.ts SyntaxError: '>' expected)*
- `npm run build` *(fails: Unexpected token in src/state/api.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689d77a1f2f08328bb36a3670f64d19f