### PR TITLE
Use bcrypt for password handling

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,6 +14,7 @@
         "@prisma/client": "^6.13.0",
         "@terraformer/wkt": "^2.2.1",
         "axios": "^1.11.0",
+        "bcrypt": "^6.0.0",
         "body-parser": "^1.20.3",
         "cors": "^2.8.5",
         "dotenv": "^16.6.1",
@@ -4325,6 +4326,20 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -8055,10 +8070,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-fetch-native": {
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.6.tgz",
       "integrity": "sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ=="
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",

--- a/server/package.json
+++ b/server/package.json
@@ -11,11 +11,11 @@
     "prisma:generate": "prisma generate",
     "postprisma:generate": "shx cp -r node_modules/.prisma/client/index.d.ts ../client/src/types/prismaTypes.d.ts",
     "typecheck": "tsc --noEmit",
-    "test": "jest src/__tests__/auth-mfa.test.ts src/__tests__/rbac-middleware.test.ts",
+    "test": "jest --runTestsByPath src/__tests__/auth-mfa.test.ts src/__tests__/rbac-middleware.test.ts src/__tests__/auth-login.test.ts",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "format": "prettier --ignore-path ../.prettierignore --write .",
-    "pretest": "prettier --ignore-path ../.prettierignore --check src/__tests__/auth-mfa.test.ts src/__tests__/rbac-middleware.test.ts src/controllers/auth-controllers.ts src/middleware/rbac.ts"
+    "pretest": "prettier --ignore-path ../.prettierignore --check src/__tests__/auth-mfa.test.ts src/__tests__/rbac-middleware.test.ts src/__tests__/auth-login.test.ts src/controllers/auth-controllers.ts src/middleware/rbac.ts"
   },
   "keywords": [],
   "author": "",
@@ -30,6 +30,7 @@
     "@prisma/client": "^6.13.0",
     "@terraformer/wkt": "^2.2.1",
     "axios": "^1.11.0",
+    "bcrypt": "^6.0.0",
     "body-parser": "^1.20.3",
     "cors": "^2.8.5",
     "dotenv": "^16.6.1",

--- a/server/src/__tests__/auth-login.test.ts
+++ b/server/src/__tests__/auth-login.test.ts
@@ -1,0 +1,44 @@
+import express from 'express';
+import request from 'supertest';
+import bcrypt from 'bcrypt';
+
+const mockPrisma = {
+  user: {
+    findUnique: jest.fn(),
+  },
+};
+
+jest.mock('../utils/prisma', () => ({
+  __esModule: true,
+  default: mockPrisma,
+}));
+
+import { login } from '../controllers/auth-controllers';
+
+const app = express();
+app.use(express.json());
+app.post('/login', login);
+
+describe('login', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('logs in with correct credentials', async () => {
+    const password = 'secret';
+    const hashed = await bcrypt.hash(password, 10);
+    mockPrisma.user.findUnique.mockResolvedValue({ id: 1, password: hashed });
+
+    const res = await request(app).post('/login').send({ userId: 1, password });
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Logged in');
+  });
+
+  it('rejects invalid credentials', async () => {
+    const hashed = await bcrypt.hash('secret', 10);
+    mockPrisma.user.findUnique.mockResolvedValue({ id: 1, password: hashed });
+
+    const res = await request(app).post('/login').send({ userId: 1, password: 'wrong' });
+    expect(res.status).toBe(401);
+  });
+});

--- a/server/src/controllers/auth-controllers.ts
+++ b/server/src/controllers/auth-controllers.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { authenticator } from 'otplib';
+import bcrypt from 'bcrypt';
 import prisma from '../utils/prisma';
 
 const issuer = process.env.TOTP_ISSUER || 'enterprise-garage-sale-app';
@@ -39,7 +40,8 @@ export const login = async (req: Request, res: Response, next: NextFunction): Pr
   try {
     const { userId, password, token } = req.body;
     const user = await prisma.user.findUnique({ where: { id: userId } });
-    if (!user || user.password !== password) {
+    const passwordMatches = user ? await bcrypt.compare(password, user.password) : false;
+    if (!user || !passwordMatches) {
       res.status(401).json({ message: 'Invalid credentials' });
       return;
     }
@@ -50,6 +52,19 @@ export const login = async (req: Request, res: Response, next: NextFunction): Pr
       }
     }
     res.json({ message: 'Logged in' });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const register = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const { email, password, role } = req.body;
+    const hashedPassword = await bcrypt.hash(password, 10);
+    const user = await prisma.user.create({
+      data: { email, password: hashedPassword, role },
+    });
+    res.status(201).json({ id: user.id });
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
## Summary
- replace plain password comparison with `bcrypt.compare`
- hash passwords during user registration
- add login tests covering correct and incorrect passwords

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a588650fa08328a7e045b46a1d0bf9