### PR TITLE
Allow partial user updates and add empty body guards

### DIFF
--- a/server/src/__tests__/manager-controllers.test.ts
+++ b/server/src/__tests__/manager-controllers.test.ts
@@ -1,8 +1,8 @@
 import { Request, Response, NextFunction } from "express";
 
 // Mock external services
-jest.mock("../utils/s3Upload", () => ({ uploadFilesToS3: jest.fn() }));
-jest.mock("../utils/geocodeAddress", () => ({ geocodeAddress: jest.fn() }));
+jest.mock("../utils/s3-upload", () => ({ uploadFilesToS3: jest.fn() }));
+jest.mock("../utils/geocode-address", () => ({ geocodeAddress: jest.fn() }));
 
 jest.mock("@terraformer/wkt", () => ({
   wktToGeoJSON: jest.fn().mockReturnValue({ coordinates: [1, 2] }),
@@ -25,7 +25,11 @@ jest.mock("@prisma/client", () => ({
 }));
 
 import prisma from "../utils/prisma";
-import { getManager, getManagerProperties } from "../controllers/manager-controllers";
+import {
+  getManager,
+  getManagerProperties,
+  updateManager,
+} from "../controllers/manager-controllers";
 
 const createMockRes = () => {
   const res: Partial<Response> = {};
@@ -60,6 +64,40 @@ describe("managerControllers", () => {
 
     expect(res.status).toHaveBeenCalledWith(404);
     expect(res.json).toHaveBeenCalledWith({ message: "Manager not found" });
+  });
+
+  it("updates manager with provided fields", async () => {
+    mockPrisma.manager.update.mockResolvedValue({
+      cognitoId: "m1",
+      name: "New Name",
+    });
+    const req = {
+      params: { cognitoId: "m1" },
+      body: { name: "New Name" },
+    } as unknown as Request;
+    const res = createMockRes();
+
+    await updateManager(req, res, next);
+
+    expect(mockPrisma.manager.update).toHaveBeenCalledWith({
+      where: { cognitoId: "m1" },
+      data: { name: "New Name" },
+    });
+    expect(res.json).toHaveBeenCalledWith({ cognitoId: "m1", name: "New Name" });
+  });
+
+  it("returns 400 when no update fields provided", async () => {
+    const req = {
+      params: { cognitoId: "m1" },
+      body: {},
+    } as unknown as Request;
+    const res = createMockRes();
+
+    await updateManager(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ message: "No fields provided" });
+    expect(mockPrisma.manager.update).not.toHaveBeenCalled();
   });
 
   it("lists manager properties with coordinates", async () => {

--- a/server/src/__tests__/tenant-controllers.test.ts
+++ b/server/src/__tests__/tenant-controllers.test.ts
@@ -1,8 +1,8 @@
 import { Request, Response, NextFunction } from "express";
 
 // Mock external services
-jest.mock("../utils/s3Upload", () => ({ uploadFilesToS3: jest.fn() }));
-jest.mock("../utils/geocodeAddress", () => ({ geocodeAddress: jest.fn() }));
+jest.mock("../utils/s3-upload", () => ({ uploadFilesToS3: jest.fn() }));
+jest.mock("../utils/geocode-address", () => ({ geocodeAddress: jest.fn() }));
 
 const mockPrisma = {
   tenant: {
@@ -21,7 +21,7 @@ jest.mock("@prisma/client", () => ({
 }));
 
 import prisma from "../utils/prisma";
-import { getTenant, createTenant } from "../controllers/tenant-controllers";
+import { getTenant, createTenant, updateTenant } from "../controllers/tenant-controllers";
 
 const createMockRes = () => {
   const res: Partial<Response> = {};
@@ -58,10 +58,49 @@ describe("tenantControllers", () => {
     expect(res.json).toHaveBeenCalledWith({ message: "Tenant not found" });
   });
 
+  it("updates tenant with provided fields", async () => {
+    mockPrisma.tenant.update.mockResolvedValue({
+      cognitoId: "abc",
+      name: "New Name",
+    });
+    const req = {
+      params: { cognitoId: "abc" },
+      body: { name: "New Name" },
+    } as unknown as Request;
+    const res = createMockRes();
+
+    await updateTenant(req, res, next);
+
+    expect(mockPrisma.tenant.update).toHaveBeenCalledWith({
+      where: { cognitoId: "abc" },
+      data: { name: "New Name" },
+    });
+    expect(res.json).toHaveBeenCalledWith({ cognitoId: "abc", name: "New Name" });
+  });
+
+  it("returns 400 when no update fields provided", async () => {
+    const req = {
+      params: { cognitoId: "abc" },
+      body: {},
+    } as unknown as Request;
+    const res = createMockRes();
+
+    await updateTenant(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ message: "No fields provided" });
+    expect(mockPrisma.tenant.update).not.toHaveBeenCalled();
+  });
+
   it("calls next on create error", async () => {
     mockPrisma.tenant.create.mockRejectedValue(new Error("fail"));
     const req = {
-      body: { cognitoId: "1", name: "a", email: "e", phoneNumber: "p" },
+      body: {
+        cognitoId: "1",
+        name: "a",
+        email: "e@example.com",
+        phoneNumber: "1234567890",
+      },
     } as unknown as Request;
     const res = createMockRes();
     const localNext = jest.fn();

--- a/server/src/__tests__/user-controllers.test.ts
+++ b/server/src/__tests__/user-controllers.test.ts
@@ -54,21 +54,20 @@ describe("Tenant validation", () => {
     expect(mockPrisma.tenant.create).not.toHaveBeenCalled();
   });
 
-  it("updates tenant with valid payload", async () => {
+  it("updates tenant with partial payload", async () => {
     mockPrisma.tenant.update.mockResolvedValue({ id: 1 });
-    const res = await request(app).put("/tenants/abc").send({
-      name: "Jane Doe",
-      email: "jane@example.com",
-      phoneNumber: "0987654321",
-    });
+    const res = await request(app)
+      .put("/tenants/abc")
+      .send({ name: "Jane Doe" });
     expect(res.status).toBe(200);
-    expect(mockPrisma.tenant.update).toHaveBeenCalled();
+    expect(mockPrisma.tenant.update).toHaveBeenCalledWith({
+      where: { cognitoId: "abc" },
+      data: { name: "Jane Doe" },
+    });
   });
 
-  it("returns 400 for invalid tenant update", async () => {
-    const res = await request(app).put("/tenants/abc").send({
-      name: "Jane Doe",
-    });
+  it("returns 400 when no tenant fields provided", async () => {
+    const res = await request(app).put("/tenants/abc").send({});
     expect(res.status).toBe(400);
     expect(mockPrisma.tenant.update).not.toHaveBeenCalled();
   });
@@ -101,21 +100,20 @@ describe("Manager validation", () => {
     expect(mockPrisma.manager.create).not.toHaveBeenCalled();
   });
 
-  it("updates manager with valid payload", async () => {
+  it("updates manager with partial payload", async () => {
     mockPrisma.manager.update.mockResolvedValue({ id: 1 });
-    const res = await request(app).put("/managers/abc").send({
-      name: "Jane Manager",
-      email: "jane.manager@example.com",
-      phoneNumber: "0987654321",
-    });
+    const res = await request(app)
+      .put("/managers/abc")
+      .send({ name: "Jane Manager" });
     expect(res.status).toBe(200);
-    expect(mockPrisma.manager.update).toHaveBeenCalled();
+    expect(mockPrisma.manager.update).toHaveBeenCalledWith({
+      where: { cognitoId: "abc" },
+      data: { name: "Jane Manager" },
+    });
   });
 
-  it("returns 400 for invalid manager update", async () => {
-    const res = await request(app).put("/managers/abc").send({
-      name: "Jane Manager",
-    });
+  it("returns 400 when no manager fields provided", async () => {
+    const res = await request(app).put("/managers/abc").send({});
     expect(res.status).toBe(400);
     expect(mockPrisma.manager.update).not.toHaveBeenCalled();
   });

--- a/server/src/controllers/manager-controllers.ts
+++ b/server/src/controllers/manager-controllers.ts
@@ -65,15 +65,14 @@ export const updateManager = async (
       res.status(400).json({ errors: parsed.error.errors });
       return;
     }
-    const { name, email, phoneNumber } = parsed.data;
+    if (Object.keys(parsed.data).length === 0) {
+      res.status(400).json({ message: "No fields provided" });
+      return;
+    }
 
     const updatedManager = await prisma.manager.update({
       where: { cognitoId },
-      data: {
-        name,
-        email,
-        phoneNumber,
-      },
+      data: parsed.data,
     });
 
     res.json(updatedManager);

--- a/server/src/controllers/tenant-controllers.ts
+++ b/server/src/controllers/tenant-controllers.ts
@@ -68,15 +68,14 @@ export const updateTenant = async (
       res.status(400).json({ errors: parsed.error.errors });
       return;
     }
-    const { name, email, phoneNumber } = parsed.data;
+    if (Object.keys(parsed.data).length === 0) {
+      res.status(400).json({ message: "No fields provided" });
+      return;
+    }
 
     const updatedTenant = await prisma.tenant.update({
       where: { cognitoId },
-      data: {
-        name,
-        email,
-        phoneNumber,
-      },
+      data: parsed.data,
     });
 
     res.json(updatedTenant);

--- a/server/src/validators/user-validators.ts
+++ b/server/src/validators/user-validators.ts
@@ -7,9 +7,5 @@ export const createUserSchema = z.object({
   phoneNumber: z.string().min(10),
 });
 
-export const updateUserSchema = z.object({
-  name: z.string(),
-  email: z.string().email(),
-  phoneNumber: z.string().min(10),
-});
+export const updateUserSchema = createUserSchema.partial();
 


### PR DESCRIPTION
## Summary
- Allow partial user updates by deriving `updateUserSchema` from `createUserSchema`
- Return 400 when manager or tenant update requests send no fields
- Expand manager and tenant controller tests for partial and empty updates

## Testing
- `npm test`
- `npx jest src/__tests__/manager-controllers.test.ts src/__tests__/tenant-controllers.test.ts src/__tests__/user-controllers.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b0fde705cc8328a7a0309d9f3d6018