### PR TITLE
feat: centralize client API URL config

### DIFF
--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -1,1 +1,1 @@
-export const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+export { API_URL } from './env';

--- a/client/src/env.ts
+++ b/client/src/env.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+const schema = z.object({
+  NEXT_PUBLIC_API_URL: z.string().url().default("http://localhost:3001"),
+});
+
+export const env = schema.parse(process.env);
+export const API_URL = env.NEXT_PUBLIC_API_URL;

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { API_URL } from '@/env';
 import { Property } from '@/types/prisma-types';
 
 

--- a/client/src/state/api.ts
+++ b/client/src/state/api.ts
@@ -1,3 +1,4 @@
+import { API_URL } from '@/env';
 import { cleanParams, createNewUserInDatabase, withToast } from '@/lib/utils';
 import { Application, Lease, Manager, Payment, Property, Tenant } from '@/types/prisma-types';
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';

--- a/client/tests/payments.mutations.test.ts
+++ b/client/tests/payments.mutations.test.ts
@@ -1,5 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit';
-import { env } from '@/env';
+import { API_URL } from '@/env';
 
 (global as any).fetch = () => Promise.resolve({});
 (global as any).Request = function (url: string, init: any = {}) {


### PR DESCRIPTION
## Summary
- add Zod-based environment parser to expose API_URL
- re-export API_URL from config and refactor modules/tests to use it

## Testing
- `npm test` *(fails: SyntaxError in src/state/api.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689fc7b450148328981e4268e8a20b35