### PR TITLE
Add Dockerfiles for client and server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./server
+          file: ./server/Dockerfile
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/garage-sale-server:latest
       - name: Build and push client image
@@ -137,5 +138,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./client
+          file: ./client/Dockerfile
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/garage-sale-client:latest

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,25 @@
+# Stage 1: install dependencies
+FROM node:18 AS deps
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+# Stage 2: build the application
+FROM node:18 AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+# Stage 3: production image
+FROM node:18 AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/next.config.ts ./next.config.ts
+COPY --from=deps /app/node_modules ./node_modules
+RUN npm prune --omit=dev
+EXPOSE 3000
+CMD ["npm", "run", "start"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18 AS base
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev
+COPY dist ./dist
+EXPOSE 3001
+CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary
- add multistage Node 18 Dockerfile for client
- add production Dockerfile for server
- explicitly reference Dockerfiles in deploy workflow

## Testing
- `npm --prefix client test` *(fails: SyntaxError in src/state/api.ts)*
- `npm --prefix server test` *(fails: SyntaxError in several files)*
- `docker build client` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `docker build server` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_689d733b6b1483289ea0c4082fe2f975