### PR TITLE
chore(client): use local Prisma client for e2e tests

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -61,6 +61,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@playwright/test": "^1.54.2",
+        "@prisma/client": "^6.14.0",
         "@testing-library/react": "^16.3.0",
         "@types/jest": "^29.5.12",
         "@types/lodash": "^4.17.20",
@@ -87,6 +88,9 @@
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3",
         "wait-on": "^8.0.4"
+      },
+      "engines": {
+        "node": "18.x"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -4102,6 +4106,29 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.14.0.tgz",
+      "integrity": "sha512-8E/Nk3eL5g7RQIg/LUj1ICyDmhD053STjxrPxUtCRybs2s/2sOEcx9NpITuAOPn07HEpWBfhAVe1T/HYWXUPOw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/number": {

--- a/client/package.json
+++ b/client/package.json
@@ -72,6 +72,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@playwright/test": "^1.54.2",
+    "@prisma/client": "^6.14.0",
     "@testing-library/react": "^16.3.0",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.17.20",

--- a/client/tests/e2e/fixtures/seed.ts
+++ b/client/tests/e2e/fixtures/seed.ts
@@ -1,5 +1,4 @@
-// @ts-ignore
-import { PrismaClient } from '../../../../server/node_modules/@prisma/client/index.js';
+import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
 


### PR DESCRIPTION
## Summary
- add `@prisma/client` as a dev dependency for the client project
- use `@prisma/client` directly in e2e seed fixture and drop `ts-ignore`

## Testing
- `npm test` *(fails: code style issues)*
- `npx jest` *(fails: 2 failed, 3 passed)*
- `npm run test:e2e` *(fails: @prisma/client did not initialize)*

------
https://chatgpt.com/codex/tasks/task_e_68a369077c6483289cbdea6e1846b926