### PR TITLE
Handle missing coordinates in formatLocation

### DIFF
--- a/server/src/utils/__tests__/format-location.test.ts
+++ b/server/src/utils/__tests__/format-location.test.ts
@@ -1,17 +1,25 @@
-import { formatLocation } from "../format-location";
-import prisma from "../prisma";
+import { formatLocation } from '../format-location';
+import prisma from '../prisma';
 
-jest.mock("../prisma", () => ({
+jest.mock('../prisma', () => ({
   $queryRaw: jest.fn(),
 }));
 
-describe("formatLocation", () => {
-  it("returns longitude and latitude", async () => {
+describe('formatLocation', () => {
+  it('returns longitude and latitude', async () => {
     (prisma.$queryRaw as jest.Mock).mockResolvedValue([
-      { coordinates: "POINT(-73.935242 40.73061)" },
+      { coordinates: 'POINT(-73.935242 40.73061)' },
     ]);
 
     const result = await formatLocation(1);
     expect(result).toEqual({ longitude: -73.935242, latitude: 40.73061 });
+  });
+
+  it('throws an error for invalid coordinates', async () => {
+    (prisma.$queryRaw as jest.Mock).mockResolvedValue([
+      { coordinates: 'GEOMETRYCOLLECTION EMPTY' },
+    ]);
+
+    await expect(formatLocation(1)).rejects.toThrow('Invalid coordinates');
   });
 });

--- a/server/src/utils/format-location.ts
+++ b/server/src/utils/format-location.ts
@@ -1,13 +1,15 @@
-import { wktToGeoJSON } from "@terraformer/wkt";
-import prisma from "./prisma";
+import { wktToGeoJSON } from '@terraformer/wkt';
+import type { Point } from 'geojson';
+import prisma from './prisma';
 
 export const formatLocation = async (
-  locationId: number
+  locationId: number,
 ): Promise<{ longitude: number; latitude: number }> => {
   const coordinates: { coordinates: string }[] =
     await prisma.$queryRaw`SELECT ST_asText(coordinates) as coordinates from "Location" where id = ${locationId}`;
 
-  const geoJSON: any = wktToGeoJSON(coordinates[0]?.coordinates || "");
+  const geoJSON = wktToGeoJSON(coordinates[0]?.coordinates || '') as Point;
+  if (!geoJSON.coordinates) throw new Error('Invalid coordinates');
   const longitude = geoJSON.coordinates[0];
   const latitude = geoJSON.coordinates[1];
 


### PR DESCRIPTION
## Summary
- use GeoJSON `Point` type for `formatLocation`
- throw on missing coordinates when parsing WKT
- test invalid WKT input returns error

## Testing
- `npx jest src/utils/__tests__/format-location.test.ts`
- `npm test` *(fails: SyntaxError in env.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689fc7ac2bbc83289c6890260e11229f