### PR TITLE
test: import API_URL in payments mutation tests

### DIFF
--- a/client/tests/payments.mutations.test.ts
+++ b/client/tests/payments.mutations.test.ts
@@ -1,5 +1,5 @@
+import { API_URL } from '@/env';
 import { configureStore } from '@reduxjs/toolkit';
-
 
 (global as any).fetch = () => Promise.resolve({});
 (global as any).Request = function (url: string, init: any = {}) {
@@ -19,8 +19,6 @@ jest.mock('@/lib/utils', () => ({
 
 const { api } = require('@/state/api');
 const { withToast } = require('@/lib/utils');
-
-
 
 const setupStore = () =>
   configureStore({


### PR DESCRIPTION
## Summary
- import API_URL in payments mutation tests for endpoint assertions

## Testing
- `npx jest tests/payments.mutations.test.ts`
- `npm test tests/payments.mutations.test.ts` *(fails: Code style issues found in 104 files)*

------
https://chatgpt.com/codex/tasks/task_e_68a377dd0ab4832899c5fab9b0e3134a