### PR TITLE
feat: add PWA share target handling

### DIFF
--- a/client/src/app/apps/contact/ShareTarget.tsx
+++ b/client/src/app/apps/contact/ShareTarget.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface SharedData {
+  title?: string;
+  text?: string;
+  files?: File[];
+  url?: string;
+}
+
+export default function ShareTarget() {
+  const [data, setData] = useState<SharedData>({});
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !("launchQueue" in window)) {
+      return;
+    }
+
+    // Handle share target launches
+    (window as any).launchQueue.setConsumer(async (launchParams: any) => {
+      if (!launchParams) return;
+
+      const files: File[] = [];
+      if (launchParams.files && launchParams.files.length) {
+        for (const fileHandle of launchParams.files) {
+          const file = await fileHandle.getFile();
+          files.push(file);
+        }
+      }
+
+      setData({
+        title: launchParams.title,
+        text: launchParams.text,
+        url: launchParams.url,
+        files,
+      });
+    });
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Shared Data</h1>
+      {data.title && <p data-testid="shared-title">Title: {data.title}</p>}
+      {data.text && <p data-testid="shared-text">Text: {data.text}</p>}
+      {data.url && <p data-testid="shared-url">URL: {data.url}</p>}
+      {data.files && data.files.length > 0 && (
+        <ul data-testid="shared-files">
+          {data.files.map((file, idx) => (
+            <li key={idx}>{file.name}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/client/src/app/apps/contact/page.tsx
+++ b/client/src/app/apps/contact/page.tsx
@@ -1,0 +1,5 @@
+import ShareTarget from "./ShareTarget";
+
+export default function ContactSharePage() {
+  return <ShareTarget />;
+}

--- a/client/src/app/manifest.ts
+++ b/client/src/app/manifest.ts
@@ -1,0 +1,36 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "GarageGuru",
+    short_name: "GarageGuru",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#ffffff",
+    theme_color: "#ffffff",
+    icons: [
+      {
+        src: "/logo.svg",
+        sizes: "512x512",
+        type: "image/svg+xml",
+        purpose: "any"
+      }
+    ],
+    share_target: {
+      action: "/apps/contact",
+      method: "POST",
+      enctype: "multipart/form-data",
+      params: {
+        title: "title",
+        text: "text",
+        url: "url",
+        files: [
+          {
+            name: "files",
+            accept: ["*/*"]
+          }
+        ]
+      }
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add manifest with share target configuration for text and files
- handle incoming shared data using the Web Share Target API

## Testing
- `npm test` *(fails: payment mutations › creates a payment via POST)*

------
https://chatgpt.com/codex/tasks/task_e_68b11e80058883289093b737f2dfd786