### PR TITLE
chore: run node app containers as non-root

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -21,5 +21,7 @@ COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/next.config.ts ./next.config.ts
 COPY --from=deps /app/node_modules ./node_modules
 RUN npm prune --omit=dev
+RUN chown -R node:node /app
+USER node
 EXPOSE 3000
 CMD ["npm", "run", "start"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,5 +3,7 @@ WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm ci --omit=dev
 COPY dist ./dist
+RUN chown -R node:node /app
+USER node
 EXPOSE 3001
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary
- ensure client container runs as `node` user
- ensure server container runs as `node` user

## Testing
- `npm test` in client
- `npm test` in server
- `docker build -t enterprise-client-test ./client` *(fails: Cannot connect to the Docker daemon)*


------
https://chatgpt.com/codex/tasks/task_e_68a588239d94832883c818ae014fda1d