### PR TITLE
feat: add unit converter utilities and UI

### DIFF
--- a/client/src/__tests__/units.test.ts
+++ b/client/src/__tests__/units.test.ts
@@ -1,0 +1,15 @@
+import { humanizeBytes, humanizeDuration } from '@/apps/converter/units';
+
+describe('unit converters', () => {
+  it('converts bytes to human readable strings', () => {
+    expect(humanizeBytes(0)).toBe('0 B');
+    expect(humanizeBytes(1024)).toBe('1 KB');
+    expect(humanizeBytes(1048576)).toBe('1 MB');
+  });
+
+  it('converts milliseconds to human readable duration', () => {
+    expect(humanizeDuration(1000)).toBe('1s');
+    expect(humanizeDuration(61000)).toBe('1m 1s');
+    expect(humanizeDuration(3661000)).toBe('1h 1m 1s');
+  });
+});

--- a/client/src/app/converter/page.tsx
+++ b/client/src/app/converter/page.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useState } from 'react';
+import { humanizeBytes, humanizeDuration } from '@/apps/converter/units';
+
+export default function ConverterPage() {
+  const [bytes, setBytes] = useState('');
+  const [ms, setMs] = useState('');
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Unit Converter</h1>
+
+      <div>
+        <label className="block mb-2">Bytes</label>
+        <input
+          className="w-full rounded border p-2"
+          value={bytes}
+          onChange={(e) => setBytes(e.target.value)}
+          type="number"
+        />
+        <p className="mt-2 text-sm text-gray-600">
+          {bytes && humanizeBytes(Number(bytes))}
+        </p>
+      </div>
+
+      <div>
+        <label className="block mb-2">Milliseconds</label>
+        <input
+          className="w-full rounded border p-2"
+          value={ms}
+          onChange={(e) => setMs(e.target.value)}
+          type="number"
+        />
+        <p className="mt-2 text-sm text-gray-600">
+          {ms && humanizeDuration(Number(ms))}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/client/src/apps/converter/units.ts
+++ b/client/src/apps/converter/units.ts
@@ -1,0 +1,23 @@
+export function humanizeBytes(bytes: number, decimals = 2): string {
+  if (!Number.isFinite(bytes) || bytes === 0) return '0 B';
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const value = bytes / Math.pow(k, i);
+  return `${parseFloat(value.toFixed(dm))} ${sizes[i]}`;
+}
+
+export function humanizeDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return '0s';
+  let seconds = Math.floor(ms / 1000);
+  const hours = Math.floor(seconds / 3600);
+  seconds %= 3600;
+  const minutes = Math.floor(seconds / 60);
+  seconds %= 60;
+  const parts: string[] = [];
+  if (hours) parts.push(`${hours}h`);
+  if (minutes) parts.push(`${minutes}m`);
+  if (seconds || parts.length === 0) parts.push(`${seconds}s`);
+  return parts.join(' ');
+}

--- a/client/tests/payments-api.test.ts
+++ b/client/tests/payments-api.test.ts
@@ -76,7 +76,7 @@ describe('payment mutations', () => {
     };
 
     const result = await store
-      .dispatch(api.endpoints.createPayment.initiate({ id: 1, ...body }))
+      .dispatch(api.endpoints.createPayment.initiate({ leaseId: 1, ...body }))
       .unwrap();
 
     const req = fetchMock.mock.calls[0][0] as any;


### PR DESCRIPTION
## Summary
- implement `humanizeBytes` and `humanizeDuration` helpers
- add converter page to demo byte and time humanization
- cover converters with unit tests and fix payment API test param

## Testing
- `cd client && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b11e86e8348328903a959d0532a159