### PR TITLE
feat: read API URL from NEXT_PUBLIC_API_URL

### DIFF
--- a/client/src/env.ts
+++ b/client/src/env.ts
@@ -1,1 +1,2 @@
-
+export const API_URL =
+  process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';


### PR DESCRIPTION
## Summary
- use NEXT_PUBLIC_API_URL to configure API base URL

## Testing
- `npm test` *(fails: src/state/api.ts syntax errors)*
- `npx jest` *(fails: src/state/api.ts syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e703b02883288d6d8996d73e4b52