### PR TITLE
Align API_URL import in payments mutations test

### DIFF
--- a/client/tests/payments.mutations.test.ts
+++ b/client/tests/payments.mutations.test.ts
@@ -1,5 +1,5 @@
-import { API_URL } from '@/env';
 import { configureStore } from '@reduxjs/toolkit';
+import { API_URL } from '@/env';
 
 (global as any).fetch = () => Promise.resolve({});
 (global as any).Request = function (url: string, init: any = {}) {


### PR DESCRIPTION
## Summary
- reorder imports to keep API_URL alongside configureStore in payments mutations test

## Testing
- `npm test` *(fails: Code style issues found in 104 files. Run Prettier with --write to fix.)*
- `npx jest tests/payments.mutations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a3f2836fc483289f574abaa2d2501d