### PR TITLE
Handle boolean fields directly in property controllers

### DIFF
--- a/server/src/__tests__/property.test.ts
+++ b/server/src/__tests__/property.test.ts
@@ -125,6 +125,8 @@ describe('Property API', () => {
       baths: '1',
       squareFeet: '900',
       propertyType: 'Apartment',
+      isPetsAllowed: true,
+      isParkingIncluded: false,
     };
 
     const res = await request(app).post('/properties').send(payload);
@@ -132,7 +134,11 @@ describe('Property API', () => {
     expect(mockPrisma.$transaction).toHaveBeenCalled();
     expect(propertyCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ managerCognitoId: 'manager' }),
+        data: expect.objectContaining({
+          managerCognitoId: 'manager',
+          isPetsAllowed: true,
+          isParkingIncluded: false,
+        }),
       }),
     );
   });
@@ -198,13 +204,14 @@ describe('Property API', () => {
       id: 1,
       name: 'Updated Property',
     });
-
-    const res = await request(app).put('/properties/1').send({ name: 'Updated Property' });
+    const res = await request(app)
+      .put('/properties/1')
+      .send({ name: 'Updated Property', isPetsAllowed: true });
     expect(res.status).toBe(200);
     expect(updateMock).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { id: 1 },
-        data: expect.objectContaining({ name: 'Updated Property' }),
+        data: expect.objectContaining({ name: 'Updated Property', isPetsAllowed: true }),
       }),
     );
   });
@@ -242,9 +249,7 @@ describe('Property API', () => {
       managerCognitoId: 'manager',
     });
 
-    const res = await request(app)
-      .delete('/properties/1')
-      .set('X-User-Id', 'other');
+    const res = await request(app).delete('/properties/1').set('X-User-Id', 'other');
     expect(res.status).toBe(403);
     expect(res.body).toEqual({ message: 'Forbidden' });
     expect(mockPrisma.property.delete).not.toHaveBeenCalled();

--- a/server/src/controllers/property-controllers.ts
+++ b/server/src/controllers/property-controllers.ts
@@ -24,8 +24,8 @@ const createPropertySchema = z.object({
   propertyType: z.string(),
   amenities: z.string().optional(),
   highlights: z.string().optional(),
-  isPetsAllowed: z.string().optional(),
-  isParkingIncluded: z.string().optional(),
+  isPetsAllowed: z.coerce.boolean().optional(),
+  isParkingIncluded: z.coerce.boolean().optional(),
 });
 
 const updatePropertySchema = z.object({
@@ -40,8 +40,8 @@ const updatePropertySchema = z.object({
   propertyType: z.string().optional(),
   amenities: z.string().optional(),
   highlights: z.string().optional(),
-  isPetsAllowed: z.string().optional(),
-  isParkingIncluded: z.string().optional(),
+  isPetsAllowed: z.coerce.boolean().optional(),
+  isParkingIncluded: z.coerce.boolean().optional(),
   photoUrls: z.array(z.string()).optional(),
 });
 
@@ -209,35 +209,35 @@ export const createProperty = async (
         RETURNING id, address, city, state, country, "postalCode", ST_AsText(coordinates) as coordinates;
       `;
 
-        return tx.property.create({
-          data: {
-            ...propertyData,
-            photoUrls,
-            locationId: location.id,
-            managerCognitoId,
-            propertyType: propertyData.propertyType as any,
-            amenities:
-              typeof propertyData.amenities === 'string'
-                ? (propertyData.amenities.split(',') as any)
-                : [],
-            highlights:
-              typeof propertyData.highlights === 'string'
-                ? (propertyData.highlights.split(',') as any)
-                : [],
-            isPetsAllowed: propertyData.isPetsAllowed === 'true',
-            isParkingIncluded: propertyData.isParkingIncluded === 'true',
-            pricePerMonth: propertyData.pricePerMonth,
-            securityDeposit: propertyData.securityDeposit,
-            applicationFee: propertyData.applicationFee,
-            beds: propertyData.beds,
-            baths: propertyData.baths,
-            squareFeet: propertyData.squareFeet,
-          },
-          include: {
-            location: true,
-            manager: true,
-          },
-        });
+      return tx.property.create({
+        data: {
+          ...propertyData,
+          photoUrls,
+          locationId: location.id,
+          managerCognitoId,
+          propertyType: propertyData.propertyType as any,
+          amenities:
+            typeof propertyData.amenities === 'string'
+              ? (propertyData.amenities.split(',') as any)
+              : [],
+          highlights:
+            typeof propertyData.highlights === 'string'
+              ? (propertyData.highlights.split(',') as any)
+              : [],
+          isPetsAllowed: propertyData.isPetsAllowed,
+          isParkingIncluded: propertyData.isParkingIncluded,
+          pricePerMonth: propertyData.pricePerMonth,
+          securityDeposit: propertyData.securityDeposit,
+          applicationFee: propertyData.applicationFee,
+          beds: propertyData.beds,
+          baths: propertyData.baths,
+          squareFeet: propertyData.squareFeet,
+        },
+        include: {
+          location: true,
+          manager: true,
+        },
+      });
     });
 
     res.status(201).json(newProperty);
@@ -272,25 +272,23 @@ export const updateProperty = async (
     }
 
     const data = parsed.data;
-      const updatedProperty = await prisma.property.update({
-        where: { id: Number(id) },
-        data: {
-          ...data,
-          propertyType: (data as any).propertyType,
-          amenities:
-            typeof data.amenities === 'string'
-              ? (data.amenities.split(',') as any)
-              : (data.amenities as any),
-          highlights:
-            typeof data.highlights === 'string'
-              ? (data.highlights.split(',') as any)
-              : (data.highlights as any),
-          isPetsAllowed:
-            data.isPetsAllowed === undefined ? undefined : data.isPetsAllowed === 'true',
-          isParkingIncluded:
-            data.isParkingIncluded === undefined ? undefined : data.isParkingIncluded === 'true',
-        },
-      });
+    const updatedProperty = await prisma.property.update({
+      where: { id: Number(id) },
+      data: {
+        ...data,
+        propertyType: (data as any).propertyType,
+        amenities:
+          typeof data.amenities === 'string'
+            ? (data.amenities.split(',') as any)
+            : (data.amenities as any),
+        highlights:
+          typeof data.highlights === 'string'
+            ? (data.highlights.split(',') as any)
+            : (data.highlights as any),
+        isPetsAllowed: data.isPetsAllowed,
+        isParkingIncluded: data.isParkingIncluded,
+      },
+    });
 
     res.json(updatedProperty);
   } catch (err) {


### PR DESCRIPTION
## Summary
- Parse `isPetsAllowed` and `isParkingIncluded` as booleans in property create/update schema
- Remove manual string-to-boolean conversions in property controllers
- Update property controller tests for boolean payloads

## Testing
- `npx jest src/__tests__/property.test.ts`
- `npm test` *(fails: SyntaxError in src/utils/__tests__/env.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689fc7b16d988328b2beb40de01fb1e1