### PR TITLE
feat: add multi-select property type facets

### DIFF
--- a/client/src/app/(nondashboard)/search/filters-bar.tsx
+++ b/client/src/app/(nondashboard)/search/filters-bar.tsx
@@ -214,7 +214,11 @@ const FiltersBar = () => {
 
         {/* Property Type */}
         <Select
-          value={filters.propertyType || "any"}
+          value={
+            filters.propertyType.includes(",")
+              ? "any"
+              : filters.propertyType || "any"
+          }
           onValueChange={(value) =>
             handleFilterChange("propertyType", value, null)
           }

--- a/client/src/app/(nondashboard)/search/filters-full.tsx
+++ b/client/src/app/(nondashboard)/search/filters-full.tsx
@@ -8,7 +8,12 @@ import { cleanParams, cn, formatEnumString } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Search } from "lucide-react";
-import { AmenityIcons, PropertyTypeIcons } from "@/lib/constants";
+import {
+  AmenityIcons,
+  PropertyTypeIcons,
+  PropertyTypeEnum,
+  AmenityEnum,
+} from "@/lib/constants";
 import { Slider } from "@/components/ui/slider";
 import {
   Select,
@@ -64,6 +69,25 @@ const FiltersFull = () => {
     }));
   };
 
+  const selectedPropertyTypes =
+    localFilters.propertyType === "any"
+      ? []
+      : localFilters.propertyType.split(",");
+
+  const handlePropertyTypeToggle = (type: PropertyTypeEnum) => {
+    setLocalFilters((prev) => {
+      const current =
+        prev.propertyType === "any" ? [] : prev.propertyType.split(",");
+      const updated = current.includes(type)
+        ? current.filter((t) => t !== type)
+        : [...current, type];
+      return {
+        ...prev,
+        propertyType: updated.length ? updated.join(",") : "any",
+      };
+    });
+  };
+
   const handleLocationSearch = async () => {
     try {
       const response = await fetch(
@@ -117,26 +141,24 @@ const FiltersFull = () => {
         <div>
           <h4 className="font-bold mb-2">Property Type</h4>
           <div className="grid grid-cols-2 gap-4">
-            {Object.entries(PropertyTypeIcons).map(([type, Icon]) => (
-              <div
-                key={type}
-                className={cn(
-                  "flex flex-col items-center justify-center p-4 border rounded-xl cursor-pointer",
-                  localFilters.propertyType === type
-                    ? "border-black"
-                    : "border-gray-200"
-                )}
-                onClick={() =>
-                  setLocalFilters((prev) => ({
-                    ...prev,
-                    propertyType: type as PropertyTypeEnum,
-                  }))
-                }
-              >
-                <Icon className="w-6 h-6 mb-2" />
-                <span>{type}</span>
-              </div>
-            ))}
+            {Object.entries(PropertyTypeIcons).map(([type, Icon]) => {
+              const isSelected = selectedPropertyTypes.includes(type);
+              return (
+                <div
+                  key={type}
+                  className={cn(
+                    "flex flex-col items-center justify-center p-4 border rounded-xl cursor-pointer",
+                    isSelected ? "border-black" : "border-gray-200"
+                  )}
+                  onClick={() =>
+                    handlePropertyTypeToggle(type as PropertyTypeEnum)
+                  }
+                >
+                  <Icon className="w-6 h-6 mb-2" />
+                  <span>{type}</span>
+                </div>
+              );
+            })}
           </div>
         </div>
 

--- a/client/src/components/advanced-search.tsx
+++ b/client/src/components/advanced-search.tsx
@@ -186,7 +186,11 @@ const AdvancedSearch: React.FC<AdvancedSearchProps> = ({ onSearch, className }) 
               {/* Property Type */}
               <FilterSection title="Property Type">
                 <Select
-                  value={localFilters.propertyType}
+                  value={
+                    localFilters.propertyType.includes(",")
+                      ? "any"
+                      : localFilters.propertyType
+                  }
                   onValueChange={(value) => handleFilterChange("propertyType", value)}
                 >
                   <SelectTrigger>

--- a/client/tests/payments-api.test.ts
+++ b/client/tests/payments-api.test.ts
@@ -76,7 +76,7 @@ describe('payment mutations', () => {
     };
 
     const result = await store
-      .dispatch(api.endpoints.createPayment.initiate({ id: 1, ...body }))
+      .dispatch(api.endpoints.createPayment.initiate({ leaseId: 1, ...body }))
       .unwrap();
 
     const req = fetchMock.mock.calls[0][0] as any;

--- a/server/src/__tests__/build-property-filters.test.ts
+++ b/server/src/__tests__/build-property-filters.test.ts
@@ -28,6 +28,15 @@ describe("buildPropertyFilters", () => {
     expect(filters.propertyType).toBe(PropertyType.Apartment);
   });
 
+  it("handles multiple property types", () => {
+    const filters = buildPropertyFilters({
+      propertyType: `${PropertyType.Apartment},${PropertyType.Villa}`,
+    });
+    expect(filters.propertyType).toEqual({
+      in: [PropertyType.Apartment, PropertyType.Villa],
+    });
+  });
+
   it("handles amenities", () => {
     const filters = buildPropertyFilters({ amenities: `${Amenity.WasherDryer},${Amenity.Gym}` });
     expect(filters.amenities).toEqual({ hasEvery: [Amenity.WasherDryer, Amenity.Gym] });

--- a/server/src/utils/build-property-filters.ts
+++ b/server/src/utils/build-property-filters.ts
@@ -63,7 +63,9 @@ export const buildPropertyFilters = (
   }
 
   if (propertyType && propertyType !== "any") {
-    filters.propertyType = propertyType as any;
+    const types = propertyType.split(",");
+    filters.propertyType =
+      types.length > 1 ? ({ in: types } as any) : (types[0] as any);
   }
 
   if (amenities && amenities !== "any") {


### PR DESCRIPTION
## Summary
- support selecting multiple property types in search filters
- parse comma-separated property types on the server
- cover property type arrays with unit tests and fix payment test

## Testing
- `npm test` (server)
- `npx jest src/__tests__/build-property-filters.test.ts` (server)
- `npm test` (client)


------
https://chatgpt.com/codex/tasks/task_e_68b11eca2c5c832882c8fe3cc96332fc