### PR TITLE
feat: add feature flag system

### DIFF
--- a/client/src/app/(dashboard)/admin/flags.tsx
+++ b/client/src/app/(dashboard)/admin/flags.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useGetFlagsQuery, useUpdateFlagMutation } from '@/state/api';
+
+const FlagsPage = () => {
+  const { data: flags } = useGetFlagsQuery();
+  const [updateFlag] = useUpdateFlagMutation();
+
+  if (!flags) return <div>Loading...</div>;
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl mb-4">Feature Flags</h1>
+      <ul>
+        {Object.entries(flags).map(([name, enabled]) => (
+          <li key={name} className="flex items-center gap-2 mb-2">
+            <span className="flex-1">{name}</span>
+            <input
+              type="checkbox"
+              checked={enabled}
+              onChange={(e) => updateFlag({ name, enabled: e.target.checked })}
+            />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default FlagsPage;

--- a/client/src/components/feature-toggle.tsx
+++ b/client/src/components/feature-toggle.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { useGetFlagsQuery } from '@/state/api';
+
+type Props = {
+  flag: string;
+  fallback?: ReactNode;
+  children: ReactNode;
+};
+
+const FeatureToggle = ({ flag, fallback = null, children }: Props) => {
+  const { data } = useGetFlagsQuery();
+  if (data && data[flag]) {
+    return <>{children}</>;
+  }
+  return <>{fallback}</>;
+};
+
+export default FeatureToggle;

--- a/client/src/components/navbar.tsx
+++ b/client/src/components/navbar.tsx
@@ -10,6 +10,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { signOut } from "aws-amplify/auth";
 import { Bell, MessageCircle, Plus, Search } from "lucide-react";
 import ThemeToggle from "./theme-toggle";
+import FeatureToggle from "./feature-toggle";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -100,7 +101,9 @@ const Navbar = () => {
           </p>
         )}
         <div className="flex items-center gap-5">
-          <ThemeToggle />
+          <FeatureToggle flag="theme-toggle">
+            <ThemeToggle />
+          </FeatureToggle>
           {authUser ? (
             <>
               <div className="relative hidden md:block">

--- a/client/src/state/api.ts
+++ b/client/src/state/api.ts
@@ -28,6 +28,7 @@ export const api = createApi({
     'Leases',
     'Payments',
     'Applications',
+    'FeatureFlags',
   ],
   endpoints: (build) => ({
     getAuthUser: build.query<User, void>({
@@ -394,6 +395,20 @@ export const api = createApi({
         });
       },
     }),
+
+    getFlags: build.query<Record<string, boolean>, void>({
+      query: () => 'flags',
+      providesTags: ['FeatureFlags'],
+    }),
+
+    updateFlag: build.mutation<void, { name: string; enabled: boolean }>({
+      query: ({ name, enabled }) => ({
+        url: `flags/${name}`,
+        method: 'PUT',
+        body: { enabled },
+      }),
+      invalidatesTags: ['FeatureFlags'],
+    }),
   }),
 });
 
@@ -419,4 +434,6 @@ export const {
   useGetApplicationsQuery,
   useUpdateApplicationStatusMutation,
   useCreateApplicationMutation,
+  useGetFlagsQuery,
+  useUpdateFlagMutation,
 } = api;

--- a/client/tests/feature-toggle.test.tsx
+++ b/client/tests/feature-toggle.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import FeatureToggle from '@/components/feature-toggle';
+
+jest.mock('@/state/api', () => ({
+  useGetFlagsQuery: () => ({ data: { on: true, off: false } }),
+}));
+
+describe('FeatureToggle', () => {
+  test('shows children when flag enabled', () => {
+    render(
+      <FeatureToggle flag="on">
+        <div>Enabled</div>
+      </FeatureToggle>
+    );
+    expect(screen.getByText('Enabled')).toBeInTheDocument();
+  });
+
+  test('shows fallback when flag disabled', () => {
+    render(
+      <FeatureToggle flag="off" fallback={<div>Fallback</div>}>
+        <div>Hidden</div>
+      </FeatureToggle>
+    );
+    expect(screen.getByText('Fallback')).toBeInTheDocument();
+  });
+});

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -193,3 +193,9 @@ model GeocodeCache {
 
   @@unique([address, city, postalCode])
 }
+
+model FeatureFlag {
+  id      Int    @id @default(autoincrement())
+  name    String @unique
+  enabled Boolean @default(false)
+}

--- a/server/src/controllers/flag-controllers.ts
+++ b/server/src/controllers/flag-controllers.ts
@@ -1,0 +1,14 @@
+import { Request, Response } from 'express';
+import { getAllFlags, setFeature } from '../utils/feature-flags';
+
+export const getFlags = async (_req: Request, res: Response) => {
+  const flags = await getAllFlags();
+  res.json(flags);
+};
+
+export const updateFlag = async (req: Request, res: Response) => {
+  const { name } = req.params;
+  const { enabled } = req.body;
+  await setFeature(name, Boolean(enabled));
+  res.status(204).send();
+};

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -7,6 +7,7 @@ import { CLIENT_ORIGIN, PORT } from './env';
 import { authMiddleware } from './middleware/auth-middleware';
 import { notFound } from './middleware/not-found';
 import { errorHandler } from './middleware/error-handler';
+import { featureFlagsMiddleware } from './middleware/feature-flags';
 
 /* ROUTE IMPORT */
 import tenantRoutes from './routes/tenant-routes';
@@ -14,6 +15,7 @@ import managerRoutes from './routes/manager-routes';
 import propertyRoutes from './routes/property-routes';
 import leaseRoutes from './routes/lease-routes';
 import applicationRoutes from './routes/application-routes';
+import flagRoutes from './routes/flag-routes';
 
 /* CONFIGURATIONS */
 const app = express();
@@ -29,6 +31,7 @@ const limiter = rateLimit({
   max: 100,
 });
 app.use(limiter);
+app.use(featureFlagsMiddleware);
 
 /* ROUTES */
 app.get('/', (req, res) => {
@@ -40,6 +43,7 @@ app.use('/properties', propertyRoutes);
 app.use('/leases', leaseRoutes);
 app.use('/tenants', authMiddleware(['tenant']), tenantRoutes);
 app.use('/managers', authMiddleware(['manager']), managerRoutes);
+app.use('/flags', flagRoutes);
 
 app.use(notFound);
 app.use(errorHandler);

--- a/server/src/middleware/feature-flags.ts
+++ b/server/src/middleware/feature-flags.ts
@@ -1,0 +1,23 @@
+import { Request, Response, NextFunction } from 'express';
+import { getAllFlags } from '../utils/feature-flags';
+
+declare global {
+  namespace Express {
+    interface Request {
+      flags?: Record<string, boolean>;
+    }
+  }
+}
+
+export const featureFlagsMiddleware = async (
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+) => {
+  try {
+    req.flags = await getAllFlags();
+  } catch {
+    req.flags = {};
+  }
+  next();
+};

--- a/server/src/routes/flag-routes.ts
+++ b/server/src/routes/flag-routes.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import { getFlags, updateFlag } from '../controllers/flag-controllers';
+
+const router = express.Router();
+
+router.get('/', getFlags);
+router.put('/:name', updateFlag);
+
+export default router;

--- a/server/src/utils/__tests__/feature-flags.test.ts
+++ b/server/src/utils/__tests__/feature-flags.test.ts
@@ -1,0 +1,43 @@
+const store: Record<string, boolean> = {};
+
+const mockPrisma = {
+  featureFlag: {
+    findMany: jest.fn(async () =>
+      Object.entries(store).map(([name, enabled]) => ({ name, enabled }))
+    ),
+    findUnique: jest.fn(async ({ where: { name } }) =>
+      store[name] !== undefined ? { name, enabled: store[name] } : null
+    ),
+    upsert: jest.fn(async ({ where: { name }, update, create }) => {
+      store[name] = update.enabled ?? create.enabled;
+    }),
+  },
+};
+
+jest.mock('../prisma', () => ({
+  __esModule: true,
+  default: mockPrisma,
+}));
+
+import { setFeature, isFeatureEnabled, getAllFlags } from '../feature-flags';
+
+describe('feature flags service', () => {
+  beforeEach(() => {
+    for (const key of Object.keys(store)) delete store[key];
+  });
+
+  test('set and get flag', async () => {
+    await setFeature('test-flag', true);
+    expect(await isFeatureEnabled('test-flag')).toBe(true);
+
+    await setFeature('test-flag', false);
+    expect(await isFeatureEnabled('test-flag')).toBe(false);
+  });
+
+  test('getAllFlags returns map', async () => {
+    await setFeature('a', true);
+    await setFeature('b', false);
+    const flags = await getAllFlags();
+    expect(flags).toMatchObject({ a: true, b: false });
+  });
+});

--- a/server/src/utils/feature-flags.ts
+++ b/server/src/utils/feature-flags.ts
@@ -1,0 +1,24 @@
+import prisma from './prisma';
+
+export type FeatureFlags = Record<string, boolean>;
+
+export const getAllFlags = async (): Promise<FeatureFlags> => {
+  const flags = await prisma.featureFlag.findMany();
+  return flags.reduce<FeatureFlags>((acc, f) => {
+    acc[f.name] = f.enabled;
+    return acc;
+  }, {});
+};
+
+export const isFeatureEnabled = async (name: string): Promise<boolean> => {
+  const flag = await prisma.featureFlag.findUnique({ where: { name } });
+  return flag?.enabled ?? false;
+};
+
+export const setFeature = async (name: string, enabled: boolean): Promise<void> => {
+  await prisma.featureFlag.upsert({
+    where: { name },
+    update: { enabled },
+    create: { name, enabled },
+  });
+};


### PR DESCRIPTION
## Summary
- add FeatureFlag model and service backed by Prisma
- expose middleware and routes to inject and toggle flags
- implement client FeatureToggle component and admin UI
- add unit tests for flags and toggle rendering

## Testing
- `npm test` (server) *(fails: SyntaxError in existing tests)*
- `npm test` (client) *(fails: Prettier found code style issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bf53cb6c8328be9134ed803c8a82