### PR TITLE
fix: import API_URL and listing payload types

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,8 +1,8 @@
 import axios from 'axios';
 
+import { API_URL } from '@/env';
 import { Property } from '@/types/prisma-types';
-
-
+import type { ListingCreationPayload } from '@/types/listing';
 
 const api = axios.create({
   baseURL: API_URL,


### PR DESCRIPTION
## Summary
- import API_URL constant and ListingCreationPayload type in client api

## Testing
- `npm test` (fails: Code style issues found in 107 files)
- `npx jest` (fails: 2 failed, 3 passed)


------
https://chatgpt.com/codex/tasks/task_e_68a36906cd7083289c27fd82af88cd06