### PR TITLE
feat: validate api url env

### DIFF
--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -1,19 +1,20 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
+import './src/env';
 
 const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
       {
-        protocol: "https",
-        hostname: "example.com",
-        port: "",
-        pathname: "/**",
+        protocol: 'https',
+        hostname: 'example.com',
+        port: '',
+        pathname: '/**',
       },
       {
-        protocol: "https",
-        hostname: "*.amazonaws.com",
-        port: "",
-        pathname: "/**",
+        protocol: 'https',
+        hostname: '*.amazonaws.com',
+        port: '',
+        pathname: '/**',
       },
     ],
   },

--- a/client/src/env.ts
+++ b/client/src/env.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const env = z
+  .object({
+    NEXT_PUBLIC_API_URL: z.string().url(),
+  })
+  .parse(process.env);

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,7 +1,8 @@
 import axios from 'axios';
 import { Property } from '@/types/prisma-types';
+import { env } from '@/env';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+const API_URL = env.NEXT_PUBLIC_API_URL;
 
 const api = axios.create({
   baseURL: API_URL,

--- a/client/src/state/api.ts
+++ b/client/src/state/api.ts
@@ -3,8 +3,9 @@ import { Application, Lease, Manager, Payment, Property, Tenant } from '@/types/
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { fetchAuthSession, getCurrentUser } from 'aws-amplify/auth';
 import { FiltersState } from '.';
+import { env } from '@/env';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+const API_URL = env.NEXT_PUBLIC_API_URL;
 
 export const api = createApi({
   baseQuery: fetchBaseQuery({
@@ -236,24 +237,21 @@ export const api = createApi({
       },
     }),
 
-    updateProperty: build.mutation<
-      Property,
-      { id: number } & Partial<Property>
-    >({
+    updateProperty: build.mutation<Property, { id: number } & Partial<Property>>({
       query: ({ id, ...updated }) => ({
         url: `properties/${id}`,
-        method: "PUT",
+        method: 'PUT',
         body: updated,
       }),
       invalidatesTags: (result, error, { id }) => [
-        { type: "Properties", id },
-        { type: "PropertyDetails", id },
-        { type: "Properties", id: "LIST" },
+        { type: 'Properties', id },
+        { type: 'PropertyDetails', id },
+        { type: 'Properties', id: 'LIST' },
       ],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          success: "Property updated successfully!",
-          error: "Failed to update property.",
+          success: 'Property updated successfully!',
+          error: 'Failed to update property.',
         });
       },
     }),
@@ -261,17 +259,17 @@ export const api = createApi({
     deleteProperty: build.mutation<{ message: string }, number>({
       query: (id) => ({
         url: `properties/${id}`,
-        method: "DELETE",
+        method: 'DELETE',
       }),
       invalidatesTags: (result, error, id) => [
-        { type: "Properties", id },
-        { type: "PropertyDetails", id },
-        { type: "Properties", id: "LIST" },
+        { type: 'Properties', id },
+        { type: 'PropertyDetails', id },
+        { type: 'Properties', id: 'LIST' },
       ],
       async onQueryStarted(_, { queryFulfilled }) {
         await withToast(queryFulfilled, {
-          success: "Property deleted successfully!",
-          error: "Failed to delete property.",
+          success: 'Property deleted successfully!',
+          error: 'Failed to delete property.',
         });
       },
     }),
@@ -309,7 +307,12 @@ export const api = createApi({
 
     createPayment: build.mutation<
       Payment,
-
+      { leaseId: number } & Partial<Omit<Payment, 'id' | 'leaseId'>>
+    >({
+      query: ({ leaseId, id, ...body }) => ({
+        url: `leases/${leaseId ?? id}/payments`,
+        method: 'POST',
+        body,
       }),
       invalidatesTags: ['Payments'],
       async onQueryStarted(_, { queryFulfilled }) {
@@ -322,7 +325,12 @@ export const api = createApi({
 
     updatePayment: build.mutation<
       Payment,
-
+      { paymentId: number } & Partial<Omit<Payment, 'id' | 'leaseId'>>
+    >({
+      query: ({ paymentId, ...body }) => ({
+        url: `leases/payments/${paymentId}`,
+        method: 'PUT',
+        body,
       }),
       invalidatesTags: ['Payments'],
       async onQueryStarted(_, { queryFulfilled }) {

--- a/client/tests/payments.mutations.test.ts
+++ b/client/tests/payments.mutations.test.ts
@@ -1,4 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit';
+import { env } from '@/env';
 
 (global as any).fetch = () => Promise.resolve({});
 (global as any).Request = function (url: string, init: any = {}) {
@@ -19,7 +20,7 @@ jest.mock('@/lib/utils', () => ({
 const { api } = require('@/state/api');
 const { withToast } = require('@/lib/utils');
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+const API_URL = env.NEXT_PUBLIC_API_URL;
 
 const setupStore = () =>
   configureStore({
@@ -51,7 +52,7 @@ describe('payments mutations', () => {
           leaseId: 1,
           amountDue: 500,
           amountPaid: 400,
-        })
+        }),
       )
       .unwrap();
     const request = (fetch as jest.Mock).mock.calls[0][0];
@@ -68,7 +69,7 @@ describe('payments mutations', () => {
         api.endpoints.updatePayment.initiate({
           paymentId: 2,
           amountPaid: 300,
-        })
+        }),
       )
       .unwrap();
     const request = (fetch as jest.Mock).mock.calls[0][0];


### PR DESCRIPTION
## Summary
- validate NEXT_PUBLIC_API_URL via zod and expose through env module
- replace direct process.env access with typed env import
- ensure build validates env vars and flesh out missing payment mutations

## Testing
- `npm test` *(fails: Code style issues found in 105 files)*
- `npx jest tests/payments.mutations.test.ts tests/payments-api.test.ts`
- `npm run build` *(fails: Cannot find module '@/types/prismaTypes')*
- `npm run build` *(fails: NEXT_PUBLIC_API_URL is required)*

------
https://chatgpt.com/codex/tasks/task_e_689d7337cae4832898008d88ad08ad05