### PR TITLE
chore: enable jest testing in client

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,7 @@
     "lint": "prettier --ignore-path ../.prettierignore --check . && next lint",
     "lint:deps": "depcheck",
     "typecheck": "tsc --noEmit",
-    "test": "echo 'no tests'",
+    "test": "jest",
     "test:e2e": "playwright test -c tests/e2e/playwright.config.ts",
     "test:e2e:ui": "playwright test -c tests/e2e/playwright.config.ts --ui",
     "format": "prettier --ignore-path ../.prettierignore --write .",

--- a/client/src/__tests__/basic.test.ts
+++ b/client/src/__tests__/basic.test.ts
@@ -1,0 +1,5 @@
+describe('sample test', () => {
+  it('adds numbers', () => {
+    expect(1 + 2).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- replace the placeholder test script with `jest`
- add a basic sample unit test under `src/__tests__`

## Testing
- `npm test` *(fails: payment API test expects lease id)*

------
https://chatgpt.com/codex/tasks/task_e_68a5880808b883288ffc5c372b6732e6