### PR TITLE
feat: parse application date

### DIFF
--- a/server/src/__tests__/application-controllers.test.ts
+++ b/server/src/__tests__/application-controllers.test.ts
@@ -66,6 +66,38 @@ describe('applicationControllers', () => {
     );
   });
 
+  it('creates an application with ISO string date', async () => {
+    const iso = new Date().toISOString();
+    mockPrisma.property.findUnique.mockResolvedValue({ id: 1 });
+    mockPrisma.application.create.mockResolvedValue({ id: 1 } as any);
+
+    const req = {
+      body: {
+        applicationDate: iso,
+        status: 'Pending',
+        propertyId: 1,
+        tenantCognitoId: 't1',
+        name: 'n',
+        email: 'e@example.com',
+        phoneNumber: 'p',
+        message: 'm',
+      },
+    } as unknown as Request;
+    const res = createMockRes();
+
+    await createApplication(req, res, next);
+
+    expect(mockPrisma.application.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          applicationDate: new Date(iso),
+        }),
+      }),
+    );
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({ id: 1 });
+  });
+
   it('returns 404 when property missing', async () => {
     mockPrisma.property.findUnique.mockResolvedValue(null);
     const req = {
@@ -207,9 +239,7 @@ describe('applicationControllers', () => {
   });
 
   it('calls next on service error', async () => {
-    (updateApplicationStatusService as jest.Mock).mockRejectedValue(
-      new Error('db'),
-    );
+    (updateApplicationStatusService as jest.Mock).mockRejectedValue(new Error('db'));
     const req = {
       params: { id: '1' },
       body: { status: 'Approved' },

--- a/server/src/controllers/application-controllers.ts
+++ b/server/src/controllers/application-controllers.ts
@@ -105,20 +105,10 @@ export const createApplication = async (
       return;
     }
 
-    const {
-      applicationDate,
-      status,
-      propertyId,
-      tenantCognitoId,
-      name,
-      email,
-      phoneNumber,
-      message,
-    } = parsed.data;
+    const { status, propertyId, tenantCognitoId, name, email, phoneNumber, message } = parsed.data;
 
     const property = await prisma.property.findUnique({
       where: { id: propertyId },
-
     });
 
     if (!property) {
@@ -128,7 +118,7 @@ export const createApplication = async (
 
     const newApplication = await prisma.application.create({
       data: {
-        applicationDate,
+        applicationDate: parsed.data.applicationDate,
         status,
         name,
         email,


### PR DESCRIPTION
## Summary
- use `z.coerce.date` for application creation schema
- pass parsed `applicationDate` directly to Prisma
- test application controller with ISO date strings

## Testing
- `npm test`
- `npx jest src/__tests__/application-controllers.test.ts`
- `npm run lint` *(fails: Code style issues found in 27 files)*

------
https://chatgpt.com/codex/tasks/task_e_68b0fde5e9a083289a022ae3b8740b5d