### PR TITLE
docs: add client env placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,9 @@ AWS_SECRET_ACCESS_KEY=your-secret-key
 # Client configuration
 # Base URL for the client to access the API
 NEXT_PUBLIC_API_URL=http://localhost:3001
+# Mapbox access token for map rendering
+NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=your-mapbox-access-token
+# AWS Cognito User Pool ID for authentication
+NEXT_PUBLIC_AWS_COGNITO_USER_POOL_ID=your-cognito-user-pool-id
+# AWS Cognito User Pool Client ID
+NEXT_PUBLIC_AWS_COGNITO_USER_POOL_CLIENT_ID=your-cognito-client-id


### PR DESCRIPTION
## Summary
- document additional client env vars for Mapbox and AWS Cognito

## Testing
- `npm test` (server) *(fails: SyntaxError in tests)*
- `npm test` (client) *(fails: prettier formatting check failed)*

------
https://chatgpt.com/codex/tasks/task_e_689d77a27dfc8328a43d288697ad250b