### PR TITLE
chore: add API_URL import next to configureStore

### DIFF
--- a/client/tests/payments.mutations.test.ts
+++ b/client/tests/payments.mutations.test.ts
@@ -1,5 +1,5 @@
-import { API_URL } from '@/env';
 import { configureStore } from '@reduxjs/toolkit';
+import { API_URL } from '@/env';
 
 (global as any).fetch = () => Promise.resolve({});
 (global as any).Request = function (url: string, init: any = {}) {


### PR DESCRIPTION
## Summary
- place `API_URL` import alongside `configureStore` in payments mutation tests

## Testing
- `npm test` *(fails: Code style issues found in 104 files)*
- `npx jest tests/payments.mutations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a3ae40b5c48328be5850b30c45931a