### PR TITLE
feat: add theme toggle

### DIFF
--- a/client/src/app/providers.tsx
+++ b/client/src/app/providers.tsx
@@ -3,14 +3,17 @@
 import StoreProvider from "@/state/redux";
 import { Authenticator } from "@aws-amplify/ui-react";
 import Auth from "./(auth)/auth-provider";
+import { ThemeProvider } from "next-themes";
 
 const Providers = ({ children }: { children: React.ReactNode }) => {
   return (
-    <StoreProvider>
-      <Authenticator.Provider>
-        <Auth>{children}</Auth>
-      </Authenticator.Provider>
-    </StoreProvider>
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      <StoreProvider>
+        <Authenticator.Provider>
+          <Auth>{children}</Auth>
+        </Authenticator.Provider>
+      </StoreProvider>
+    </ThemeProvider>
   );
 };
 

--- a/client/src/components/navbar.tsx
+++ b/client/src/components/navbar.tsx
@@ -9,6 +9,7 @@ import { useGetAuthUserQuery } from "@/state/api";
 import { usePathname, useRouter } from "next/navigation";
 import { signOut } from "aws-amplify/auth";
 import { Bell, MessageCircle, Plus, Search } from "lucide-react";
+import ThemeToggle from "./theme-toggle";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -99,6 +100,7 @@ const Navbar = () => {
           </p>
         )}
         <div className="flex items-center gap-5">
+          <ThemeToggle />
           {authUser ? (
             <>
               <div className="relative hidden md:block">

--- a/client/src/components/theme-toggle.tsx
+++ b/client/src/components/theme-toggle.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+import { Sun, Moon } from "lucide-react";
+import { Button } from "./ui/button";
+
+const ThemeToggle = () => {
+  const { setTheme, resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) return null;
+
+  const toggleTheme = () => {
+    setTheme(resolvedTheme === "light" ? "dark" : "light");
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleTheme}
+      className="rounded-full text-primary-200 hover:text-primary-400 hover:bg-transparent"
+    >
+      {resolvedTheme === "light" ? (
+        <Moon className="h-5 w-5" />
+      ) : (
+        <Sun className="h-5 w-5" />
+      )}
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+};
+
+export default ThemeToggle;


### PR DESCRIPTION
## Summary
- add ThemeProvider for global theme handling
- create ThemeToggle component with sun/moon icons
- integrate ThemeToggle into Navbar

## Testing
- `npm run lint`
- `npm test` *(fails: Code style issues found in 105 files)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f294aa4c8328b675197f3e807668