### PR TITLE
Add streaming hash worker and UI

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -41,6 +41,7 @@
         "filepond-plugin-image-exif-orientation": "^1.0.11",
         "filepond-plugin-image-preview": "^4.6.12",
         "framer-motion": "^12.23.11",
+        "hash-wasm": "^4.12.0",
         "lodash": "^4.17.21",
         "lucide-react": "^0.474.0",
         "mapbox-gl": "^3.13.0",
@@ -11381,6 +11382,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/hash-wasm": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.12.0.tgz",
+      "integrity": "sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ==",
+      "license": "MIT"
     },
     "node_modules/hasown": {
       "version": "2.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -52,6 +52,7 @@
     "filepond-plugin-image-exif-orientation": "^1.0.11",
     "filepond-plugin-image-preview": "^4.6.12",
     "framer-motion": "^12.23.11",
+    "hash-wasm": "^4.12.0",
     "lodash": "^4.17.21",
     "lucide-react": "^0.474.0",
     "mapbox-gl": "^3.13.0",

--- a/client/src/app/hash/page.tsx
+++ b/client/src/app/hash/page.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import type { HashResults } from '@/workers/hash-worker';
+
+export default function HashPage() {
+  const workerRef = useRef<Worker | null>(null);
+  const [progress, setProgress] = useState(0);
+  const [results, setResults] = useState<HashResults | null>(null);
+
+  useEffect(() => {
+    workerRef.current = new Worker(new URL('../../workers/hash-worker.ts', import.meta.url), {
+      type: 'module',
+    });
+    workerRef.current.onmessage = (e: MessageEvent) => {
+      const data = e.data as any;
+      if (data.type === 'progress') {
+        setProgress(data.progress);
+      } else if (data.type === 'result') {
+        setResults(data.results);
+        setProgress(1);
+      }
+    };
+    return () => {
+      workerRef.current?.terminate();
+    };
+  }, []);
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file && workerRef.current) {
+      setProgress(0);
+      setResults(null);
+      workerRef.current.postMessage({ file });
+    }
+  };
+
+  const handleDownload = () => {
+    if (!results) return;
+    const blob = new Blob([JSON.stringify(results, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'hashes.json';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">File Hash</h1>
+      <input type="file" onChange={handleFile} />
+      {progress > 0 && progress < 1 && (
+        <div className="w-full bg-gray-200 rounded h-2">
+          <div className="bg-blue-500 h-2 rounded" style={{ width: `${progress * 100}%` }} />
+        </div>
+      )}
+      {results && (
+        <div className="space-y-2">
+          <pre className="bg-gray-100 p-2 rounded text-sm overflow-x-auto">
+            {JSON.stringify(results, null, 2)}
+          </pre>
+          <Button onClick={handleDownload}>Download Results</Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/workers/hash-worker.ts
+++ b/client/src/workers/hash-worker.ts
@@ -1,0 +1,58 @@
+import { createSHA256, createBLAKE3, createCRC32 } from 'hash-wasm';
+
+export interface HashResults {
+  sha256: { hex: string; base64: string };
+  blake3: { hex: string; base64: string };
+  crc32: { hex: string; base64: string };
+}
+
+function hexToBase64(hex: string): string {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.substr(i * 2, 2), 16);
+  }
+  let binary = '';
+  bytes.forEach((b) => {
+    binary += String.fromCharCode(b);
+  });
+  return btoa(binary);
+}
+
+self.onmessage = async (e: MessageEvent<{ file: File }>) => {
+  const { file } = e.data;
+  const total = file.size;
+
+  const sha256 = await createSHA256();
+  const blake3 = await createBLAKE3();
+  const crc32 = await createCRC32();
+  sha256.init();
+  blake3.init();
+  crc32.init();
+
+  const reader = file.stream().getReader();
+  let processed = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    sha256.update(value);
+    blake3.update(value);
+    crc32.update(value);
+    processed += value.length;
+    self.postMessage({ type: 'progress', progress: processed / total });
+  }
+
+  const sha256Hex = sha256.digest('hex');
+  const blake3Hex = blake3.digest('hex');
+  const crc32Hex = crc32.digest('hex');
+
+  const results: HashResults = {
+    sha256: { hex: sha256Hex, base64: hexToBase64(sha256Hex) },
+    blake3: { hex: blake3Hex, base64: hexToBase64(blake3Hex) },
+    crc32: { hex: crc32Hex, base64: hexToBase64(crc32Hex) },
+  };
+
+  self.postMessage({ type: 'result', results });
+};
+
+export {};


### PR DESCRIPTION
## Summary
- add hash-wasm dependency and worker for streaming SHA-256/BLAKE3/CRC32 hashing with base64 output
- create hash page to run hashing in a web worker, show progress, and download results

## Testing
- `npm run lint` (fails: Code style issues found in 102 files)
- `npm run typecheck` (fails: numerous TypeScript errors)
- `npm test` (fails: payment mutations creates a payment via POST)


------
https://chatgpt.com/codex/tasks/task_e_68b11e846fc08328ad4585466e7eeb9b