### PR TITLE
Ensure property deletion checks existence and authorization

### DIFF
--- a/server/src/controllers/property-controllers.ts
+++ b/server/src/controllers/property-controllers.ts
@@ -332,7 +332,9 @@ export const deleteProperty = async (
 ): Promise<void> => {
   try {
     const { id } = req.params;
-
+    const property = await prisma.property.findUnique({
+      where: { id: Number(id) },
+    });
 
     if (!property) {
       res.status(404).json({ message: 'Property not found' });


### PR DESCRIPTION
## Summary
- Fetch property by id before deletion
- Return 404 when property is missing
- Enforce manager ownership, delete S3 photos, then remove record

## Testing
- `npm test` *(fails: SyntaxError in tests)*
- `npm run lint` *(fails: SyntaxError in tests)*
- `npm run typecheck` *(fails: TypeScript compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e70257e48328a8e251c5458dd43f