### PR TITLE
refactor: type payment mutations with ids

### DIFF
--- a/client/src/state/api.ts
+++ b/client/src/state/api.ts
@@ -307,7 +307,10 @@ export const api = createApi({
 
     createPayment: build.mutation<
       Payment,
-
+      { leaseId: number } & Partial<Payment>
+    >({
+      query: ({ leaseId, ...body }) => ({
+        url: `leases/${leaseId}/payments`,
         method: 'POST',
         body,
       }),
@@ -322,7 +325,7 @@ export const api = createApi({
 
     updatePayment: build.mutation<
       Payment,
-
+      { paymentId: number } & Partial<Payment>
     >({
       query: ({ paymentId, ...body }) => ({
         url: `leases/payments/${paymentId}`,


### PR DESCRIPTION
## Summary
- type `createPayment` and `updatePayment` mutations with explicit IDs
- pull IDs from the request body when building payment URLs

## Testing
- `npm test` *(fails: Code style issues found in 107 files. Run Prettier with --write to fix.)*
- `npx jest` *(fails: payment tests expect API_URL and full URLs)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e7045c9c8328a98c071c5dbeac41