### PR TITLE
Add scan session list with CSV export

### DIFF
--- a/client/src/__tests__/scan-page.test.tsx
+++ b/client/src/__tests__/scan-page.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ScanPage from '../app/scan/page';
+
+describe('ScanPage', () => {
+  it('accumulates and resets scans', () => {
+    render(<ScanPage />);
+
+    const input = screen.getByPlaceholderText(/scan result/i);
+    const addButton = screen.getByText(/add/i);
+
+    fireEvent.change(input, { target: { value: 'first' } });
+    fireEvent.click(addButton);
+    fireEvent.change(input, { target: { value: 'second' } });
+    fireEvent.click(addButton);
+
+    expect(screen.getByText('first')).toBeTruthy();
+    expect(screen.getByText('second')).toBeTruthy();
+    expect(screen.getByText(/export csv/i)).toBeTruthy();
+
+    fireEvent.click(screen.getByText(/reset/i));
+    expect(screen.queryByText('first')).toBeNull();
+    expect(screen.queryByText(/export csv/i)).toBeNull();
+  });
+});

--- a/client/src/app/scan/page.tsx
+++ b/client/src/app/scan/page.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState } from 'react';
+
+const ScanPage = () => {
+  const [scans, setScans] = useState<string[]>([]);
+  const [input, setInput] = useState('');
+
+  const addScan = () => {
+    if (!input.trim()) return;
+    setScans((prev) => [...prev, input.trim()]);
+    setInput('');
+  };
+
+  const exportCSV = () => {
+    if (scans.length === 0) return;
+    const header = 'scan';
+    const csv = [header, ...scans].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', 'scans.csv');
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  const resetList = () => setScans([]);
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Scan result"
+          className="flex-1 rounded-md border p-2"
+        />
+        <button onClick={addScan} className="rounded bg-blue-500 px-4 py-2 text-white">
+          Add
+        </button>
+      </div>
+
+      {scans.length > 0 && (
+        <div className="space-y-2">
+          <ul className="list-disc pl-5">
+            {scans.map((scan, idx) => (
+              <li key={idx}>{scan}</li>
+            ))}
+          </ul>
+          <div className="flex gap-2">
+            <button onClick={exportCSV} className="rounded bg-green-500 px-4 py-2 text-white">
+              Export CSV
+            </button>
+            <button onClick={resetList} className="rounded bg-red-500 px-4 py-2 text-white">
+              Reset
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ScanPage;

--- a/client/tests/payments-api.test.ts
+++ b/client/tests/payments-api.test.ts
@@ -76,7 +76,7 @@ describe('payment mutations', () => {
     };
 
     const result = await store
-      .dispatch(api.endpoints.createPayment.initiate({ id: 1, ...body }))
+      .dispatch(api.endpoints.createPayment.initiate({ leaseId: 1, ...body }))
       .unwrap();
 
     const req = fetchMock.mock.calls[0][0] as any;
@@ -89,7 +89,7 @@ describe('payment mutations', () => {
       expect.objectContaining({
         success: 'Payment created successfully!',
         error: 'Failed to create payment.',
-      })
+      }),
     );
   });
 
@@ -135,7 +135,7 @@ describe('payment mutations', () => {
       expect.objectContaining({
         success: 'Payment updated successfully!',
         error: 'Failed to update payment.',
-      })
+      }),
     );
   });
 });

--- a/client/tsconfig.jest.json
+++ b/client/tsconfig.jest.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
-    "types": ["jest"]
+    "types": ["jest"],
+    "jsx": "react-jsx"
   }
 }


### PR DESCRIPTION
## Summary
- add scan page to collect session results, export them as CSV, and allow reset
- cover scan interactions with tests and fix payment API test parameter
- enable JSX transformation for Jest tests

## Testing
- `cd client && npm test`
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b11ebedfb883288e73ddd6fc773823