### PR TITLE
chore: update CI workflow actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,11 @@ env:
 
 jobs:
   client-lint:
+    permissions: { contents: read }
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4.1.1
+      - uses: actions/setup-node@v4.1.0
         with:
           node-version: 18
           cache: 'npm'
@@ -31,10 +32,11 @@ jobs:
           npm run lint
 
   client-test:
+    permissions: { contents: read }
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4.1.1
+      - uses: actions/setup-node@v4.1.0
         with:
           node-version: 18
           cache: 'npm'
@@ -49,10 +51,11 @@ jobs:
           npm test
 
   server-lint:
+    permissions: { contents: read }
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4.1.1
+      - uses: actions/setup-node@v4.1.0
         with:
           node-version: 18
           cache: 'npm'
@@ -67,10 +70,11 @@ jobs:
           npm run lint
 
   server-test:
+    permissions: { contents: read }
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4.1.1
+      - uses: actions/setup-node@v4.1.0
         with:
           node-version: 18
           cache: 'npm'
@@ -85,10 +89,11 @@ jobs:
           npm test
 
   e2e:
+    permissions: { contents: read }
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4.1.1
+      - uses: actions/setup-node@v4.1.0
         with:
           node-version: 18
           cache: 'npm'
@@ -114,10 +119,11 @@ jobs:
 
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions: { contents: read }
     runs-on: ubuntu-latest
     needs: [client-lint, client-test, server-lint, server-test, e2e]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
       - uses: docker/setup-buildx-action@v3
       - name: Log in to Docker registry
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary
- upgrade to actions/checkout@v4.1.1 and actions/setup-node@v4.1.0
- restrict job permissions to read-only contents

## Testing
- `act -j client-lint -P ubuntu-latest=catthehacker/ubuntu:act-latest` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_689d733b29b48328829e27569faf2f92