### PR TITLE
chore: log errors in handler

### DIFF
--- a/server/src/__tests__/not-found.test.ts
+++ b/server/src/__tests__/not-found.test.ts
@@ -17,4 +17,22 @@ describe('notFound middleware', () => {
     expect(res.status).toBe(404);
     expect(res.body).toEqual({ message: 'Route not found' });
   });
+
+  it('logs errors with errorHandler', async () => {
+    const app = express();
+    const testError = new Error('Test error');
+    app.get('/error', () => {
+      throw testError;
+    });
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    app.use(errorHandler);
+
+    const res = await request(app).get('/error');
+
+    expect(res.status).toBe(500);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(testError);
+    consoleErrorSpy.mockRestore();
+  });
 });

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -6,6 +6,10 @@ export const errorHandler = (
   res: Response,
   _next: NextFunction
 ): void => {
+  console.error(err);
+  if (err && err.stack) {
+    console.error(err.stack);
+  }
   const status = err.status || err.statusCode || 500;
   const message = err.message || "Internal Server Error";
   res.status(status).json({ message });


### PR DESCRIPTION
## Summary
- log error and stack trace in Express error handler for better visibility
- test error handler logs using console.error

## Testing
- `npm test` *(fails: src/utils/__tests__/env.test.ts: SyntaxError: ',' expected)*
- `npx jest src/__tests__/not-found.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689fc7af1df08328b9bc00dd639de21d