### PR TITLE
feat(e2e): seed manager for tests

### DIFF
--- a/client/tests/e2e/fixtures/seed.ts
+++ b/client/tests/e2e/fixtures/seed.ts
@@ -1,0 +1,26 @@
+// @ts-ignore
+import { PrismaClient } from '../../../../server/node_modules/@prisma/client/index.js';
+
+const prisma = new PrismaClient();
+
+const testManager = {
+  cognitoId: 'e2e-test-manager',
+  name: 'E2E Test Manager',
+  email: 'e2e.manager@example.com',
+  phoneNumber: '555-555-5555',
+};
+
+export async function seed() {
+  await prisma.manager.upsert({
+    where: { cognitoId: testManager.cognitoId },
+    update: {},
+    create: testManager,
+  });
+}
+
+export async function cleanup() {
+  await prisma.manager.deleteMany({
+    where: { cognitoId: testManager.cognitoId },
+  });
+  await prisma.$disconnect();
+}

--- a/client/tests/e2e/global-setup.ts
+++ b/client/tests/e2e/global-setup.ts
@@ -1,0 +1,5 @@
+import { seed } from './fixtures/seed';
+
+export default async function globalSetup() {
+  await seed();
+}

--- a/client/tests/e2e/global-teardown.ts
+++ b/client/tests/e2e/global-teardown.ts
@@ -1,0 +1,5 @@
+import { cleanup } from './fixtures/seed';
+
+export default async function globalTeardown() {
+  await cleanup();
+}

--- a/client/tests/e2e/playwright.config.ts
+++ b/client/tests/e2e/playwright.config.ts
@@ -4,6 +4,8 @@ export default defineConfig({
   testDir: './specs',
   fullyParallel: true,
   retries: process.env.CI ? 2 : 0,
+  globalSetup: './global-setup',
+  globalTeardown: './global-teardown',
   use: {
     baseURL: 'http://localhost:3000',
     trace: 'on-first-retry',


### PR DESCRIPTION
## Summary
- seed Prisma with an E2E test manager
- add Playwright global setup/teardown invoking the seed
- reference setup/teardown in Playwright config

## Testing
- `npm run test:e2e` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_689d71cd6c7c8328bf941b07a005faa0