### PR TITLE
feat: add barcode scanning support

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -30,6 +30,8 @@
         "@radix-ui/react-tooltip": "^1.1.7",
         "@reduxjs/toolkit": "^2.5.1",
         "@terraformer/wkt": "^2.2.1",
+        "@zxing/browser": "^0.1.5",
+        "@zxing/library": "^0.21.3",
         "aws-amplify": "^6.12.2",
         "axios": "^1.11.0",
         "class-variance-authority": "^0.7.1",
@@ -7476,6 +7478,40 @@
       "integrity": "sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@zxing/browser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@zxing/browser/-/browser-0.1.5.tgz",
+      "integrity": "sha512-4Lmrn/il4+UNb87Gk8h1iWnhj39TASEHpd91CwwSJtY5u+wa0iH9qS0wNLAWbNVYXR66WmT5uiMhZ7oVTrKfxw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@zxing/text-encoding": "^0.9.0"
+      },
+      "peerDependencies": {
+        "@zxing/library": "^0.21.0"
+      }
+    },
+    "node_modules/@zxing/library": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.21.3.tgz",
+      "integrity": "sha512-hZHqFe2JyH/ZxviJZosZjV+2s6EDSY0O24R+FQmlWZBZXP9IqMo7S3nb3+2LBWxodJQkSurdQGnqE7KXqrYgow==",
+      "license": "MIT",
+      "dependencies": {
+        "ts-custom-error": "^3.2.1"
+      },
+      "engines": {
+        "node": ">= 10.4.0"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "~0.9.0"
+      }
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "license": "(Unlicense OR Apache-2.0)",
+      "optional": true
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -16942,6 +16978,15 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-custom-error": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
+      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-interface-checker": {

--- a/client/package.json
+++ b/client/package.json
@@ -41,6 +41,8 @@
     "@radix-ui/react-tooltip": "^1.1.7",
     "@reduxjs/toolkit": "^2.5.1",
     "@terraformer/wkt": "^2.2.1",
+    "@zxing/browser": "^0.1.5",
+    "@zxing/library": "^0.21.3",
     "aws-amplify": "^6.12.2",
     "axios": "^1.11.0",
     "class-variance-authority": "^0.7.1",

--- a/client/src/app/scan/page.tsx
+++ b/client/src/app/scan/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useState } from "react";
+import Navbar from "@/components/navbar";
+import BarcodeScanner from "@/components/barcode-scanner";
+
+const ScanPage = () => {
+  const [result, setResult] = useState<string | null>(null);
+
+  return (
+    <div className="h-full w-full">
+      <Navbar />
+      <main className="flex flex-col items-center p-4">
+        <BarcodeScanner onDetected={setResult} />
+        {result && <p className="mt-4 font-bold">{result}</p>}
+      </main>
+    </div>
+  );
+};
+
+export default ScanPage;
+

--- a/client/src/components/barcode-scanner.tsx
+++ b/client/src/components/barcode-scanner.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { Result } from "@zxing/library";
+
+interface BarcodeScannerProps {
+  onDetected?: (value: string) => void;
+}
+
+const BarcodeScanner = ({ onDetected }: BarcodeScannerProps) => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let stream: MediaStream | null = null;
+    let reader: any;
+
+    const start = async () => {
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: "environment" },
+        });
+
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+          await videoRef.current.play();
+        }
+
+        if ("BarcodeDetector" in window) {
+          const formats = ["qr_code", "ean_13", "code_128", "upc_a", "ean_8"];
+          // @ts-ignore
+          const detector = new BarcodeDetector({ formats });
+
+          const scan = async () => {
+            if (!videoRef.current) return;
+            try {
+              const barcodes = await detector.detect(videoRef.current);
+              if (barcodes.length > 0) {
+                onDetected?.(barcodes[0].rawValue);
+              }
+            } catch {
+              /* ignore */
+            }
+            requestAnimationFrame(scan);
+          };
+
+          requestAnimationFrame(scan);
+        } else {
+          const { BrowserMultiFormatReader } = await import("@zxing/browser");
+          reader = new BrowserMultiFormatReader();
+          const devices = await BrowserMultiFormatReader.listVideoInputDevices();
+          const firstDeviceId = devices[0]?.deviceId;
+
+          await reader.decodeFromVideoDevice(
+            firstDeviceId,
+            videoRef.current!,
+            (result: Result | undefined) => {
+              if (result) {
+                onDetected?.(result.getText());
+              }
+            }
+          );
+        }
+      } catch (err) {
+        setError((err as Error).message);
+      }
+    };
+
+    start();
+
+    return () => {
+      if (reader && typeof reader.reset === "function") {
+        reader.reset();
+      }
+      if (stream) {
+        stream.getTracks().forEach((t) => t.stop());
+      }
+    };
+  }, [onDetected]);
+
+  return (
+    <div className="w-full">
+      <video ref={videoRef} className="h-auto w-full" />
+      {error && <p className="mt-2 text-red-500">{error}</p>}
+    </div>
+  );
+};
+
+export default BarcodeScanner;
+


### PR DESCRIPTION
## Summary
- add barcode scanner component leveraging BarcodeDetector API with ZXing fallback
- create scan page to auto-start camera and display results
- include ZXing dependencies

## Testing
- `npm test` (fails: Expected `http://localhost:3001/leases/1/payments` Received `http://localhost:3001/leases/undefined/payments`)
- `npm run lint` (fails: Code style issues found in 103 files)


------
https://chatgpt.com/codex/tasks/task_e_68b11ea4c8a88328a43cbb124166455f