### PR TITLE
Delete S3 assets when removing property

### DIFF
--- a/server/src/__tests__/property.test.ts
+++ b/server/src/__tests__/property.test.ts
@@ -10,6 +10,12 @@ jest.mock('../utils/geocode-address', () => ({
   geocodeAddress: jest.fn().mockResolvedValue([0, 0]),
 }));
 
+const s3SendMock = jest.fn();
+jest.mock('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn(() => ({ send: s3SendMock })),
+  DeleteObjectCommand: jest.fn().mockImplementation((params) => params),
+}));
+
 const mockPrisma = {
   property: {
     deleteMany: jest.fn(),
@@ -225,21 +231,30 @@ describe('Property API', () => {
   });
 
   it('deletes property when authorized', async () => {
+    const photos = [
+      'https://bucket.s3.amazonaws.com/properties/1.jpg',
+      'https://bucket.s3.amazonaws.com/properties/2.jpg',
+    ];
     mockPrisma.property.findUnique.mockResolvedValue({
       id: 1,
       managerCognitoId: 'manager',
+      photoUrls: photos,
     });
 
     const res = await request(app).delete('/properties/1');
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ message: 'Property deleted' });
     expect(mockPrisma.property.delete).toHaveBeenCalledWith({ where: { id: 1 } });
+    expect(s3SendMock).toHaveBeenCalledTimes(2);
+    expect(s3SendMock).toHaveBeenCalledWith({ Bucket: 'test', Key: 'properties/1.jpg' });
+    expect(s3SendMock).toHaveBeenCalledWith({ Bucket: 'test', Key: 'properties/2.jpg' });
   });
 
   it('returns 403 when deleting property not owned by manager', async () => {
     mockPrisma.property.findUnique.mockResolvedValue({
       id: 1,
       managerCognitoId: 'manager',
+      photoUrls: [],
     });
 
     const res = await request(app)

--- a/server/src/controllers/property-controllers.ts
+++ b/server/src/controllers/property-controllers.ts
@@ -6,6 +6,21 @@ import { uploadFilesToS3 } from '../utils/s3-upload';
 import { geocodeAddress } from '../utils/geocode-address';
 import { z } from 'zod';
 import prisma from '../utils/prisma';
+import { S3Client, DeleteObjectCommand } from '@aws-sdk/client-s3';
+import {
+  AWS_REGION,
+  S3_BUCKET_NAME,
+  AWS_ACCESS_KEY_ID,
+  AWS_SECRET_ACCESS_KEY,
+} from '../env';
+
+const s3Client = new S3Client({
+  region: AWS_REGION,
+  credentials: {
+    accessKeyId: AWS_ACCESS_KEY_ID,
+    secretAccessKey: AWS_SECRET_ACCESS_KEY,
+  },
+});
 
 const createPropertySchema = z.object({
   address: z.string(),
@@ -315,6 +330,21 @@ export const deleteProperty = async (
     if (property.managerCognitoId !== req.user?.id) {
       res.status(403).json({ message: 'Forbidden' });
       return;
+    }
+
+    for (const url of property.photoUrls) {
+      try {
+        const parsed = new URL(url);
+        let Key = parsed.pathname.replace(/^\/+/g, '');
+        if (Key.startsWith(`${S3_BUCKET_NAME}/`)) {
+          Key = Key.slice(S3_BUCKET_NAME.length + 1);
+        }
+        await s3Client.send(
+          new DeleteObjectCommand({ Bucket: S3_BUCKET_NAME, Key }),
+        );
+      } catch {
+        // ignore errors from invalid URLs or S3 deletions
+      }
     }
 
     await prisma.property.delete({ where: { id: Number(id) } });


### PR DESCRIPTION
## Summary
- Remove property images from S3 before deleting the property record
- Mock S3 in controller tests and verify image cleanup

## Testing
- `npm test` *(fails: src/utils/__tests__/env.test.ts SyntaxError)*
- `npx jest src/__tests__/property.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689fc7afbdec8328af9833dbd454a387