### PR TITLE
feat: add photo uploads to listing form

### DIFF
--- a/client/src/components/forms/ListingForm.tsx
+++ b/client/src/components/forms/ListingForm.tsx
@@ -1,30 +1,27 @@
-import { z } from "zod";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm } from "react-hook-form";
-import { Form } from "@/components/ui/form";
-import { Button } from "@/components/ui/button";
-import { CustomFormField } from "../form-field";
-import { createListing } from "@/lib/api";
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { Form } from '@/components/ui/form';
+import { Button } from '@/components/ui/button';
+import { CustomFormField } from '../form-field';
+import { createListing } from '@/lib/api';
 
 const listingSchema = z.object({
-  name: z.string().min(1, "Name is required"),
-  description: z.string().min(1, "Description is required"),
-  pricePerMonth: z.coerce.number().positive("Price must be positive"),
-  securityDeposit: z.coerce
-    .number()
-    .nonnegative("Security deposit must be zero or more"),
-  applicationFee: z.coerce
-    .number()
-    .nonnegative("Application fee must be zero or more"),
-  beds: z.coerce.number().int().positive("Beds must be at least 1"),
-  baths: z.coerce.number().positive("Baths must be positive"),
-  squareFeet: z.coerce.number().int().positive("Square feet must be positive"),
-  propertyType: z.string().min(1, "Property type is required"),
-  address: z.string().min(1, "Address is required"),
-  city: z.string().min(1, "City is required"),
-  state: z.string().min(1, "State is required"),
-  country: z.string().min(1, "Country is required"),
-  postalCode: z.string().min(1, "Postal code is required"),
+  name: z.string().min(1, 'Name is required'),
+  description: z.string().min(1, 'Description is required'),
+  pricePerMonth: z.coerce.number().positive('Price must be positive'),
+  securityDeposit: z.coerce.number().nonnegative('Security deposit must be zero or more'),
+  applicationFee: z.coerce.number().nonnegative('Application fee must be zero or more'),
+  beds: z.coerce.number().int().positive('Beds must be at least 1'),
+  baths: z.coerce.number().positive('Baths must be positive'),
+  squareFeet: z.coerce.number().int().positive('Square feet must be positive'),
+  propertyType: z.string().min(1, 'Property type is required'),
+  address: z.string().min(1, 'Address is required'),
+  city: z.string().min(1, 'City is required'),
+  state: z.string().min(1, 'State is required'),
+  country: z.string().min(1, 'Country is required'),
+  postalCode: z.string().min(1, 'Postal code is required'),
+  photos: z.array(z.instanceof(File)).optional(),
 });
 
 export type ListingFormData = z.infer<typeof listingSchema>;
@@ -35,7 +32,7 @@ const ListingForm = ({ onSuccess }: { onSuccess?: () => void }) => {
   });
 
   const onSubmit = async (data: ListingFormData) => {
-    await createListing(data);
+    await createListing({ ...data, photos: data.photos });
     form.reset();
     onSuccess?.();
   };
@@ -45,34 +42,19 @@ const ListingForm = ({ onSuccess }: { onSuccess?: () => void }) => {
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
         <CustomFormField name="name" label="Property Name" />
         <CustomFormField name="description" label="Description" type="textarea" />
-        <CustomFormField
-          name="pricePerMonth"
-          label="Price per Month"
-          type="number"
-        />
-        <CustomFormField
-          name="securityDeposit"
-          label="Security Deposit"
-          type="number"
-        />
-        <CustomFormField
-          name="applicationFee"
-          label="Application Fee"
-          type="number"
-        />
+        <CustomFormField name="pricePerMonth" label="Price per Month" type="number" />
+        <CustomFormField name="securityDeposit" label="Security Deposit" type="number" />
+        <CustomFormField name="applicationFee" label="Application Fee" type="number" />
         <CustomFormField name="beds" label="Beds" type="number" />
         <CustomFormField name="baths" label="Baths" type="number" />
-        <CustomFormField
-          name="squareFeet"
-          label="Square Feet"
-          type="number"
-        />
+        <CustomFormField name="squareFeet" label="Square Feet" type="number" />
         <CustomFormField name="propertyType" label="Property Type" />
         <CustomFormField name="address" label="Address" />
         <CustomFormField name="city" label="City" />
         <CustomFormField name="state" label="State" />
         <CustomFormField name="country" label="Country" />
         <CustomFormField name="postalCode" label="Postal Code" />
+        <CustomFormField name="photos" label="Photos" type="file" />
         <Button type="submit">Submit</Button>
       </form>
     </Form>


### PR DESCRIPTION
## Summary
- support optional photo uploads on listing creation
- submit photo files with new listing

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 102 files)*
- `npx prettier src/components/forms/ListingForm.tsx --check`


------
https://chatgpt.com/codex/tasks/task_e_68a6d1ffac548328b68b418da3e750f5