### PR TITLE
feat: add OPFS task list with share target

### DIFF
--- a/client/public/manifest.json
+++ b/client/public/manifest.json
@@ -1,0 +1,28 @@
+{
+  "name": "GarageGuru Tasks",
+  "short_name": "Tasks",
+  "start_url": "/tasks",
+  "display": "standalone",
+  "icons": [
+    {
+      "src": "/logo.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ],
+  "share_target": {
+    "action": "/share-target",
+    "method": "POST",
+    "enctype": "multipart/form-data",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "files": [
+        {
+          "name": "files",
+          "accept": ["*/*"]
+        }
+      ]
+    }
+  }
+}

--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -1,0 +1,25 @@
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()));
+
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url);
+  if (url.pathname === '/share-target' && event.request.method === 'POST') {
+    event.respondWith((async () => {
+      const formData = await event.request.formData();
+      const text = formData.get('text') || formData.get('title');
+      const files = formData.getAll('files');
+      let fileData;
+      let fileName;
+      if (files.length && files[0] instanceof File) {
+        const file = files[0];
+        fileName = file.name;
+        fileData = await file.arrayBuffer();
+      }
+      const clients = await self.clients.matchAll();
+      for (const client of clients) {
+        client.postMessage({ action: 'share', text, fileData, fileName });
+      }
+      return Response.redirect('/tasks', 303);
+    })());
+  }
+});

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -44,6 +44,7 @@ export const metadata: Metadata = {
     images: ["/og-image.png"],
     creator: "@GarageGuru",
   },
+  manifest: "/manifest.json",
 };
 
 export default function RootLayout({

--- a/client/src/app/providers.tsx
+++ b/client/src/app/providers.tsx
@@ -4,8 +4,27 @@ import StoreProvider from "@/state/redux";
 import { Authenticator } from "@aws-amplify/ui-react";
 import Auth from "./(auth)/auth-provider";
 import { ThemeProvider } from "next-themes";
+import { useEffect } from "react";
+import { addTask } from "@/lib/opfs-tasks";
 
 const Providers = ({ children }: { children: React.ReactNode }) => {
+  useEffect(() => {
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker.register("/sw.js");
+      navigator.serviceWorker.addEventListener("message", async (event) => {
+        if (event.data?.action === "share") {
+          const { text, fileName, fileData } = event.data;
+          let file: File | undefined;
+          if (fileData && fileName) {
+            const bytes = new Uint8Array(fileData);
+            file = new File([bytes], fileName);
+          }
+          await addTask({ text: text || fileName || "", file });
+        }
+      });
+    }
+  }, []);
+
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
       <StoreProvider>

--- a/client/src/app/share-target/page.tsx
+++ b/client/src/app/share-target/page.tsx
@@ -1,0 +1,37 @@
+"use client";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { addTask } from "@/lib/opfs-tasks";
+
+export default function ShareTargetPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    async function handleShare() {
+      if ("launchQueue" in window) {
+        (window as any).launchQueue.setConsumer(async (launchParams: any) => {
+          if (launchParams.files?.length) {
+            for (const file of launchParams.files) {
+              await addTask({ text: file.name, file });
+            }
+          }
+          const text = launchParams?.text || "";
+          if (text) {
+            await addTask({ text });
+          }
+          router.replace("/tasks");
+        });
+      } else {
+        const params = new URLSearchParams(window.location.search);
+        const text = params.get("text") || params.get("title");
+        if (text) {
+          await addTask({ text });
+        }
+        router.replace("/tasks");
+      }
+    }
+    handleShare();
+  }, [router]);
+
+  return <p>Processing shared content...</p>;
+}

--- a/client/src/app/tasks/page.tsx
+++ b/client/src/app/tasks/page.tsx
@@ -1,0 +1,75 @@
+"use client";
+import { useEffect, useState } from "react";
+import {
+  listTasks,
+  addTask,
+  updateTask,
+  deleteTask,
+  Task,
+} from "@/lib/opfs-tasks";
+
+export default function TasksPage() {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [text, setText] = useState("");
+  const [file, setFile] = useState<File | undefined>();
+
+  useEffect(() => {
+    listTasks().then(setTasks);
+  }, []);
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    if (!text && !file) return;
+    const task = await addTask({ text, file });
+    setTasks((prev) => [...prev, task]);
+    setText("");
+    setFile(undefined);
+  }
+
+  async function handleDelete(id: string) {
+    await deleteTask(id);
+    setTasks((prev) => prev.filter((t) => t.id !== id));
+  }
+
+  async function handleUpdate(id: string, newText: string) {
+    await updateTask(id, { text: newText });
+    setTasks((prev) => prev.map((t) => (t.id === id ? { ...t, text: newText } : t)));
+  }
+
+  return (
+    <main className="p-4">
+      <form onSubmit={handleAdd} className="flex gap-2 mb-4">
+        <input
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="New task"
+          className="border p-1 flex-1"
+        />
+        <input
+          type="file"
+          onChange={(e) => setFile(e.target.files?.[0])}
+        />
+        <button type="submit" className="bg-blue-500 text-white px-2">
+          Add
+        </button>
+      </form>
+      <ul>
+        {tasks.map((t) => (
+          <li key={t.id} className="mb-2">
+            <input
+              value={t.text}
+              onChange={(e) => handleUpdate(t.id, e.target.value)}
+              className="border p-1 mr-2"
+            />
+            <button
+              onClick={() => handleDelete(t.id)}
+              className="text-red-500"
+            >
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/client/src/lib/opfs-tasks.ts
+++ b/client/src/lib/opfs-tasks.ts
@@ -1,0 +1,87 @@
+export interface Task {
+  id: string;
+  text: string;
+  filePath?: string;
+}
+
+const TASKS_FILE = 'tasks.json';
+
+async function getRootDir() {
+  // Origin Private File System root
+  return await (navigator as any).storage.getDirectory();
+}
+
+async function getTasksFileHandle() {
+  const root = await getRootDir();
+  try {
+    return await root.getFileHandle(TASKS_FILE);
+  } catch {
+    const handle = await root.getFileHandle(TASKS_FILE, { create: true });
+    const writable = await handle.createWritable();
+    await writable.write('[]');
+    await writable.close();
+    return handle;
+  }
+}
+
+async function readTasks(): Promise<Task[]> {
+  const handle = await getTasksFileHandle();
+  const file = await handle.getFile();
+  const text = await file.text();
+  try {
+    return JSON.parse(text) as Task[];
+  } catch {
+    return [];
+  }
+}
+
+async function writeTasks(tasks: Task[]) {
+  const handle = await getTasksFileHandle();
+  const writable = await handle.createWritable();
+  await writable.write(JSON.stringify(tasks));
+  await writable.close();
+}
+
+export async function listTasks() {
+  return await readTasks();
+}
+
+export async function addTask(data: { text: string; file?: File }) {
+  const tasks = await readTasks();
+  const id = crypto.randomUUID();
+  let filePath: string | undefined;
+  if (data.file) {
+    const root = await getRootDir();
+    const fileHandle = await root.getFileHandle(`${id}-${data.file.name}`, { create: true });
+    const writable = await fileHandle.createWritable();
+    await writable.write(await data.file.arrayBuffer());
+    await writable.close();
+    filePath = fileHandle.name;
+  }
+  const newTask: Task = { id, text: data.text, filePath };
+  tasks.push(newTask);
+  await writeTasks(tasks);
+  return newTask;
+}
+
+export async function updateTask(id: string, updates: { text?: string }) {
+  const tasks = await readTasks();
+  const idx = tasks.findIndex((t) => t.id === id);
+  if (idx === -1) return;
+  tasks[idx] = { ...tasks[idx], ...updates };
+  await writeTasks(tasks);
+}
+
+export async function deleteTask(id: string) {
+  const tasks = await readTasks();
+  const idx = tasks.findIndex((t) => t.id === id);
+  if (idx === -1) return;
+  const [task] = tasks.splice(idx, 1);
+  await writeTasks(tasks);
+  if (task.filePath) {
+    const root = await getRootDir();
+    try {
+      await root.removeEntry(task.filePath);
+    } catch {}
+  }
+}


### PR DESCRIPTION
## Summary
- add OPFS-backed task storage with CRUD helpers
- create tasks UI and handle share-target additions
- register service worker and manifest for Android share sheet

## Testing
- `npm test` (client) *(fails: Expected "http://localhost:3001/leases/1/payments" Received "http://localhost:3001/leases/undefined/payments")*
- `npm test` (server)`

------
https://chatgpt.com/codex/tasks/task_e_68b11e6efd508328853c8af7b17bf46e