### PR TITLE
feat: add drag-drop parser table

### DIFF
--- a/client/src/__tests__/parseEntries.test.ts
+++ b/client/src/__tests__/parseEntries.test.ts
@@ -1,0 +1,20 @@
+import { parseEntries } from "../lib/parseEntries";
+
+describe('parseEntries', () => {
+  it('parses text lines into entries', () => {
+    const text = 'example.com /index.html high\nexample.org /about low';
+    const entries = parseEntries(text);
+    expect(entries).toEqual([
+      { host: 'example.com', path: '/index.html', severity: 'high' },
+      { host: 'example.org', path: '/about', severity: 'low' }
+    ]);
+  });
+
+  it('parses xml into entries', () => {
+    const xml = `<?xml version="1.0"?><root><entry><host>a.com</host><path>/</path><severity>medium</severity></entry></root>`;
+    const entries = parseEntries(xml);
+    expect(entries).toEqual([
+      { host: 'a.com', path: '/', severity: 'medium' }
+    ]);
+  });
+});

--- a/client/src/app/entries/page.tsx
+++ b/client/src/app/entries/page.tsx
@@ -1,0 +1,9 @@
+import VulnerabilityTable from '@/components/vulnerability-table';
+
+export default function EntriesPage() {
+  return (
+    <div className="p-4">
+      <VulnerabilityTable />
+    </div>
+  );
+}

--- a/client/src/components/vulnerability-table.tsx
+++ b/client/src/components/vulnerability-table.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useState } from 'react';
+import { parseEntries, Entry } from '@/lib/parseEntries';
+
+export default function VulnerabilityTable() {
+  const [entries, setEntries] = useState<Entry[]>([]);
+  const [hostFilter, setHostFilter] = useState('');
+  const [pathFilter, setPathFilter] = useState('');
+  const [search, setSearch] = useState('');
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const files = e.dataTransfer.files;
+    if (files && files.length > 0) {
+      const file = files[0];
+      const reader = new FileReader();
+      reader.onload = ev => {
+        const text = ev.target?.result as string;
+        const parsed = parseEntries(text);
+        setEntries(prev => [...prev, ...parsed]);
+      };
+      reader.readAsText(file);
+      e.dataTransfer.clearData();
+    } else {
+      const text = e.dataTransfer.getData('text/plain');
+      if (text) {
+        const parsed = parseEntries(text);
+        setEntries(prev => [...prev, ...parsed]);
+      }
+    }
+  };
+
+  const severityClass = (sev: string) => {
+    switch (sev.toLowerCase()) {
+      case 'high':
+        return 'text-red-600';
+      case 'medium':
+        return 'text-yellow-600';
+      case 'low':
+        return 'text-green-600';
+      default:
+        return '';
+    }
+  };
+
+  const filtered = entries.filter(e =>
+    (!hostFilter || e.host.includes(hostFilter)) &&
+    (!pathFilter || e.path.includes(pathFilter)) &&
+    (!search || `${e.host} ${e.path} ${e.severity}`.toLowerCase().includes(search.toLowerCase()))
+  );
+
+  return (
+    <div className="space-y-4">
+      <div
+        onDragOver={e => e.preventDefault()}
+        onDrop={handleDrop}
+        className="border-2 border-dashed rounded p-6 text-center text-sm text-muted-foreground"
+      >
+        Drag & drop text or XML data here
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <input
+          className="border p-1"
+          placeholder="Filter host"
+          value={hostFilter}
+          onChange={e => setHostFilter(e.target.value)}
+        />
+        <input
+          className="border p-1"
+          placeholder="Filter path"
+          value={pathFilter}
+          onChange={e => setPathFilter(e.target.value)}
+        />
+        <input
+          className="border p-1 flex-1"
+          placeholder="Search"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+      </div>
+      <table className="min-w-full text-sm border">
+        <thead className="bg-gray-100">
+          <tr>
+            <th className="border px-2 py-1 text-left">Host</th>
+            <th className="border px-2 py-1 text-left">Path</th>
+            <th className="border px-2 py-1 text-left">Severity</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map((e, idx) => (
+            <tr key={idx} className="border-t">
+              <td className="border px-2 py-1">{e.host}</td>
+              <td className="border px-2 py-1">{e.path}</td>
+              <td className={`border px-2 py-1 ${severityClass(e.severity)}`}>{e.severity}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/client/src/lib/parseEntries.ts
+++ b/client/src/lib/parseEntries.ts
@@ -1,0 +1,43 @@
+export interface Entry {
+  host: string;
+  path: string;
+  severity: string;
+}
+
+function parseText(text: string): Entry[] {
+  return text
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(line => {
+      const [host, path, severity] = line.split(/\s+/);
+      return { host, path, severity } as Entry;
+    })
+    .filter(e => e.host && e.path && e.severity);
+}
+
+function parseXml(text: string): Entry[] {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(text, 'application/xml');
+  const entries: Entry[] = [];
+  doc.querySelectorAll('entry').forEach(node => {
+    const host = node.querySelector('host')?.textContent?.trim() || '';
+    const path = node.querySelector('path')?.textContent?.trim() || '';
+    const severity = node.querySelector('severity')?.textContent?.trim() || '';
+    if (host && path && severity) {
+      entries.push({ host, path, severity });
+    }
+  });
+  return entries;
+}
+
+export function parseEntries(text: string): Entry[] {
+  // try XML first
+  try {
+    const xmlEntries = parseXml(text);
+    if (xmlEntries.length) return xmlEntries;
+  } catch {
+    // ignore
+  }
+  return parseText(text);
+}


### PR DESCRIPTION
## Summary
- parse text or XML into host/path/severity entries
- add drag-and-drop vulnerability table with filters, search, and severity highlighting
- expose new page to view parsed entries

## Testing
- `npm test` *(fails: payment mutations test)*

------
https://chatgpt.com/codex/tasks/task_e_68b11e9a3bd083288e51d7eff25df76b