### PR TITLE
test: setup express app for property search

### DIFF
--- a/server/src/__tests__/property-search.test.ts
+++ b/server/src/__tests__/property-search.test.ts
@@ -1,8 +1,12 @@
 import request from 'supertest';
 import express from 'express';
+import propertyRoutes from '../routes/property-routes';
 import prisma from '../utils/prisma';
 
+const app = express();
+app.use('/properties', propertyRoutes);
 
+describe('property search', () => {
   const createProperty = async (name: string, description: string) => {
     const managerId = name.replace(/\s+/g, '-') + '-mgr';
     await prisma.manager.create({


### PR DESCRIPTION
## Summary
- create an Express app in property search tests and mount property routes
- wrap property search tests in a describe block

## Testing
- `npm test -- src/__tests__/property-search.test.ts` *(fails: SyntaxError in unrelated files)*
- `npx jest src/__tests__/property-search.test.ts` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_689d73386da083288e6bef11beb9edfd