### PR TITLE
feat: add middleware imports to server index

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -32,6 +32,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@types/bcrypt": "^6.0.0",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/geojson": "^7946.0.0",
@@ -3296,6 +3297,16 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/body-parser": {

--- a/server/package.json
+++ b/server/package.json
@@ -48,6 +48,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/bcrypt": "^6.0.0",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/geojson": "^7946.0.0",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,11 +3,11 @@ import helmet from 'helmet';
 import morgan from 'morgan';
 import cors from 'cors';
 import rateLimit from 'express-rate-limit';
-import http from 'http';
-import { CLIENT_ORIGIN, PORT } from './env';
+import { PORT, CLIENT_ORIGIN } from './env';
 import { authMiddleware } from './middleware/auth-middleware';
-import { notFound } from './middleware/not-found';
-import { errorHandler } from './middleware/error-handler';
+import notFound from './middleware/not-found';
+import errorHandler from './middleware/error-handler';
+import http from 'http';
 import { initWebSocket } from './ws';
 
 /* ROUTE IMPORT */

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -1,17 +1,13 @@
-import { Request, Response, NextFunction } from "express";
+import { Request, Response, NextFunction } from 'express';
 
-export const errorHandler = (
-  err: any,
-  _req: Request,
-  res: Response,
-  _next: NextFunction
-): void => {
+export const errorHandler = (err: any, _req: Request, res: Response, _next: NextFunction): void => {
   console.error(err);
   if (err && err.stack) {
     console.error(err.stack);
   }
   const status = err.status || err.statusCode || 500;
-  const message = err.message || "Internal Server Error";
+  const message = err.message || 'Internal Server Error';
   res.status(status).json({ message });
 };
 
+export default errorHandler;


### PR DESCRIPTION
## Summary
- add express and middleware imports to server entry point
- export error handler as default and add missing bcrypt types

## Testing
- `npm test`
- `npm run lint` *(fails: code style issues found in 27 files)*
- `npm run build`
- `PORT=4000 DATABASE_URL=postgresql://user:pass@localhost:5432/db GEOCODE_USER_AGENT=agent COGNITO_AUDIENCE=aud COGNITO_ISSUER=iss AWS_REGION=us-east-1 S3_BUCKET_NAME=bucket AWS_ACCESS_KEY_ID=key AWS_SECRET_ACCESS_KEY=secret CLIENT_ORIGIN=http://localhost:3000 JWT_SECRET=secret node dist/server/src/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0fde35b1083289e59c19d9801cefe