### PR TITLE
chore: add geojson type definitions

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -30,6 +30,7 @@
       "devDependencies": {
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
+        "@types/geojson": "^7946.0.0",
         "@types/jest": "^29.5.14",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/morgan": "^1.9.10",
@@ -52,6 +53,9 @@
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
+      },
+      "engines": {
+        "node": "18.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/server/package.json
+++ b/server/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
+    "@types/geojson": "^7946.0.0",
     "@types/jest": "^29.5.14",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/morgan": "^1.9.10",


### PR DESCRIPTION
## Summary
- add `@types/geojson` to server dev dependencies
- install types for GeoJSON utilities

## Testing
- `npm run typecheck` *(fails: Cannot find name 'express')*
- `npx tsc src/utils/format-location.ts --noEmit --module nodenext --target es2016 --moduleResolution nodenext --esModuleInterop`
- `npm test` *(fails: Prettier found syntax errors)*
- `npm run lint` *(fails: Prettier found syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a35b30e4bc83289504a2346f091503