### PR TITLE
Add Wireshark filter examples and selection UI

### DIFF
--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  experimental: {
+    externalDir: true,
+  },
   images: {
     remotePatterns: [
       {

--- a/client/src/app/(dashboard)/packets/page.tsx
+++ b/client/src/app/(dashboard)/packets/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import WiresharkFilterSelect from "@/components/wireshark-filter-select";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface Packet {
+  id: number;
+  protocol: string;
+  info: string;
+  filter: string;
+}
+
+const packets: Packet[] = [
+  { id: 1, protocol: "HTTP", info: "GET /index.html", filter: "http" },
+  { id: 2, protocol: "TCP", info: "SYN", filter: "tcp" },
+  { id: 3, protocol: "UDP", info: "DNS Query", filter: "udp" },
+  { id: 4, protocol: "TCP", info: "ACK", filter: "tcp" },
+];
+
+export default function PacketPage() {
+  const [filter, setFilter] = useState("");
+  const filtered = packets.filter(
+    (p) => !filter || p.filter.includes(filter)
+  );
+
+  return (
+    <div className="p-6 space-y-4">
+      <div className="flex items-center gap-4">
+        <Input
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder="Enter filter expression"
+          className="max-w-sm"
+        />
+        <WiresharkFilterSelect onSelect={setFilter} />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Packet List</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr>
+                <th className="py-2">ID</th>
+                <th>Protocol</th>
+                <th>Info</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((p) => (
+                <tr key={p.id} className="border-t">
+                  <td className="py-1">{p.id}</td>
+                  <td>{p.protocol}</td>
+                  <td>{p.info}</td>
+                </tr>
+              ))}
+              {filtered.length === 0 && (
+                <tr>
+                  <td colSpan={3} className="py-4 text-center text-gray-500">
+                    No packets match the current filter
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/components/wireshark-filter-select.tsx
+++ b/client/src/components/wireshark-filter-select.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import filters from "../../../data/wireshark-filters.json";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger
+} from "@/components/ui/tooltip";
+
+interface WiresharkFilter {
+  name: string;
+  expression: string;
+  description: string;
+}
+
+interface Props {
+  onSelect: (expression: string) => void;
+}
+
+export default function WiresharkFilterSelect({ onSelect }: Props) {
+  return (
+    <TooltipProvider>
+      <Select onValueChange={onSelect}>
+        <SelectTrigger className="w-[240px]">
+          <SelectValue placeholder="Example filters" />
+        </SelectTrigger>
+        <SelectContent>
+          {(filters as WiresharkFilter[]).map((f) => (
+            <Tooltip key={f.expression}>
+              <TooltipTrigger asChild>
+                <SelectItem value={f.expression}>{f.name}</SelectItem>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{f.description}</p>
+                <code className="text-xs">{f.expression}</code>
+              </TooltipContent>
+            </Tooltip>
+          ))}
+        </SelectContent>
+      </Select>
+    </TooltipProvider>
+  );
+}

--- a/data/wireshark-filters.json
+++ b/data/wireshark-filters.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "HTTP Traffic",
+    "expression": "http",
+    "description": "Show all HTTP protocol packets"
+  },
+  {
+    "name": "TCP Only",
+    "expression": "tcp",
+    "description": "Display only TCP packets"
+  },
+  {
+    "name": "UDP Only",
+    "expression": "udp",
+    "description": "Display only UDP packets"
+  },
+  {
+    "name": "IP Address 192.168.1.1",
+    "expression": "ip.addr == 192.168.1.1",
+    "description": "Packets to or from 192.168.1.1"
+  }
+]


### PR DESCRIPTION
## Summary
- add sample Wireshark filters in structured JSON
- add dropdown with tooltips to choose predefined filters
- show new packet list page that applies selected filter

## Testing
- `npm test` *(fails: Expected URL http://localhost:3001/leases/1/payments)*
- `npm run lint` *(fails: Code style issues found in 103 files)*

------
https://chatgpt.com/codex/tasks/task_e_68b11e5977008328a0739de759b7e285