### PR TITLE
feat: support wasm disassembly with fallback

### DIFF
--- a/client/src/components/disassembler.tsx
+++ b/client/src/components/disassembler.tsx
@@ -1,0 +1,31 @@
+import React, { useCallback, useState } from 'react';
+import { disassemble, Arch } from '../lib/disassembler';
+
+export const Disassembler: React.FC = () => {
+  const [output, setOutput] = useState<string>('');
+  const [duration, setDuration] = useState<number | null>(null);
+
+  const handleDrop = useCallback(async (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files[0];
+    if (!file) return;
+    const buffer = await file.arrayBuffer();
+    // Assume x86 by default
+    const { output: result, duration } = await disassemble(new Uint8Array(buffer), 'x86');
+    setOutput(Array.isArray(result) ? result.join('\n') : String(result));
+    setDuration(duration);
+    if (duration > 100) {
+      console.warn(`Disassembly took ${duration}ms`);
+    }
+  }, []);
+
+  return (
+    <div onDrop={handleDrop} onDragOver={(e) => e.preventDefault()} style={{ border: '1px dashed gray', padding: '1rem' }}>
+      <p>Drop binary data here</p>
+      {duration !== null && <p>Duration: {duration.toFixed(2)}ms</p>}
+      <pre>{output}</pre>
+    </div>
+  );
+};
+
+export default Disassembler;

--- a/client/src/lib/disassembler.ts
+++ b/client/src/lib/disassembler.ts
@@ -1,0 +1,38 @@
+export type Arch = 'x86' | 'arm';
+
+function hasGhidra(): boolean {
+  return typeof window !== 'undefined' && Boolean((window as any).Ghidra);
+}
+
+async function loadCapstone(): Promise<any> {
+  if (typeof window === 'undefined') return null;
+  if ((window as any).capstone) return (window as any).capstone;
+  await new Promise<void>((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = 'https://unpkg.com/capstone-wasm@latest/dist/capstone.min.js';
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error('Failed to load Capstone.js'));
+    document.head.appendChild(script);
+  });
+  return (window as any).capstone;
+}
+
+export async function disassemble(bytes: Uint8Array, arch: Arch) {
+  const start = typeof performance !== 'undefined' ? performance.now() : Date.now();
+
+  try {
+    if (hasGhidra()) {
+      const ghidra = (window as any).Ghidra;
+      const result = ghidra.disassemble(bytes, arch);
+      const end = typeof performance !== 'undefined' ? performance.now() : Date.now();
+      return { output: result, duration: end - start };
+    }
+  } catch (err) {
+    console.warn('GHIDRA disassembly failed, falling back to Capstone.js', err);
+  }
+
+  const capstone = await loadCapstone();
+  const result = capstone ? capstone.disasm(bytes, 0, arch) : [];
+  const end = typeof performance !== 'undefined' ? performance.now() : Date.now();
+  return { output: result, duration: end - start };
+}

--- a/client/types/index.d.ts
+++ b/client/types/index.d.ts
@@ -89,7 +89,7 @@ declare global {
     propertyId: number;
   }
 
-  interface ApplicationCardProps {
+interface ApplicationCardProps {
     application: Application;
     userType: "manager" | "renter";
     children: React.ReactNode;
@@ -134,6 +134,10 @@ declare global {
     cognitoInfo: AuthUser;
     userInfo: Tenant | Manager;
     userRole: JsonObject | JsonPrimitive | JsonArray;
+  }
+  interface Window {
+    Ghidra?: any;
+    capstone?: any;
   }
 }
 


### PR DESCRIPTION
## Summary
- detect Ghidra WebAssembly and fall back to Capstone.js
- add drag-and-drop disassembler component with runtime timing
- declare global window hooks for disassembly engines

## Testing
- `npm test` (fails: payment mutations creates a payment via POST)


------
https://chatgpt.com/codex/tasks/task_e_68b11edc0a88832880f2c8ff2d4500c2