### PR TITLE
feat(gallery): add filterable showcase with code snippets

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,7 @@
         "@fortawesome/free-brands-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@hookform/resolvers": "^3.10.0",
+        "@monaco-editor/react": "^4.7.0",
         "@radix-ui/react-avatar": "^1.1.2",
         "@radix-ui/react-checkbox": "^1.1.3",
         "@radix-ui/react-dialog": "^1.1.5",
@@ -3901,6 +3902,29 @@
       "license": "ISC",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.5.0.tgz",
+      "integrity": "sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@next/env": {
@@ -13868,6 +13892,13 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/motion-dom": {
       "version": "12.23.9",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.9.tgz",
@@ -16325,6 +16356,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
     },
     "node_modules/string-length": {
       "version": "4.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -24,6 +24,7 @@
     "@fortawesome/free-brands-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@hookform/resolvers": "^3.10.0",
+    "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-avatar": "^1.1.2",
     "@radix-ui/react-checkbox": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.5",

--- a/client/src/app/(nondashboard)/gallery/page.tsx
+++ b/client/src/app/(nondashboard)/gallery/page.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Image from 'next/image';
+import dynamic from 'next/dynamic';
+import { galleryData } from '@/lib/gallery-data';
+
+const MonacoEditor = dynamic(() => import('@monaco-editor/react'), {
+  ssr: false,
+});
+
+export default function GalleryPage() {
+  const [selectedStacks, setSelectedStacks] = useState<string[]>([]);
+  const [selectedYear, setSelectedYear] = useState<number | null>(null);
+
+  useEffect(() => {
+    const saved = localStorage.getItem('galleryFilters');
+    if (saved) {
+      const { stacks, year } = JSON.parse(saved);
+      setSelectedStacks(stacks || []);
+      setSelectedYear(year ?? null);
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(
+      'galleryFilters',
+      JSON.stringify({ stacks: selectedStacks, year: selectedYear }),
+    );
+  }, [selectedStacks, selectedYear]);
+
+  const stacks = useMemo(
+    () => Array.from(new Set(galleryData.flatMap((g) => g.stacks))).sort(),
+    [],
+  );
+  const years = useMemo(() => Array.from(new Set(galleryData.map((g) => g.year))).sort(), []);
+
+  const filtered = galleryData.filter(
+    (item) =>
+      (selectedStacks.length === 0 || selectedStacks.every((s) => item.stacks.includes(s))) &&
+      (selectedYear === null || item.year === selectedYear),
+  );
+
+  const toggleStack = (stack: string) => {
+    setSelectedStacks((prev) =>
+      prev.includes(stack) ? prev.filter((s) => s !== stack) : [...prev, stack],
+    );
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex flex-wrap gap-4 items-center">
+        {stacks.map((stack) => (
+          <label key={stack} className="flex items-center gap-1">
+            <input
+              type="checkbox"
+              checked={selectedStacks.includes(stack)}
+              onChange={() => toggleStack(stack)}
+            />
+            <span className="capitalize">{stack}</span>
+          </label>
+        ))}
+        <select
+          className="border p-1 rounded"
+          value={selectedYear ?? ''}
+          onChange={(e) => setSelectedYear(e.target.value ? Number(e.target.value) : null)}
+        >
+          <option value="">All years</option>
+          {years.map((y) => (
+            <option key={y} value={y}>
+              {y}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="space-y-12">
+        {filtered.map((item) => (
+          <div key={item.id} className="grid md:grid-cols-2 gap-4">
+            <Image
+              src={item.image}
+              alt={item.title}
+              width={600}
+              height={400}
+              className="w-full h-auto border"
+            />
+            <MonacoEditor
+              height="400px"
+              defaultLanguage="typescript"
+              theme="vs-dark"
+              options={{ readOnly: true }}
+              value={item.code}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client/src/lib/gallery-data.ts
+++ b/client/src/lib/gallery-data.ts
@@ -1,0 +1,29 @@
+export interface GalleryItem {
+  id: string;
+  title: string;
+  image: string;
+  code: string;
+  stacks: string[];
+  year: number;
+}
+
+export const galleryData: GalleryItem[] = [
+  {
+    id: 'search-feature',
+    title: 'Search Feature',
+    image: '/landing-search1.png',
+    code: `function search(query: string) {
+  return fetch('/api/search?q=' + query);
+}`,
+    stacks: ['nextjs', 'typescript'],
+    year: 2024,
+  },
+  {
+    id: 'listing-card',
+    title: 'Listing Card',
+    image: '/landing-i1.png',
+    code: `export const ListingCard = () => <div>Listing</div>;`,
+    stacks: ['react', 'tailwind'],
+    year: 2023,
+  },
+];

--- a/client/tests/payments-api.test.ts
+++ b/client/tests/payments-api.test.ts
@@ -76,7 +76,7 @@ describe('payment mutations', () => {
     };
 
     const result = await store
-      .dispatch(api.endpoints.createPayment.initiate({ id: 1, ...body }))
+      .dispatch(api.endpoints.createPayment.initiate({ leaseId: 1, ...body }))
       .unwrap();
 
     const req = fetchMock.mock.calls[0][0] as any;
@@ -89,7 +89,7 @@ describe('payment mutations', () => {
       expect.objectContaining({
         success: 'Payment created successfully!',
         error: 'Failed to create payment.',
-      })
+      }),
     );
   });
 
@@ -135,7 +135,7 @@ describe('payment mutations', () => {
       expect.objectContaining({
         success: 'Payment updated successfully!',
         error: 'Failed to update payment.',
-      })
+      }),
     );
   });
 });


### PR DESCRIPTION
## Summary
- add gallery data including stack tags and build year metadata
- show gallery with Monaco-based code snippets and instant filters with persistence
- fix payment test to use leaseId param

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b11e495c848328a21e9c5aa6aceee1