### PR TITLE
refactor: clarify settings form types

### DIFF
--- a/client/src/components/settings-form.tsx
+++ b/client/src/components/settings-form.tsx
@@ -1,16 +1,13 @@
-import { SettingsFormData, settingsSchema } from "@/lib/schemas";
-import { zodResolver } from "@hookform/resolvers/zod";
-import React, { useState } from "react";
-import { useForm } from "react-hook-form";
-import { Form } from "./ui/form";
-import { CustomFormField } from "./form-field";
-import { Button } from "./ui/button";
+import { settingsSchema } from '@/lib/schemas';
+import type { SettingsFormData } from '@/types';
+import { zodResolver } from '@hookform/resolvers/zod';
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { Form } from './ui/form';
+import { CustomFormField } from './form-field';
+import { Button } from './ui/button';
 
-const SettingsForm = ({
-  initialData,
-  onSubmit,
-  userType,
-}: SettingsFormProps) => {
+const SettingsForm = ({ initialData, onSubmit, userType }: SettingsFormProps) => {
   const [editMode, setEditMode] = useState(false);
   const form = useForm<SettingsFormData>({
     resolver: zodResolver(settingsSchema),
@@ -41,22 +38,10 @@ const SettingsForm = ({
       </div>
       <div className="bg-white rounded-xl p-6">
         <Form {...form}>
-          <form
-            onSubmit={form.handleSubmit(handleSubmit)}
-            className="space-y-6"
-          >
+          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
             <CustomFormField name="name" label="Name" disabled={!editMode} />
-            <CustomFormField
-              name="email"
-              label="Email"
-              type="email"
-              disabled={!editMode}
-            />
-            <CustomFormField
-              name="phoneNumber"
-              label="Phone Number"
-              disabled={!editMode}
-            />
+            <CustomFormField name="email" label="Email" type="email" disabled={!editMode} />
+            <CustomFormField name="phoneNumber" label="Phone Number" disabled={!editMode} />
 
             <div className="pt-4 flex justify-between">
               <Button
@@ -64,13 +49,10 @@ const SettingsForm = ({
                 onClick={toggleEditMode}
                 className="bg-secondary-500 text-white hover:bg-secondary-600"
               >
-                {editMode ? "Cancel" : "Edit"}
+                {editMode ? 'Cancel' : 'Edit'}
               </Button>
               {editMode && (
-                <Button
-                  type="submit"
-                  className="bg-primary-700 text-white hover:bg-primary-800"
-                >
+                <Button type="submit" className="bg-primary-700 text-white hover:bg-primary-800">
                   Save Changes
                 </Button>
               )}

--- a/client/src/lib/schemas.ts
+++ b/client/src/lib/schemas.ts
@@ -1,45 +1,41 @@
-import * as z from "zod";
-import { PropertyTypeEnum } from "@/lib/constants";
+import * as z from 'zod';
+import { PropertyTypeEnum } from '@/lib/constants';
 
 export const propertySchema = z.object({
-  name: z.string().min(1, "Name is required"),
-  description: z.string().min(1, "Description is required"),
+  name: z.string().min(1, 'Name is required'),
+  description: z.string().min(1, 'Description is required'),
   pricePerMonth: z.coerce.number().positive().min(0).int(),
   securityDeposit: z.coerce.number().positive().min(0).int(),
   applicationFee: z.coerce.number().positive().min(0).int(),
   isPetsAllowed: z.boolean(),
   isParkingIncluded: z.boolean(),
-  photoUrls: z
-    .array(z.instanceof(File))
-    .min(1, "At least one photo is required"),
-  amenities: z.string().min(1, "Amenities are required"),
-  highlights: z.string().min(1, "Highlights are required"),
+  photoUrls: z.array(z.instanceof(File)).min(1, 'At least one photo is required'),
+  amenities: z.string().min(1, 'Amenities are required'),
+  highlights: z.string().min(1, 'Highlights are required'),
   beds: z.coerce.number().positive().min(0).max(10).int(),
   baths: z.coerce.number().positive().min(0).max(10).int(),
   squareFeet: z.coerce.number().int().positive(),
   propertyType: z.nativeEnum(PropertyTypeEnum),
-  address: z.string().min(1, "Address is required"),
-  city: z.string().min(1, "City is required"),
-  state: z.string().min(1, "State is required"),
-  country: z.string().min(1, "Country is required"),
-  postalCode: z.string().min(1, "Postal code is required"),
+  address: z.string().min(1, 'Address is required'),
+  city: z.string().min(1, 'City is required'),
+  state: z.string().min(1, 'State is required'),
+  country: z.string().min(1, 'Country is required'),
+  postalCode: z.string().min(1, 'Postal code is required'),
 });
 
 export type PropertyFormData = z.infer<typeof propertySchema>;
 
 export const applicationSchema = z.object({
-  name: z.string().min(1, "Name is required"),
-  email: z.string().email("Invalid email address"),
-  phoneNumber: z.string().min(10, "Phone number must be at least 10 digits"),
+  name: z.string().min(1, 'Name is required'),
+  email: z.string().email('Invalid email address'),
+  phoneNumber: z.string().min(10, 'Phone number must be at least 10 digits'),
   message: z.string().optional(),
 });
 
 export type ApplicationFormData = z.infer<typeof applicationSchema>;
 
 export const settingsSchema = z.object({
-  name: z.string().min(1, "Name is required"),
-  email: z.string().email("Invalid email address"),
-  phoneNumber: z.string().min(10, "Phone number must be at least 10 digits"),
+  name: z.string().min(1, 'Name is required'),
+  email: z.string().email('Invalid email address'),
+  phoneNumber: z.string().min(10, 'Phone number must be at least 10 digits'),
 });
-
-export type SettingsFormData = z.infer<typeof settingsSchema>;

--- a/client/src/types/index.d.ts
+++ b/client/src/types/index.d.ts
@@ -1,14 +1,18 @@
-import { LucideIcon } from "lucide-react";
-import { AuthUser } from "aws-amplify/auth";
-import { Manager, Tenant, Property, Application } from "./prisma-types";
-import type { MotionProps } from "framer-motion";
+import { LucideIcon } from 'lucide-react';
+import { AuthUser } from 'aws-amplify/auth';
+import { Manager, Tenant, Property, Application } from './prisma-types';
+import type { MotionProps } from 'framer-motion';
 
-type SettingsFormData = any;
+export interface SettingsFormData {
+  name: string;
+  email: string;
+  phoneNumber: string;
+}
 type JsonObject = Record<string, unknown>;
 type JsonPrimitive = string | number | boolean | null;
 type JsonArray = unknown[];
 
-declare module "framer-motion" {
+declare module 'framer-motion' {
   interface MotionProps {
     className?: string;
   }
@@ -16,46 +20,46 @@ declare module "framer-motion" {
 
 declare global {
   enum AmenityEnum {
-    WasherDryer = "WasherDryer",
-    AirConditioning = "AirConditioning",
-    Dishwasher = "Dishwasher",
-    HighSpeedInternet = "HighSpeedInternet",
-    HardwoodFloors = "HardwoodFloors",
-    WalkInClosets = "WalkInClosets",
-    Microwave = "Microwave",
-    Refrigerator = "Refrigerator",
-    Pool = "Pool",
-    Gym = "Gym",
-    Parking = "Parking",
-    PetsAllowed = "PetsAllowed",
-    WiFi = "WiFi",
+    WasherDryer = 'WasherDryer',
+    AirConditioning = 'AirConditioning',
+    Dishwasher = 'Dishwasher',
+    HighSpeedInternet = 'HighSpeedInternet',
+    HardwoodFloors = 'HardwoodFloors',
+    WalkInClosets = 'WalkInClosets',
+    Microwave = 'Microwave',
+    Refrigerator = 'Refrigerator',
+    Pool = 'Pool',
+    Gym = 'Gym',
+    Parking = 'Parking',
+    PetsAllowed = 'PetsAllowed',
+    WiFi = 'WiFi',
   }
 
   enum HighlightEnum {
-    HighSpeedInternetAccess = "HighSpeedInternetAccess",
-    WasherDryer = "WasherDryer",
-    AirConditioning = "AirConditioning",
-    Heating = "Heating",
-    SmokeFree = "SmokeFree",
-    CableReady = "CableReady",
-    SatelliteTV = "SatelliteTV",
-    DoubleVanities = "DoubleVanities",
-    TubShower = "TubShower",
-    Intercom = "Intercom",
-    SprinklerSystem = "SprinklerSystem",
-    RecentlyRenovated = "RecentlyRenovated",
-    CloseToTransit = "CloseToTransit",
-    GreatView = "GreatView",
-    QuietNeighborhood = "QuietNeighborhood",
+    HighSpeedInternetAccess = 'HighSpeedInternetAccess',
+    WasherDryer = 'WasherDryer',
+    AirConditioning = 'AirConditioning',
+    Heating = 'Heating',
+    SmokeFree = 'SmokeFree',
+    CableReady = 'CableReady',
+    SatelliteTV = 'SatelliteTV',
+    DoubleVanities = 'DoubleVanities',
+    TubShower = 'TubShower',
+    Intercom = 'Intercom',
+    SprinklerSystem = 'SprinklerSystem',
+    RecentlyRenovated = 'RecentlyRenovated',
+    CloseToTransit = 'CloseToTransit',
+    GreatView = 'GreatView',
+    QuietNeighborhood = 'QuietNeighborhood',
   }
 
   enum PropertyTypeEnum {
-    Rooms = "Rooms",
-    Tinyhouse = "Tinyhouse",
-    Apartment = "Apartment",
-    Villa = "Villa",
-    Townhouse = "Townhouse",
-    Cottage = "Cottage",
+    Rooms = 'Rooms',
+    Tinyhouse = 'Tinyhouse',
+    Apartment = 'Apartment',
+    Villa = 'Villa',
+    Townhouse = 'Townhouse',
+    Cottage = 'Cottage',
   }
 
   interface SidebarLinkProps {
@@ -86,17 +90,13 @@ declare global {
     propertyId: number;
   }
 
-  interface PropertyOverviewProps {
-    propertyId: number;
-  }
-
   interface PropertyLocationProps {
     propertyId: number;
   }
 
   interface ApplicationCardProps {
     application: Application;
-    userType: "manager" | "renter";
+    userType: 'manager' | 'renter';
     children: React.ReactNode;
   }
 
@@ -126,13 +126,13 @@ declare global {
   }
 
   interface AppSidebarProps {
-    userType: "manager" | "tenant";
+    userType: 'manager' | 'tenant';
   }
 
   interface SettingsFormProps {
     initialData: SettingsFormData;
     onSubmit: (data: SettingsFormData) => Promise<void>;
-    userType: "manager" | "tenant";
+    userType: 'manager' | 'tenant';
   }
 
   interface User {


### PR DESCRIPTION
## Summary
- define `SettingsFormData` interface and clean up PropertyOverviewProps definition
- use central types for `SettingsForm` component
- prune unused schema type export

## Testing
- `npm run lint` *(fails: Code style issues found in 101 files)*
- `npm run typecheck` *(fails: cannot find modules and other type errors)*
- `npm test` *(fails: payment mutations creates a payment via POST)*

------
https://chatgpt.com/codex/tasks/task_e_68b0fde7f1e083288cd0f760a383752c