### PR TITLE
chore(ci): run e2e tests across browsers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        browser: [chromium, firefox, webkit]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -110,7 +113,15 @@ jobs:
           cd client
           npm start &
           npx wait-on http://localhost:3000
-          npm run test:e2e
+          npm run test:e2e -- --browser=${{ matrix.browser }}
+      - name: Upload Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-${{ matrix.browser }}
+          path: |
+            client/playwright-report
+            client/test-results
 
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary
- run Playwright E2E tests for Chromium, Firefox and WebKit
- pass selected browser via Playwright CLI
- upload Playwright artifacts with browser-specific names

## Testing
- `npm test` (server) *(fails: Error occurred when checking code style in 3 files)*
- `npm test` (client) *(fails: Error occurred when checking code style in the above file)*

------
https://chatgpt.com/codex/tasks/task_e_689d71d08d008328918549335c7abc4b