### PR TITLE
feat: add placeholder periodic sync

### DIFF
--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -1,0 +1,25 @@
+self.addEventListener('periodicsync', (event) => {
+  if (event.tag === 'placeholder-sync') {
+    event.waitUntil(handleSync());
+  }
+});
+
+// Placeholder hook for future remote sync events
+self.addEventListener('sync', (event) => {
+  if (event.tag === 'remote-placeholder-sync') {
+    event.waitUntil(handleSync());
+  }
+});
+
+async function handleSync() {
+  try {
+    const res = await fetch('https://jsonplaceholder.typicode.com/todos/1');
+    const data = await res.json();
+    const allClients = await self.clients.matchAll({ includeUncontrolled: true });
+    for (const client of allClients) {
+      client.postMessage({ type: 'placeholder-sync', data });
+    }
+  } catch (err) {
+    // Fail silently for now
+  }
+}

--- a/client/src/app/providers.tsx
+++ b/client/src/app/providers.tsx
@@ -1,11 +1,13 @@
-"use client";
+'use client';
 
-import StoreProvider from "@/state/redux";
-import { Authenticator } from "@aws-amplify/ui-react";
-import Auth from "./(auth)/auth-provider";
-import { ThemeProvider } from "next-themes";
+import StoreProvider from '@/state/redux';
+import { Authenticator } from '@aws-amplify/ui-react';
+import Auth from './(auth)/auth-provider';
+import { ThemeProvider } from 'next-themes';
+import { usePlaceholderSync } from '@/hooks/use-placeholder-sync';
 
 const Providers = ({ children }: { children: React.ReactNode }) => {
+  usePlaceholderSync();
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
       <StoreProvider>

--- a/client/src/hooks/use-placeholder-sync.test.ts
+++ b/client/src/hooks/use-placeholder-sync.test.ts
@@ -1,0 +1,25 @@
+import { renderHook, act } from '@testing-library/react';
+import { usePlaceholderSync } from './use-placeholder-sync';
+
+describe('usePlaceholderSync', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      json: async () => ({ id: 1, title: 'test' }),
+    });
+    Object.defineProperty(global.navigator, 'serviceWorker', {
+      value: undefined,
+      configurable: true,
+    });
+  });
+
+  it('falls back to manual sync and fetches data', async () => {
+    const { result } = renderHook(() => usePlaceholderSync());
+    expect(result.current.isSupported).toBe(false);
+
+    await act(async () => {
+      await result.current.manualSync();
+    });
+
+    expect(result.current.data).toEqual({ id: 1, title: 'test' });
+  });
+});

--- a/client/src/hooks/use-placeholder-sync.ts
+++ b/client/src/hooks/use-placeholder-sync.ts
@@ -1,0 +1,69 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+type PlaceholderData = unknown;
+
+export function usePlaceholderSync() {
+  const [data, setData] = useState<PlaceholderData | null>(null);
+  const [error, setError] = useState<unknown>(null);
+  const [isSupported, setIsSupported] = useState(true);
+
+  const manualSync = useCallback(async () => {
+    try {
+      const res = await fetch('https://jsonplaceholder.typicode.com/todos/1');
+      const json = await res.json();
+      setData(json);
+      setError(null);
+      return json;
+    } catch (err) {
+      setError(err);
+      return null;
+    }
+  }, []);
+
+  useEffect(() => {
+    let messageHandler: ((event: MessageEvent) => void) | null = null;
+
+    async function register() {
+      if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) {
+        setIsSupported(false);
+        return;
+      }
+
+      try {
+        const registration = await navigator.serviceWorker.register('/sw.js');
+        if ('periodicSync' in registration) {
+          try {
+            await registration.periodicSync.register('placeholder-sync', {
+              minInterval: 24 * 60 * 60 * 1000,
+            });
+          } catch {
+            setIsSupported(false);
+          }
+        } else {
+          setIsSupported(false);
+        }
+
+        messageHandler = (event: MessageEvent) => {
+          if (event.data?.type === 'placeholder-sync') {
+            setData(event.data.data);
+          }
+        };
+        navigator.serviceWorker.addEventListener('message', messageHandler);
+      } catch {
+        setIsSupported(false);
+      }
+    }
+
+    register();
+
+    return () => {
+      if (messageHandler && typeof navigator !== 'undefined') {
+        navigator.serviceWorker.removeEventListener('message', messageHandler);
+      }
+    };
+  }, []);
+
+  return { data, error, isSupported, manualSync };
+}


### PR DESCRIPTION
## Summary
- register periodic background sync and manual fallback
- add service worker hook for placeholder data and future remote sync
- expose hook via providers

## Testing
- `npm test` (fails: payment mutations › creates a payment via POST)
- `npm run lint` (fails: Code style issues found in 103 files)
- `npm test` (server)


------
https://chatgpt.com/codex/tasks/task_e_68b11e7453488328bb83c2721d1a0258