### PR TITLE
Use PaymentStatus enum for payment operations

### DIFF
--- a/server/src/__tests__/payment.test.ts
+++ b/server/src/__tests__/payment.test.ts
@@ -10,11 +10,20 @@ const mockPrisma = {
   $disconnect: jest.fn(),
 };
 
+const mockPaymentStatus = {
+  Pending: 'Pending',
+  Paid: 'Paid',
+  PartiallyPaid: 'PartiallyPaid',
+  Overdue: 'Overdue',
+};
+
 jest.mock('@prisma/client', () => ({
   PrismaClient: jest.fn(() => mockPrisma),
   Prisma: { join: jest.fn() },
+  PaymentStatus: mockPaymentStatus,
 }));
 
+const { PaymentStatus } = require('@prisma/client');
 const prisma = require('../utils/prisma').default;
 const { createPayment, updatePayment } = require('../controllers/lease-controllers');
 
@@ -47,6 +56,7 @@ describe('Payment API', () => {
       amountDue: 100,
       amountPaid: 50,
       leaseId: 1,
+      paymentStatus: PaymentStatus.Pending,
     });
 
     const res = await request(app)
@@ -59,6 +69,7 @@ describe('Payment API', () => {
         leaseId: 1,
         amountDue: 100,
         amountPaid: 50,
+        paymentStatus: PaymentStatus.Pending,
       }),
     });
   });
@@ -76,9 +87,12 @@ describe('Payment API', () => {
       amountDue: 100,
       amountPaid: 75,
       leaseId: 1,
+      paymentStatus: PaymentStatus.Paid,
     });
 
-    const res = await request(app).put('/leases/payments/1').send({ amountPaid: 75 });
+    const res = await request(app)
+      .put('/leases/payments/1')
+      .send({ amountPaid: 75, paymentStatus: PaymentStatus.Paid });
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
@@ -86,10 +100,11 @@ describe('Payment API', () => {
       amountDue: 100,
       amountPaid: 75,
       leaseId: 1,
+      paymentStatus: PaymentStatus.Paid,
     });
     expect(mockPrisma.payment.update).toHaveBeenCalledWith({
       where: { id: 1 },
-      data: { amountPaid: 75 },
+      data: { amountPaid: 75, paymentStatus: PaymentStatus.Paid },
     });
   });
 

--- a/server/src/controllers/lease-controllers.ts
+++ b/server/src/controllers/lease-controllers.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
+import { PaymentStatus } from '@prisma/client';
 import prisma from '../utils/prisma';
 
 export const getLeases = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
@@ -35,6 +36,7 @@ export const getLeasePayments = async (
 const paymentSchema = z.object({
   amountDue: z.coerce.number(),
   amountPaid: z.coerce.number(),
+  paymentStatus: z.nativeEnum(PaymentStatus).optional(),
 });
 
 const updatePaymentSchema = paymentSchema.partial();
@@ -57,7 +59,7 @@ export const createPayment = async (
         leaseId: Number(id),
         dueDate: new Date(),
         paymentDate: new Date(),
-        paymentStatus: 'PENDING' as any,
+        paymentStatus: parsed.data.paymentStatus ?? PaymentStatus.Pending,
       },
     });
     res.status(201).json(payment);


### PR DESCRIPTION
## Summary
- use `PaymentStatus` enum in lease payment controller and schemas
- test enum-based payment status handling

## Testing
- `npm test`
- `npx jest src/__tests__/payment.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b0fde4f2748328b7348b541f433218