### PR TITLE
Rename updated manager variable for clarity

### DIFF
--- a/server/src/controllers/manager-controllers.ts
+++ b/server/src/controllers/manager-controllers.ts
@@ -67,7 +67,7 @@ export const updateManager = async (
     }
     const { name, email, phoneNumber } = parsed.data;
 
-    const updateManager = await prisma.manager.update({
+    const updatedManager = await prisma.manager.update({
       where: { cognitoId },
       data: {
         name,
@@ -76,7 +76,7 @@ export const updateManager = async (
       },
     });
 
-    res.json(updateManager);
+    res.json(updatedManager);
   } catch (error) {
     next(error);
   }


### PR DESCRIPTION
## Summary
- rename `updateManager` variable to `updatedManager` in controller
- return `updatedManager` in response

## Testing
- `npm test` (fails: SyntaxError in existing test files)


------
https://chatgpt.com/codex/tasks/task_e_68a35b301db08328aacf8c6457820ccf