### PR TITLE
Validate application status and date

### DIFF
--- a/server/src/__tests__/application-controllers.test.ts
+++ b/server/src/__tests__/application-controllers.test.ts
@@ -124,13 +124,58 @@ describe('applicationControllers', () => {
     expect(mockPrisma.property.findUnique).not.toHaveBeenCalled();
   });
 
-  it('updates application status to Approved', async () => {
+  it('returns 400 for invalid status', async () => {
+    const req = {
+      body: {
+        applicationDate: new Date().toISOString(),
+        status: 'NotAStatus',
+        propertyId: 1,
+        tenantCognitoId: 't1',
+        name: 'n',
+        email: 'e@example.com',
+        phoneNumber: 'p',
+      },
+    } as unknown as Request;
+    const res = createMockRes();
 
+    await createApplication(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockPrisma.property.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid application date', async () => {
+    const req = {
+      body: {
+        applicationDate: 'not-a-date',
+        status: 'Pending',
+        propertyId: 1,
+        tenantCognitoId: 't1',
+        name: 'n',
+        email: 'e@example.com',
+        phoneNumber: 'p',
+      },
+    } as unknown as Request;
+    const res = createMockRes();
+
+    await createApplication(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockPrisma.property.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('updates application status to Approved', async () => {
+    (updateApplicationStatusService as jest.Mock).mockResolvedValue({ id: 1 });
+    const req = {
+      params: { id: '1' },
+      body: { status: 'Approved' },
+    } as unknown as Request;
     const res = createMockRes();
 
     await updateApplicationStatus(req, res, next);
 
-
+    expect(updateApplicationStatusService).toHaveBeenCalledWith(1, 'Approved');
+    expect(res.json).toHaveBeenCalledWith({ id: 1 });
   });
 
   it('updates application status to non-Approved value', async () => {
@@ -149,7 +194,10 @@ describe('applicationControllers', () => {
 
   it('returns 404 when updating missing application', async () => {
     (updateApplicationStatusService as jest.Mock).mockResolvedValue(null);
-
+    const req = {
+      params: { id: '1' },
+      body: { status: 'Approved' },
+    } as unknown as Request;
     const res = createMockRes();
 
     await updateApplicationStatus(req, res, next);

--- a/server/src/controllers/application-controllers.ts
+++ b/server/src/controllers/application-controllers.ts
@@ -4,8 +4,8 @@ import prisma from '../utils/prisma';
 import { updateApplicationStatus as updateApplicationStatusService } from '../services/application-service';
 
 const createApplicationSchema = z.object({
-  applicationDate: z.string(),
-  status: z.string(),
+  applicationDate: z.coerce.date(),
+  status: z.enum(['Pending', 'Denied', 'Approved']),
   propertyId: z.coerce.number(),
   tenantCognitoId: z.string(),
   name: z.string(),
@@ -126,13 +126,13 @@ export const createApplication = async (
       return;
     }
 
-      const newApplication = await prisma.application.create({
-        data: {
-          applicationDate: new Date(applicationDate),
-          status: status as any,
-          name,
-          email,
-          phoneNumber,
+    const newApplication = await prisma.application.create({
+      data: {
+        applicationDate,
+        status,
+        name,
+        email,
+        phoneNumber,
         message,
         property: {
           connect: { id: propertyId },


### PR DESCRIPTION
## Summary
- restrict application status to Pending, Denied, or Approved
- coerce applicationDate to Date and drop manual date conversion
- add controller tests for invalid statuses and dates

## Testing
- `npm test`
- `npx jest src/__tests__/application-controllers.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a6d20077c88328b130a44de98c7a55