### PR TITLE
Use shared API_URL for auth and persist JWT

### DIFF
--- a/client/src/app/(auth)/login.tsx
+++ b/client/src/app/(auth)/login.tsx
@@ -1,8 +1,11 @@
 'use client';
 import { useState } from 'react';
 import axios from 'axios';
+import { useRouter } from 'next/navigation';
+import { API_URL } from '@/config';
 
 export default function Login() {
+  const router = useRouter();
   const [userId, setUserId] = useState('');
   const [password, setPassword] = useState('');
   const [token, setToken] = useState('');
@@ -11,8 +14,15 @@ export default function Login() {
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await axios.post('/api/login', { userId, password, token });
-      alert('Logged in');
+      const res = await axios.post(`${API_URL}/auth/login`, {
+        userId,
+        password,
+        token,
+      });
+      if (res.data?.token || res.data?.jwt) {
+        localStorage.setItem('jwt', res.data.token ?? res.data.jwt);
+      }
+      router.push('/dashboard');
     } catch (err: any) {
       if (err.response?.status === 401) {
         setMfa(true);

--- a/client/src/app/(auth)/setup-mfa.tsx
+++ b/client/src/app/(auth)/setup-mfa.tsx
@@ -1,22 +1,29 @@
 'use client';
 import { useState } from 'react';
 import axios from 'axios';
+import { useRouter } from 'next/navigation';
+import { API_URL } from '@/config';
 
 export default function SetupMfa() {
+  const router = useRouter();
   const [userId, setUserId] = useState('');
   const [secret, setSecret] = useState('');
   const [token, setToken] = useState('');
   const [verified, setVerified] = useState(false);
 
   const handleSetup = async () => {
-    const res = await axios.post('/api/mfa/setup', { userId });
+    const res = await axios.post(`${API_URL}/auth/mfa/setup`, { userId });
     setSecret(res.data.secret);
   };
 
   const handleVerify = async () => {
     try {
-      await axios.post('/api/mfa/verify', { userId, token });
+      const res = await axios.post(`${API_URL}/auth/mfa/verify`, { userId, token });
       setVerified(true);
+      if (res.data?.token || res.data?.jwt) {
+        localStorage.setItem('jwt', res.data.token ?? res.data.jwt);
+      }
+      router.push('/dashboard');
     } catch {
       setVerified(false);
     }


### PR DESCRIPTION
## Summary
- import API_URL into auth pages and use it for login and MFA requests
- store returned JWT in local storage and navigate to dashboard on success

## Testing
- `npm test` (client)
- `npm test` (server)


------
https://chatgpt.com/codex/tasks/task_e_68a6d1fe534483288267c1080954e56d