### PR TITLE
Add LSASS credential access demo page

### DIFF
--- a/client/public/lsass-diagram.svg
+++ b/client/public/lsass-diagram.svg
@@ -1,0 +1,12 @@
+<svg width="300" height="150" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#4a5568" />
+    </marker>
+  </defs>
+  <rect x="10" y="40" width="100" height="60" rx="4" ry="4" fill="#cbd5e0" stroke="#4a5568" />
+  <text x="60" y="75" text-anchor="middle" font-size="14" fill="#1a202c">LSASS</text>
+  <rect x="150" y="40" width="120" height="60" rx="4" ry="4" fill="#fbd38d" stroke="#dd6b20" />
+  <text x="210" y="75" text-anchor="middle" font-size="14" fill="#1a202c">Memory Dump</text>
+  <line x1="110" y1="70" x2="150" y2="70" stroke="#4a5568" stroke-width="2" marker-end="url(#arrow)" />
+</svg>

--- a/client/src/app/(nondashboard)/credential-access/page.tsx
+++ b/client/src/app/(nondashboard)/credential-access/page.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+
+interface SampleEvent {
+  id: number;
+  timestamp: string;
+  description: string;
+}
+
+const sampleEvents: SampleEvent[] = [
+  {
+    id: 1,
+    timestamp: '2023-06-01T12:00:00Z',
+    description: 'Process procdump.exe accessed lsass.exe memory',
+  },
+  {
+    id: 2,
+    timestamp: '2023-06-01T12:00:05Z',
+    description: 'Dump file written to C:\\temp\\lsass.dmp',
+  },
+  {
+    id: 3,
+    timestamp: '2023-06-01T12:00:10Z',
+    description: 'Tool mimikatz.exe extracted credentials from dump',
+  },
+];
+
+export default function CredentialAccessPage() {
+  const [logLines, setLogLines] = useState<string[]>([]);
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const text = reader.result as string;
+      const lines = text.split(/\r?\n/);
+      setLogLines(lines);
+    };
+    reader.readAsText(file);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Credential Access</h1>
+      <Image src="/lsass-diagram.svg" alt="LSASS credential flow" width={300} height={150} />
+      <Tabs defaultValue="attacker" className="w-full">
+        <TabsList className="grid w-full grid-cols-2">
+          <TabsTrigger value="attacker">Attacker</TabsTrigger>
+          <TabsTrigger value="defender">Defender</TabsTrigger>
+        </TabsList>
+        <TabsContent value="attacker" className="space-y-2">
+          <p>
+            Attackers target the LSASS process to dump credentials and move laterally within a
+            network.
+          </p>
+          <ul className="list-disc pl-6">
+            {sampleEvents.map((event) => (
+              <li key={event.id}>
+                <span className="font-mono">[{event.timestamp}]</span> {event.description}
+              </li>
+            ))}
+          </ul>
+        </TabsContent>
+        <TabsContent value="defender" className="space-y-2">
+          <p>Defenders monitor access to LSASS and alert on suspicious tools or memory dumps.</p>
+          <p>Import logs to highlight potential credential access events.</p>
+          <input type="file" accept=".log,.txt" onChange={handleFile} />
+          {logLines.length > 0 && (
+            <pre className="mt-2 max-h-64 overflow-auto rounded bg-muted p-2 text-sm">
+              {logLines.map((line, idx) => {
+                const highlight = /lsass|credential/i.test(line);
+                return (
+                  <div key={idx} className={highlight ? 'bg-yellow-200' : undefined}>
+                    {line}
+                  </div>
+                );
+              })}
+            </pre>
+          )}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/client/tests/payments-api.test.ts
+++ b/client/tests/payments-api.test.ts
@@ -76,7 +76,7 @@ describe('payment mutations', () => {
     };
 
     const result = await store
-      .dispatch(api.endpoints.createPayment.initiate({ id: 1, ...body }))
+      .dispatch(api.endpoints.createPayment.initiate({ leaseId: 1, ...body }))
       .unwrap();
 
     const req = fetchMock.mock.calls[0][0] as any;
@@ -89,7 +89,7 @@ describe('payment mutations', () => {
       expect.objectContaining({
         success: 'Payment created successfully!',
         error: 'Failed to create payment.',
-      })
+      }),
     );
   });
 
@@ -135,7 +135,7 @@ describe('payment mutations', () => {
       expect.objectContaining({
         success: 'Payment updated successfully!',
         error: 'Failed to update payment.',
-      })
+      }),
     );
   });
 });


### PR DESCRIPTION
## Summary
- Demonstrate LSASS credential access with sample events and diagram
- Add attacker and defender tabs with log import highlighting
- Align payment API test with leaseId parameter

## Testing
- `cd client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b11ede19c483289e7d5d70101c3f64