### PR TITLE
Handle lease creation on application approval

### DIFF
--- a/server/src/__tests__/application-controllers.test.ts
+++ b/server/src/__tests__/application-controllers.test.ts
@@ -66,18 +66,12 @@ describe('applicationControllers', () => {
     );
   });
 
-
-
-      await createApplication(req, res, next);
-
-
-
   it('returns 404 when property missing', async () => {
     mockPrisma.property.findUnique.mockResolvedValue(null);
     const req = {
       body: {
         applicationDate: new Date().toISOString(),
-        status: 'PENDING',
+        status: 'Pending',
         propertyId: 1,
         tenantCognitoId: 't1',
         name: 'n',
@@ -99,7 +93,7 @@ describe('applicationControllers', () => {
     const req = {
       body: {
         applicationDate: new Date().toISOString(),
-        status: 'PENDING',
+        status: 'Pending',
         propertyId: 1,
         tenantCognitoId: 't1',
         name: 'n',
@@ -130,19 +124,33 @@ describe('applicationControllers', () => {
     expect(mockPrisma.property.findUnique).not.toHaveBeenCalled();
   });
 
-  it('updates application status', async () => {
-    (updateApplicationStatusService as jest.Mock).mockResolvedValue({ id: 1 });
-    const req = { params: { id: '1' }, body: { status: 'APPROVED' } } as unknown as Request;
+  it('updates application status to Approved', async () => {
+    const updated = { id: 1, status: 'Approved', leaseId: 10 };
+    (updateApplicationStatusService as jest.Mock).mockResolvedValue(updated);
+    const req = { params: { id: '1' }, body: { status: 'Approved' } } as unknown as Request;
     const res = createMockRes();
 
     await updateApplicationStatus(req, res, next);
 
-    expect(res.json).toHaveBeenCalledWith({ id: 1 });
+    expect(updateApplicationStatusService).toHaveBeenCalledWith(1, 'Approved');
+    expect(res.json).toHaveBeenCalledWith(updated);
+  });
+
+  it('updates application status without approval', async () => {
+    const updated = { id: 1, status: 'Denied', leaseId: null };
+    (updateApplicationStatusService as jest.Mock).mockResolvedValue(updated);
+    const req = { params: { id: '1' }, body: { status: 'Denied' } } as unknown as Request;
+    const res = createMockRes();
+
+    await updateApplicationStatus(req, res, next);
+
+    expect(updateApplicationStatusService).toHaveBeenCalledWith(1, 'Denied');
+    expect(res.json).toHaveBeenCalledWith(updated);
   });
 
   it('returns 404 when updating missing application', async () => {
     (updateApplicationStatusService as jest.Mock).mockResolvedValue(null);
-    const req = { params: { id: '1' }, body: { status: 'APPROVED' } } as unknown as Request;
+    const req = { params: { id: '1' }, body: { status: 'Approved' } } as unknown as Request;
     const res = createMockRes();
 
     await updateApplicationStatus(req, res, next);

--- a/server/src/services/application-service.ts
+++ b/server/src/services/application-service.ts
@@ -13,30 +13,35 @@ export const updateApplicationStatus = async (id: number, status: ApplicationSta
   }
 
   return prisma.$transaction(async (tx) => {
-
-
-        await tx.property.update({
-          where: { id: application.propertyId },
-          data: {
-            tenants: {
-              connect: { cognitoId: application.tenantCognitoId },
-            },
-          },
-        });
-
-        return tx.application.update({
-          where: { id },
-          data: { status, leaseId: lease.id },
-          include: { property: true, tenant: true, lease: true },
-        });
-      }
-
-      // For statuses other than transitioning to Approved, simply update the status
-      return tx.application.update({
-        where: { id },
-        data: { status },
-        include: { property: true, tenant: true, lease: true },
+    if (status === 'Approved') {
+      const lease = await tx.lease.create({
+        data: {
+          property: { connect: { id: application.propertyId } },
+          tenant: { connect: { cognitoId: application.tenantCognitoId } },
+        },
       });
 
+      await tx.property.update({
+        where: { id: application.propertyId },
+        data: {
+          tenants: {
+            connect: { cognitoId: application.tenantCognitoId },
+          },
+        },
+      });
+
+      return tx.application.update({
+        where: { id },
+        data: { status, leaseId: lease.id },
+        include: { property: true, tenant: true, lease: true },
+      });
+    }
+
+    // For statuses other than transitioning to Approved, simply update the status
+    return tx.application.update({
+      where: { id },
+      data: { status },
+      include: { property: true, tenant: true, lease: true },
     });
-  };
+  });
+};


### PR DESCRIPTION
## Summary
- Create a lease and attach it to the application only when approving
- Connect tenant and property upon approval
- Add controller tests for approval and non-approval status updates

## Testing
- `npm test` *(fails: SyntaxError in existing tests)*
- `npx prettier src/services/application-service.ts src/__tests__/application-controllers.test.ts --check`
- `npx jest src/__tests__/application-controllers.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689d3f3180e88328b0df81cbf5eafffb