### PR TITLE
Handle geocode timeout with descriptive error and test

### DIFF
--- a/server/src/utils/__tests__/geocode-address.test.ts
+++ b/server/src/utils/__tests__/geocode-address.test.ts
@@ -5,7 +5,10 @@ describe('geocodeAddress', () => {
   });
 
   it('throws error when GEOCODE_USER_AGENT is undefined', async () => {
-    jest.doMock('axios', () => ({ get: jest.fn().mockResolvedValue({ data: [{ lon: '1', lat: '2' }] }) }));
+    jest.doMock('axios', () => ({
+      get: jest.fn().mockResolvedValue({ data: [{ lon: '1', lat: '2' }] }),
+      isAxiosError: () => false,
+    }));
     jest.doMock('../../env', () => ({ GEOCODE_USER_AGENT: undefined }));
     jest.doMock('../../services/geocode-cache', () => ({
       getCachedGeocode: jest.fn().mockResolvedValue(null),
@@ -14,19 +17,16 @@ describe('geocodeAddress', () => {
 
     const { geocodeAddress } = require('../geocode-address');
 
-    await expect(
-      geocodeAddress('123 Main St', 'Springfield', 'USA', '12345'),
-    ).rejects.toThrow('GEOCODE_USER_AGENT environment variable is required');
+    await expect(geocodeAddress('123 Main St', 'Springfield', 'USA', '12345')).rejects.toThrow(
+      'GEOCODE_USER_AGENT environment variable is required',
+    );
   });
 
   it('caching prevents duplicate HTTP requests', async () => {
     const axiosGet = jest.fn().mockResolvedValue({ data: [{ lon: '1', lat: '2' }] });
-    jest.doMock('axios', () => ({ get: axiosGet }));
+    jest.doMock('axios', () => ({ get: axiosGet, isAxiosError: () => false }));
 
-    const getCachedGeocode = jest
-      .fn()
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce([1, 2]);
+    const getCachedGeocode = jest.fn().mockResolvedValueOnce(null).mockResolvedValueOnce([1, 2]);
     const saveGeocode = jest.fn();
 
     jest.doMock('../../env', () => ({ GEOCODE_USER_AGENT: 'agent' }));
@@ -43,5 +43,23 @@ describe('geocodeAddress', () => {
     expect(axiosGet).toHaveBeenCalledTimes(1);
     expect(getCachedGeocode).toHaveBeenCalledTimes(2);
   });
-});
 
+  it('throws a descriptive error when the geocoding request times out', async () => {
+    jest.doMock('axios', () => ({
+      get: jest.fn().mockRejectedValue({ code: 'ECONNABORTED' }),
+      isAxiosError: () => true,
+    }));
+
+    jest.doMock('../../env', () => ({ GEOCODE_USER_AGENT: 'agent' }));
+    jest.doMock('../../services/geocode-cache', () => ({
+      getCachedGeocode: jest.fn().mockResolvedValue(null),
+      saveGeocode: jest.fn(),
+    }));
+
+    const { geocodeAddress } = require('../geocode-address');
+
+    await expect(geocodeAddress('123 Main St', 'Springfield', 'USA', '12345')).rejects.toThrow(
+      'Geocoding request timed out',
+    );
+  });
+});

--- a/server/src/utils/geocode-address.ts
+++ b/server/src/utils/geocode-address.ts
@@ -26,11 +26,21 @@ export const geocodeAddress = async (
     throw new Error('GEOCODE_USER_AGENT environment variable is required for geocoding requests');
   }
 
-  const geocodingResponse = await axios.get(geocodingUrl, {
-    headers: {
-      'User-Agent': GEOCODE_USER_AGENT,
-    },
-  });
+  let geocodingResponse;
+
+  try {
+    geocodingResponse = await axios.get(geocodingUrl, {
+      headers: {
+        'User-Agent': GEOCODE_USER_AGENT,
+      },
+      timeout: 5000,
+    });
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.code === 'ECONNABORTED') {
+      throw new Error('Geocoding request timed out');
+    }
+    throw error;
+  }
 
   if (!geocodingResponse.data?.[0]) {
     throw new Error('Geocoding failed');


### PR DESCRIPTION
## Summary
- add 5s timeout and timeout error handling to geocode utility
- cover timeout case in geocode unit tests

## Testing
- `npm test`
- `npx jest src/utils/__tests__/geocode-address.test.ts`
- `npm run lint` *(fails: Code style issues found in 27 files. Run Prettier with --write to fix.)*

------
https://chatgpt.com/codex/tasks/task_e_68a5880a157883288e6f7b8968b720a7