### PR TITLE
Add middleware imports to server index

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,3 +1,12 @@
+import express from 'express';
+import helmet from 'helmet';
+import morgan from 'morgan';
+import cors from 'cors';
+import rateLimit from 'express-rate-limit';
+import { CLIENT_ORIGIN, PORT } from './env';
+import { authMiddleware } from './middleware/auth-middleware';
+import { notFound } from './middleware/not-found';
+import { errorHandler } from './middleware/error-handler';
 
 /* ROUTE IMPORT */
 import tenantRoutes from './routes/tenant-routes';


### PR DESCRIPTION
## Summary
- import express, helmet, morgan, cors, rate limiting, and middleware utilities in server entry

## Testing
- `npm test` *(fails: SyntaxError in src/__tests__/property.test.ts, src/utils/__tests__/env.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a35b2e7ca08328b6c333eac57d5a09