### PR TITLE
Add WebSocket messaging and chat UI

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -52,6 +52,7 @@
         "react-hook-form": "^7.61.1",
         "react-redux": "^9.2.0",
         "recharts": "^2.12.0",
+        "socket.io-client": "^4.7.5",
         "sonner": "^1.7.4",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
@@ -6641,6 +6642,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -9665,6 +9672,66 @@
       "dev": true,
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
+      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -13818,7 +13885,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/multimatch": {
@@ -16116,6 +16182,68 @@
         "node": ">=8"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/sonner": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.4.tgz",
@@ -17734,6 +17862,14 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/xstate": {
       "version": "4.38.3",

--- a/client/package.json
+++ b/client/package.json
@@ -67,7 +67,8 @@
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "uuid": "^11.1.0",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "socket.io-client": "^4.7.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/client/src/components/chat/chat-window.tsx
+++ b/client/src/components/chat/chat-window.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { io, Socket } from 'socket.io-client';
+import MessageList from './message-list';
+import MessageInput from './message-input';
+
+interface Message {
+  id: number;
+  senderCognitoId: string;
+  content: string;
+  createdAt: string;
+}
+
+interface ChatWindowProps {
+  conversationId: number;
+  token: string;
+}
+
+export default function ChatWindow({ conversationId, token }: ChatWindowProps) {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [socket, setSocket] = useState<Socket | null>(null);
+
+  useEffect(() => {
+    const s = io('', {
+      auth: { token },
+    });
+    s.emit('joinConversation', conversationId);
+    s.on('newMessage', (msg: Message) => {
+      setMessages((prev) => [...prev, msg]);
+    });
+    setSocket(s);
+    return () => {
+      s.disconnect();
+    };
+  }, [conversationId, token]);
+
+  const handleSend = (content: string) => {
+    socket?.emit('sendMessage', { conversationId, content });
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <MessageList messages={messages} />
+      <MessageInput onSend={handleSend} />
+    </div>
+  );
+}

--- a/client/src/components/chat/message-input.tsx
+++ b/client/src/components/chat/message-input.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+
+interface MessageInputProps {
+  onSend: (content: string) => void;
+}
+
+export default function MessageInput({ onSend }: MessageInputProps) {
+  const [value, setValue] = useState('');
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!value.trim()) return;
+    onSend(value);
+    setValue('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex p-2 border-t">
+      <input
+        className="flex-1 border rounded px-2"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+      <button type="submit" className="ml-2 px-4 py-1 bg-blue-500 text-white rounded">
+        Send
+      </button>
+    </form>
+  );
+}

--- a/client/src/components/chat/message-list.tsx
+++ b/client/src/components/chat/message-list.tsx
@@ -1,0 +1,23 @@
+interface Message {
+  id: number;
+  senderCognitoId: string;
+  content: string;
+  createdAt: string;
+}
+
+interface MessageListProps {
+  messages: Message[];
+}
+
+export default function MessageList({ messages }: MessageListProps) {
+  return (
+    <div className="flex-1 overflow-y-auto p-2">
+      {messages.map((m) => (
+        <div key={m.id} className="mb-2">
+          <div className="text-xs text-gray-500">{m.senderCognitoId}</div>
+          <div>{m.content}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -24,6 +24,7 @@
         "morgan": "^1.10.1",
         "multer": "^1.4.5-lts.1",
         "prisma": "^6.13.0",
+        "socket.io": "^4.7.5",
         "uuid": "^11.1.0",
         "zod": "^3.23.8"
       },
@@ -49,6 +50,7 @@
         "prettier": "^3.6.2",
         "rimraf": "^6.0.1",
         "shx": "^0.3.4",
+        "socket.io-client": "^4.7.5",
         "supertest": "^7.1.1",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
@@ -3158,6 +3160,12 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
@@ -3273,7 +3281,6 @@
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
       "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3431,7 +3438,6 @@
       "version": "22.17.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.0.tgz",
       "integrity": "sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4243,6 +4249,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",
@@ -5170,6 +5185,106 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
+      "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
+      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -9093,6 +9208,157 @@
         "node": ">=8"
       }
     },
+    "node_modules/socket.io": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-client/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -9814,8 +10080,7 @@
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",
@@ -10121,6 +10386,36 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/server/package.json
+++ b/server/package.json
@@ -40,6 +40,7 @@
     "morgan": "^1.10.1",
     "multer": "^1.4.5-lts.1",
     "prisma": "^6.13.0",
+    "socket.io": "^4.7.5",
     "uuid": "^11.1.0",
     "zod": "^3.23.8"
   },
@@ -65,6 +66,7 @@
     "prettier": "^3.6.2",
     "rimraf": "^6.0.1",
     "shx": "^0.3.4",
+    "socket.io-client": "^4.7.5",
     "supertest": "^7.1.1",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",

--- a/server/prisma/migrations/20250819183000_add_conversation_message/migration.sql
+++ b/server/prisma/migrations/20250819183000_add_conversation_message/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable Conversation
+CREATE TABLE "Conversation" (
+    "id" SERIAL PRIMARY KEY,
+    "tenantCognitoId" TEXT NOT NULL,
+    "managerCognitoId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable Message
+CREATE TABLE "Message" (
+    "id" SERIAL PRIMARY KEY,
+    "conversationId" INTEGER NOT NULL,
+    "senderCognitoId" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- AddForeignKey
+ALTER TABLE "Conversation" ADD CONSTRAINT "Conversation_tenantCognitoId_fkey" FOREIGN KEY ("tenantCognitoId") REFERENCES "Tenant"("cognitoId") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Conversation" ADD CONSTRAINT "Conversation_managerCognitoId_fkey" FOREIGN KEY ("managerCognitoId") REFERENCES "Manager"("cognitoId") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Message" ADD CONSTRAINT "Message_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "Conversation"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -103,6 +103,7 @@ model Manager {
   phoneNumber String
 
   managedProperties Property[]
+  conversations    Conversation[]
 }
 
 model Tenant {
@@ -116,6 +117,7 @@ model Tenant {
   favorites    Property[]    @relation("TenantFavorites")
   applications Application[]
   leases       Lease[]
+  conversations Conversation[]
 }
 
 model Location {
@@ -172,6 +174,27 @@ model Payment {
   leaseId       Int
 
   lease Lease @relation(fields: [leaseId], references: [id])
+}
+
+model Conversation {
+  id               Int      @id @default(autoincrement())
+  tenantCognitoId  String
+  managerCognitoId String
+  createdAt        DateTime @default(now())
+
+  tenant  Tenant  @relation(fields: [tenantCognitoId], references: [cognitoId])
+  manager Manager @relation(fields: [managerCognitoId], references: [cognitoId])
+  messages Message[]
+}
+
+model Message {
+  id              Int      @id @default(autoincrement())
+  conversationId  Int
+  senderCognitoId String
+  content         String
+  createdAt       DateTime @default(now())
+
+  conversation Conversation @relation(fields: [conversationId], references: [id])
 }
 
 model Listing {

--- a/server/src/__tests__/messages.test.ts
+++ b/server/src/__tests__/messages.test.ts
@@ -1,0 +1,174 @@
+import request from 'supertest';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import { createServer } from 'http';
+import { Server } from 'socket.io';
+import Client from 'socket.io-client';
+
+const mockPrisma = {
+  conversation: {
+    findUnique: jest.fn(),
+  },
+  message: {
+    findMany: jest.fn(),
+    create: jest.fn(),
+  },
+};
+
+jest.mock('../utils/prisma', () => ({
+  __esModule: true,
+  default: mockPrisma,
+}));
+
+jest.mock('../middleware/auth-middleware', () => ({
+  authMiddleware: () => (_req: any, _res: any, next: any) => next(),
+}));
+
+import messageRoutes from '../routes/message-routes';
+
+const setEnv = () => {
+  process.env.JWT_SECRET = 'test-secret';
+  process.env.COGNITO_AUDIENCE = 'test-aud';
+  process.env.COGNITO_ISSUER = 'test-iss';
+};
+
+describe('Messages API', () => {
+  let app: express.Express;
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    let currentUser = { id: 'tenant1', role: 'tenant' } as any;
+    app.use((req, _res, next) => {
+      req.user = currentUser;
+      next();
+    });
+    app.use('/messages', messageRoutes);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns messages for participant', async () => {
+    mockPrisma.conversation.findUnique.mockResolvedValue({
+      id: 1,
+      tenantCognitoId: 'tenant1',
+      managerCognitoId: 'manager1',
+    });
+    mockPrisma.message.findMany.mockResolvedValue([
+      {
+        id: 1,
+        conversationId: 1,
+        senderCognitoId: 'tenant1',
+        content: 'hi',
+        createdAt: new Date(),
+      },
+    ]);
+    const res = await request(app).get('/messages/1');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+  });
+
+  it('rejects non-participant', async () => {
+    mockPrisma.conversation.findUnique.mockResolvedValue({
+      id: 1,
+      tenantCognitoId: 'tenant1',
+      managerCognitoId: 'manager1',
+    });
+    const app2 = express();
+    app2.use(express.json());
+    app2.use((req, _res, next) => {
+      req.user = { id: 'other', role: 'tenant' } as any;
+      next();
+    });
+    app2.use('/messages', messageRoutes);
+    const res = await request(app2).get('/messages/1');
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('WebSocket messaging', () => {
+  let io: Server, server: any, port: number;
+
+  beforeAll((done) => {
+    setEnv();
+    const app = express();
+    server = createServer(app);
+    io = new Server(server);
+    io.use((socket, next) => {
+      const token = socket.handshake.auth.token;
+      try {
+        const decoded = jwt.verify(token, process.env.JWT_SECRET!, {
+          algorithms: ['HS256'],
+          audience: process.env.COGNITO_AUDIENCE,
+          issuer: process.env.COGNITO_ISSUER,
+        }) as any;
+        socket.data.user = { id: decoded.sub };
+        next();
+      } catch {
+        next(new Error('Unauthorized'));
+      }
+    });
+    io.on('connection', (socket) => {
+      socket.on('joinConversation', async (conversationId: number) => {
+        const convo = await mockPrisma.conversation.findUnique({ where: { id: conversationId } });
+        const userId = socket.data.user.id;
+        if (convo && (convo.tenantCognitoId === userId || convo.managerCognitoId === userId)) {
+          socket.join(`conversation_${conversationId}`);
+        }
+      });
+      socket.on('sendMessage', async ({ conversationId, content }) => {
+        const convo = await mockPrisma.conversation.findUnique({ where: { id: conversationId } });
+        const userId = socket.data.user.id;
+        if (convo && (convo.tenantCognitoId === userId || convo.managerCognitoId === userId)) {
+          const message = await mockPrisma.message.create({
+            data: { conversationId, senderCognitoId: userId, content },
+          });
+          io.to(`conversation_${conversationId}`).emit('newMessage', message);
+        }
+      });
+    });
+    server.listen(() => {
+      port = (server.address() as any).port;
+      done();
+    });
+  });
+
+  afterAll(() => {
+    io.close();
+    server.close();
+  });
+
+  it('emits messages to room participants', (done) => {
+    mockPrisma.conversation.findUnique.mockResolvedValue({
+      id: 1,
+      tenantCognitoId: 'tenant1',
+      managerCognitoId: 'manager1',
+    });
+    mockPrisma.message.create.mockResolvedValue({
+      id: 1,
+      conversationId: 1,
+      senderCognitoId: 'tenant1',
+      content: 'hello',
+      createdAt: new Date(),
+    });
+
+    const token = jwt.sign({ sub: 'tenant1', 'custom:role': 'tenant' }, process.env.JWT_SECRET!, {
+      algorithm: 'HS256',
+      audience: process.env.COGNITO_AUDIENCE,
+      issuer: process.env.COGNITO_ISSUER,
+    });
+    const client = Client(`http://localhost:${port}`, {
+      auth: { token },
+    });
+    client.on('connect', () => {
+      client.emit('joinConversation', 1);
+      client.emit('sendMessage', { conversationId: 1, content: 'hello' });
+    });
+    client.on('newMessage', (msg: any) => {
+      expect(msg.content).toBe('hello');
+      client.close();
+      done();
+    });
+  });
+});

--- a/server/src/controllers/message-controllers.ts
+++ b/server/src/controllers/message-controllers.ts
@@ -1,0 +1,32 @@
+import { Request, Response, NextFunction } from 'express';
+import prisma from '../utils/prisma';
+import { getMessages as getMessagesService } from '../services/message-service';
+
+export const getMessages = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const conversationId = Number(req.params.conversationId);
+    const conversation = await prisma.conversation.findUnique({
+      where: { id: conversationId },
+    });
+
+    if (!conversation) {
+      res.status(404).json({ message: 'Conversation not found' });
+      return;
+    }
+
+    const userId = req.user?.id;
+    if (userId !== conversation.tenantCognitoId && userId !== conversation.managerCognitoId) {
+      res.status(403).json({ message: 'Access Denied' });
+      return;
+    }
+
+    const messages = await getMessagesService(conversationId);
+    res.json(messages);
+  } catch (err) {
+    next(err);
+  }
+};

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,10 +3,21 @@ import helmet from 'helmet';
 import morgan from 'morgan';
 import cors from 'cors';
 import rateLimit from 'express-rate-limit';
-import { CLIENT_ORIGIN, PORT } from './env';
+import { createServer } from 'http';
+import { Server as SocketIOServer } from 'socket.io';
+import jwt from 'jsonwebtoken';
+import {
+  CLIENT_ORIGIN,
+  PORT,
+  COGNITO_JWT_PUBLIC_KEY,
+  JWT_SECRET,
+  COGNITO_AUDIENCE,
+  COGNITO_ISSUER,
+} from './env';
 import { authMiddleware } from './middleware/auth-middleware';
 import { notFound } from './middleware/not-found';
 import { errorHandler } from './middleware/error-handler';
+import prisma from './utils/prisma';
 
 /* ROUTE IMPORT */
 import tenantRoutes from './routes/tenant-routes';
@@ -14,6 +25,7 @@ import managerRoutes from './routes/manager-routes';
 import propertyRoutes from './routes/property-routes';
 import leaseRoutes from './routes/lease-routes';
 import applicationRoutes from './routes/application-routes';
+import messageRoutes from './routes/message-routes';
 
 /* CONFIGURATIONS */
 const app = express();
@@ -40,12 +52,86 @@ app.use('/properties', propertyRoutes);
 app.use('/leases', leaseRoutes);
 app.use('/tenants', authMiddleware(['tenant']), tenantRoutes);
 app.use('/managers', authMiddleware(['manager']), managerRoutes);
+app.use('/messages', messageRoutes);
 
 app.use(notFound);
 app.use(errorHandler);
 
 /* SERVER */
 const port = PORT;
-app.listen(port, '0.0.0.0', () => {
+const httpServer = createServer(app);
+
+const io = new SocketIOServer(httpServer, {
+  cors: { origin: CLIENT_ORIGIN },
+});
+
+io.use((socket, next) => {
+  const token = socket.handshake.auth?.token;
+  if (!token) {
+    return next(new Error('Unauthorized'));
+  }
+  try {
+    let decoded: any;
+    if (COGNITO_JWT_PUBLIC_KEY) {
+      decoded = jwt.verify(token, COGNITO_JWT_PUBLIC_KEY, {
+        algorithms: ['RS256'],
+        audience: COGNITO_AUDIENCE,
+        issuer: COGNITO_ISSUER,
+      });
+    } else if (JWT_SECRET) {
+      decoded = jwt.verify(token, JWT_SECRET, {
+        algorithms: ['HS256'],
+        audience: COGNITO_AUDIENCE,
+        issuer: COGNITO_ISSUER,
+      });
+    } else {
+      throw new Error('Missing JWT configuration');
+    }
+    socket.data.user = { id: decoded.sub, role: decoded['custom:role'] || '' };
+    next();
+  } catch (_err) {
+    next(new Error('Unauthorized'));
+  }
+});
+
+io.on('connection', (socket) => {
+  socket.on('joinConversation', async (conversationId: number) => {
+    const conversation = await prisma.conversation.findUnique({
+      where: { id: conversationId },
+    });
+    const userId = socket.data.user.id;
+    if (
+      conversation &&
+      (conversation.tenantCognitoId === userId || conversation.managerCognitoId === userId)
+    ) {
+      socket.join(`conversation_${conversationId}`);
+    }
+  });
+
+  socket.on(
+    'sendMessage',
+    async ({ conversationId, content }: { conversationId: number; content: string }) => {
+      const conversation = await prisma.conversation.findUnique({
+        where: { id: conversationId },
+      });
+      const userId = socket.data.user.id;
+      if (
+        conversation &&
+        (conversation.tenantCognitoId === userId || conversation.managerCognitoId === userId)
+      ) {
+        const message = await prisma.message.create({
+          data: {
+            conversationId,
+            senderCognitoId: userId,
+            content,
+          },
+        });
+        io.to(`conversation_${conversationId}`).emit('newMessage', message);
+      }
+    },
+  );
+});
+
+httpServer.listen(port, '0.0.0.0', () => {
   console.log(`Server running on port ${port}`);
 });

--- a/server/src/routes/message-routes.ts
+++ b/server/src/routes/message-routes.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import { getMessages } from '../controllers/message-controllers';
+import { authMiddleware } from '../middleware/auth-middleware';
+
+const router = express.Router();
+
+router.get('/:conversationId', authMiddleware(['tenant', 'manager']), getMessages);
+
+export default router;

--- a/server/src/services/message-service.ts
+++ b/server/src/services/message-service.ts
@@ -1,0 +1,18 @@
+import prisma from '../utils/prisma';
+
+export const getMessages = async (conversationId: number) => {
+  return prisma.message.findMany({
+    where: { conversationId },
+    orderBy: { createdAt: 'asc' },
+  });
+};
+
+export const createMessage = async (
+  conversationId: number,
+  senderCognitoId: string,
+  content: string,
+) => {
+  return prisma.message.create({
+    data: { conversationId, senderCognitoId, content },
+  });
+};


### PR DESCRIPTION
## Summary
- introduce Socket.IO gateway and message routes on server
- add Prisma Conversation and Message models with migration
- create client chat components using Socket.IO

## Testing
- `npx prisma migrate dev --name add-conversation-message --create-only` *(fails: missing database server)*
- `cd server && npm test` *(fails: prettier parse errors in existing tests)*
- `cd client && npm test` *(fails: code style issues in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c0ee624483289d514f852035bbfc