### PR TITLE
feat: add runtime font loader and style sharing

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -37,6 +37,7 @@
         "cmdk": "^1.0.0",
         "date-fns": "^4.1.0",
         "dotenv": "^16.6.1",
+        "figlet": "^1.8.2",
         "filepond": "^4.32.8",
         "filepond-plugin-image-exif-orientation": "^1.0.11",
         "filepond-plugin-image-preview": "^4.6.12",
@@ -10695,6 +10696,18 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/figlet": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.8.2.tgz",
+      "integrity": "sha512-iPCpE9B/rOcjewIzDnagP9F2eySzGeHReX8WlrZQJkqFBk2wvq8gY0c6U6Hd2y9HnX1LQcYSeP7aEHoPt6sVKQ==",
+      "license": "MIT",
+      "bin": {
+        "figlet": "bin/index.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/file-entry-cache": {

--- a/client/package.json
+++ b/client/package.json
@@ -48,6 +48,7 @@
     "cmdk": "^1.0.0",
     "date-fns": "^4.1.0",
     "dotenv": "^16.6.1",
+    "figlet": "^1.8.2",
     "filepond": "^4.32.8",
     "filepond-plugin-image-exif-orientation": "^1.0.11",
     "filepond-plugin-image-preview": "^4.6.12",

--- a/client/src/__tests__/style-url.test.ts
+++ b/client/src/__tests__/style-url.test.ts
@@ -1,0 +1,16 @@
+import { styleToSearchParams, styleFromSearchParams, StyleOptions } from "@/lib/style-url";
+
+describe('style url helpers', () => {
+  it('serializes and parses style options', () => {
+    const style: StyleOptions = {
+      text: 'Hello',
+      font: 'Standard',
+      sc: '#123456',
+      ec: '#abcdef',
+      k: 2,
+    };
+    const qs = styleToSearchParams(style);
+    const parsed = styleFromSearchParams(new URLSearchParams(qs));
+    expect(parsed).toEqual(style);
+  });
+});

--- a/client/src/app/text-art/page.tsx
+++ b/client/src/app/text-art/page.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState, useEffect, ChangeEvent } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import figlet from "figlet";
+import {
+  styleFromSearchParams,
+  styleToSearchParams
+} from "@/lib/style-url";
+
+export default function TextArtPage() {
+  const router = useRouter();
+  const search = useSearchParams();
+  const initial = styleFromSearchParams(new URLSearchParams(search.toString()));
+
+  const [text, setText] = useState(initial.text || "Hello");
+  const [font, setFont] = useState(initial.font);
+  const [startColor, setStartColor] = useState(initial.sc);
+  const [endColor, setEndColor] = useState(initial.ec);
+  const [kerning, setKerning] = useState(initial.k);
+  const [ascii, setAscii] = useState("");
+
+  useEffect(() => {
+    figlet.text(text, { font }, (err, data) => {
+      if (!err && data) {
+        setAscii(data);
+      }
+    });
+  }, [text, font]);
+
+  useEffect(() => {
+    const qs = styleToSearchParams({
+      text,
+      font,
+      sc: startColor,
+      ec: endColor,
+      k: kerning,
+    });
+    router.replace(`/text-art?${qs}`, { scroll: false });
+  }, [text, font, startColor, endColor, kerning, router]);
+
+  const handleFontFile = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const content = await file.text();
+    const name = file.name.replace(/\.flf$/i, "");
+    figlet.parseFont(name, content);
+    setFont(name);
+  };
+
+  return (
+    <div className="p-6 space-y-4">
+      <input
+        className="border p-2"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="Text"
+      />
+      <input type="file" accept=".flf" onChange={handleFontFile} />
+      <div className="flex items-center gap-2">
+        <label>Start</label>
+        <input
+          type="color"
+          value={startColor}
+          onChange={(e) => setStartColor(e.target.value)}
+        />
+        <label>End</label>
+        <input
+          type="color"
+          value={endColor}
+          onChange={(e) => setEndColor(e.target.value)}
+        />
+      </div>
+      <div className="flex items-center gap-2">
+        <label>Kerning</label>
+        <input
+          type="range"
+          min="-5"
+          max="20"
+          value={kerning}
+          onChange={(e) => setKerning(parseInt(e.target.value))}
+        />
+      </div>
+      <pre
+        style={{
+          whiteSpace: "pre",
+          background: `linear-gradient(to right, ${startColor}, ${endColor})`,
+          WebkitBackgroundClip: "text",
+          color: "transparent",
+          letterSpacing: `${kerning}px`,
+        }}
+      >
+        {ascii}
+      </pre>
+    </div>
+  );
+}

--- a/client/src/lib/style-url.ts
+++ b/client/src/lib/style-url.ts
@@ -1,0 +1,27 @@
+export interface StyleOptions {
+  text: string;
+  font: string;
+  sc: string; // start color
+  ec: string; // end color
+  k: number; // kerning
+}
+
+export function styleToSearchParams(style: StyleOptions): string {
+  const params = new URLSearchParams();
+  params.set("text", style.text);
+  params.set("font", style.font);
+  params.set("sc", style.sc);
+  params.set("ec", style.ec);
+  params.set("k", style.k.toString());
+  return params.toString();
+}
+
+export function styleFromSearchParams(params: URLSearchParams): StyleOptions {
+  return {
+    text: params.get("text") || "",
+    font: params.get("font") || "Standard",
+    sc: params.get("sc") || "#ff0000",
+    ec: params.get("ec") || "#0000ff",
+    k: parseInt(params.get("k") || "0", 10),
+  };
+}

--- a/client/tests/payments-api.test.ts
+++ b/client/tests/payments-api.test.ts
@@ -76,7 +76,7 @@ describe('payment mutations', () => {
     };
 
     const result = await store
-      .dispatch(api.endpoints.createPayment.initiate({ id: 1, ...body }))
+      .dispatch(api.endpoints.createPayment.initiate({ leaseId: 1, ...body }))
       .unwrap();
 
     const req = fetchMock.mock.calls[0][0] as any;


### PR DESCRIPTION
## Summary
- load figlet .flf fonts at runtime and render with gradient and kerning controls
- serialize current text-art style to URL for easy sharing
- fix createPayment test to use leaseId

## Testing
- `npm test`
- `npm run lint` *(fails: Code style issues found in 104 files)*

------
https://chatgpt.com/codex/tasks/task_e_68b11ed908e88328a6ae0c22ab9990bc