### PR TITLE
feat: parse vulnerability XML and export CSV

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -37,6 +37,7 @@
         "cmdk": "^1.0.0",
         "date-fns": "^4.1.0",
         "dotenv": "^16.6.1",
+        "fast-xml-parser": "^4.4.2",
         "filepond": "^4.32.8",
         "filepond-plugin-image-exif-orientation": "^1.0.11",
         "filepond-plugin-image-preview": "^4.6.12",
@@ -51,6 +52,7 @@
         "react-filepond": "^7.1.3",
         "react-hook-form": "^7.61.1",
         "react-redux": "^9.2.0",
+        "react-window": "^1.8.10",
         "recharts": "^2.12.0",
         "socket.io-client": "^4.8.1",
         "sonner": "^1.7.4",
@@ -13797,6 +13799,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -15338,6 +15346,23 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/client/package.json
+++ b/client/package.json
@@ -60,6 +60,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-filepond": "^7.1.3",
+    "react-window": "^1.8.10",
     "react-hook-form": "^7.61.1",
     "react-redux": "^9.2.0",
     "recharts": "^2.12.0",
@@ -68,7 +69,8 @@
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "uuid": "^11.1.0",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "fast-xml-parser": "^4.4.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/client/src/app/(dashboard)/vulns/page.tsx
+++ b/client/src/app/(dashboard)/vulns/page.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import React, { useRef, useState } from 'react';
+import Header from '@/components/header';
+import { Button } from '@/components/ui/button';
+import { FixedSizeList as List } from 'react-window';
+
+interface VulnRecord {
+  host: string;
+  vuln: string;
+  cvss: number;
+}
+
+const VulnsPage = () => {
+  const [rows, setRows] = useState<VulnRecord[]>([]);
+  const workerRef = useRef<Worker>();
+
+  const handleFile = async (file: File) => {
+    const text = await file.text();
+    if (!workerRef.current) {
+      workerRef.current = new Worker(new URL('../../../workers/vulnParser.ts', import.meta.url));
+      workerRef.current.onmessage = (e: MessageEvent<VulnRecord[]>) => {
+        setRows(e.data);
+      };
+    }
+    workerRef.current.postMessage(text);
+  };
+
+  const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    if (f) handleFile(f);
+  };
+
+  const exportCsv = () => {
+    const header = 'Host,Vulnerability,CVSS\n';
+    const csvRows = rows.map((r) => `${r.host},"${r.vuln.replace(/"/g, '""')}",${r.cvss}`);
+    const blob = new Blob([header + csvRows.join('\n')], {
+      type: 'text/csv',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'vulnerabilities.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const Row = ({ index, style }: { index: number; style: React.CSSProperties }) => {
+    const item = rows[index];
+    return (
+      <div style={style} className="flex border-b">
+        <div className="w-1/3 p-2 truncate">{item.host}</div>
+        <div className="w-1/2 p-2 truncate">{item.vuln}</div>
+        <div className="w-1/6 p-2">{item.cvss}</div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="dashboard-container space-y-4">
+      <Header title="Vulnerability Report" subtitle="Upload a Nessus XML file" />
+      <input type="file" accept=".xml" onChange={onFileChange} />
+      {rows.length > 0 && (
+        <>
+          <Button onClick={exportCsv} className="mt-2">
+            Export CSV
+          </Button>
+          <div className="border rounded mt-4">
+            <div className="flex font-semibold border-b">
+              <div className="w-1/3 p-2">Host</div>
+              <div className="w-1/2 p-2">Vulnerability</div>
+              <div className="w-1/6 p-2">CVSS</div>
+            </div>
+            <List height={500} itemCount={rows.length} itemSize={35} width={'100%'}>
+              {Row}
+            </List>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default VulnsPage;

--- a/client/src/workers/vulnParser.ts
+++ b/client/src/workers/vulnParser.ts
@@ -1,0 +1,32 @@
+import { XMLParser } from 'fast-xml-parser';
+
+interface VulnRecord {
+  host: string;
+  vuln: string;
+  cvss: number;
+}
+
+self.onmessage = (event: MessageEvent<string>) => {
+  const xml = event.data;
+  const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '@_' });
+  const jsObj = parser.parse(xml);
+  const reportHosts = jsObj?.NessusClientData_v2?.Report?.ReportHost || [];
+  const hostsArray = Array.isArray(reportHosts) ? reportHosts : [reportHosts];
+  const results: VulnRecord[] = [];
+
+  for (const host of hostsArray) {
+    const hostName = host?.['@_name'] || host?.name || '';
+    const items = host?.ReportItem || [];
+    const itemsArray = Array.isArray(items) ? items : [items];
+    for (const item of itemsArray) {
+      const vulnName = item?.['@_pluginName'] || item?.plugin_name || item?.name || '';
+      const cvssRaw = item?.cvss3_base_score || item?.cvss_base_score || item?.cvss_score || '0';
+      const cvss = parseFloat(cvssRaw) || 0;
+      results.push({ host: hostName, vuln: vulnName, cvss });
+    }
+  }
+
+  postMessage(results);
+};
+
+export default null as any;


### PR DESCRIPTION
## Summary
- parse dropped Nessus XML in a Web Worker to extract host, vulnerability and CVSS info
- add dashboard page to upload XML, render a virtualized table for large datasets, and export results to CSV

## Testing
- `npm run lint` (fails: Code style issues found)
- `npm test` (fails: payment mutations › creates a payment via POST)


------
https://chatgpt.com/codex/tasks/task_e_68b11ec7309083288eeb6710b5685063