### PR TITLE
Populate lease creation data on application approval

### DIFF
--- a/server/src/services/application-service.ts
+++ b/server/src/services/application-service.ts
@@ -1,10 +1,7 @@
 import { ApplicationStatus } from '@prisma/client';
 import prisma from '../utils/prisma';
 
-export const updateApplicationStatus = async (
-  id: number,
-  status: ApplicationStatus,
-) => {
+export const updateApplicationStatus = async (id: number, status: ApplicationStatus) => {
   const application = await prisma.application.findUnique({
     where: { id },
     include: { property: true, tenant: true },
@@ -16,9 +13,18 @@ export const updateApplicationStatus = async (
 
   return prisma.$transaction(async (tx) => {
     if (status === 'Approved') {
+      const startDate = new Date();
+      const endDate = new Date(startDate);
+      endDate.setFullYear(endDate.getFullYear() + 1);
+
       const lease = await tx.lease.create({
         data: {
-
+          startDate,
+          endDate,
+          rent: application.property.pricePerMonth,
+          deposit: application.property.securityDeposit,
+          property: { connect: { id: application.propertyId } },
+          tenant: { connect: { cognitoId: application.tenantCognitoId } },
         },
       });
 
@@ -37,7 +43,6 @@ export const updateApplicationStatus = async (
         include: { property: true, tenant: true, lease: true },
       });
     }
-
 
     return tx.application.update({
       where: { id },


### PR DESCRIPTION
## Summary
- set lease start/end dates, rent, deposit and relations when approving an application

## Testing
- `npm test` *(fails: Declaration or statement expected in property.test.ts; ',' expected in env.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e702e80c83288513ec8f0770a028