### PR TITLE
ci: add dependency lint jobs and run e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
           cd client
           npm test
 
+  client-deps-lint:
+    permissions: { contents: read }
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1
@@ -105,7 +107,8 @@ jobs:
           cd server
           npm test
 
-
+  server-deps-lint:
+    permissions: { contents: read }
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1
@@ -149,9 +152,15 @@ jobs:
           cd client
           npx playwright install --with-deps
       - name: Run E2E tests
+        env:
+          BROWSER: ${{ matrix.browser }}
         run: |
           cd client
           npm start &
+          SERVER_PID=$!
+          npx wait-on http://localhost:3000
+          npm run test:e2e -- --project=${{ matrix.browser }}
+          kill $SERVER_PID
 
 
   deploy:


### PR DESCRIPTION
## Summary
- split client/server dependency linting into distinct jobs
- run Playwright E2E tests and clean up server process

## Testing
- `/root/.local/share/mise/installs/go/1.24.3/bin/actionlint .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a58804d0b883289e7334421b4041ae