### PR TITLE
chore: import NextConfig type

### DIFF
--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -1,4 +1,4 @@
-
+import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   images: {


### PR DESCRIPTION
## Summary
- import NextConfig type in Next.js config

## Testing
- `npm run typecheck` *(fails: Cannot find module '@aws-amplify/core/dist/esm/Hub/types' or its corresponding type declarations, and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a58806ce78832881cf1dcf6416f90f