### PR TITLE
feat: add HTML filter sandbox

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -36,6 +36,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
         "date-fns": "^4.1.0",
+        "diff": "^5.2.0",
         "dotenv": "^16.6.1",
         "filepond": "^4.32.8",
         "filepond-plugin-image-exif-orientation": "^1.0.11",
@@ -9523,10 +9524,10 @@
       "license": "Apache-2.0"
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "devOptional": true,
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -17087,6 +17088,16 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "devOptional": true
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",

--- a/client/package.json
+++ b/client/package.json
@@ -47,6 +47,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
     "date-fns": "^4.1.0",
+    "diff": "^5.2.0",
     "dotenv": "^16.6.1",
     "filepond": "^4.32.8",
     "filepond-plugin-image-exif-orientation": "^1.0.11",

--- a/client/src/app/html-filter/page.tsx
+++ b/client/src/app/html-filter/page.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useState } from 'react';
+import { diffLines } from 'diff';
+
+interface Rule {
+  pattern: string;
+  replacement: string;
+}
+
+export default function HtmlFilterPage() {
+  const [rulesText, setRulesText] = useState(
+    '[\n  {"pattern": "<script[^>]*>[\\s\\S]*?<\\/script>", "replacement": ""}\n]',
+  );
+  const [htmlText, setHtmlText] = useState('<div>Hello <script>alert("x")</script>World</div>');
+  const [diff, setDiff] = useState(diffLines(htmlText, htmlText));
+  const [error, setError] = useState<string | null>(null);
+
+  const applyRules = () => {
+    try {
+      const rules = JSON.parse(rulesText) as Rule[];
+      let rewritten = htmlText;
+      for (const rule of rules) {
+        const regex = new RegExp(rule.pattern, 'g');
+        rewritten = rewritten.replace(regex, rule.replacement);
+      }
+      setDiff(diffLines(htmlText, rewritten));
+      setError(null);
+    } catch (e: any) {
+      setError(e.message);
+      setDiff(diffLines(htmlText, htmlText));
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">HTML Filter Sandbox</h1>
+      <p className="text-sm text-gray-600">
+        Enter filter rules and sample HTML to preview how rewriting affects the markup.
+      </p>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="flex flex-col space-y-2">
+          <label className="font-medium">Filter Rules (JSON)</label>
+          <textarea
+            className="h-40 w-full rounded border p-2 font-mono"
+            value={rulesText}
+            onChange={(e) => setRulesText(e.target.value)}
+          />
+        </div>
+        <div className="flex flex-col space-y-2">
+          <label className="font-medium">Sample HTML</label>
+          <textarea
+            className="h-40 w-full rounded border p-2 font-mono"
+            value={htmlText}
+            onChange={(e) => setHtmlText(e.target.value)}
+          />
+        </div>
+      </div>
+      <button onClick={applyRules} className="rounded bg-blue-600 px-4 py-2 text-white">
+        Apply Rules
+      </button>
+      {error && <p className="text-red-600">{error}</p>}
+      <pre className="whitespace-pre-wrap rounded border p-2 font-mono text-sm">
+        {diff.map((part, idx) => (
+          <span
+            key={idx}
+            className={part.added ? 'bg-green-200' : part.removed ? 'bg-red-200' : ''}
+          >
+            {part.value}
+          </span>
+        ))}
+      </pre>
+      <section className="space-y-2">
+        <h2 className="text-xl font-semibold">Risks and Mitigations</h2>
+        <p className="text-sm text-gray-600">
+          Rewriting HTML can inadvertently remove required attributes or expose the application to
+          cross‑site scripting (XSS) if filters are misconfigured. Validate rule syntax, test
+          changes thoroughly, and sanitize output before rendering it to users.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/client/tests/payments-api.test.ts
+++ b/client/tests/payments-api.test.ts
@@ -76,7 +76,7 @@ describe('payment mutations', () => {
     };
 
     const result = await store
-      .dispatch(api.endpoints.createPayment.initiate({ id: 1, ...body }))
+      .dispatch(api.endpoints.createPayment.initiate({ leaseId: 1, ...body }))
       .unwrap();
 
     const req = fetchMock.mock.calls[0][0] as any;
@@ -89,7 +89,7 @@ describe('payment mutations', () => {
       expect.objectContaining({
         success: 'Payment created successfully!',
         error: 'Failed to create payment.',
-      })
+      }),
     );
   });
 
@@ -135,7 +135,7 @@ describe('payment mutations', () => {
       expect.objectContaining({
         success: 'Payment updated successfully!',
         error: 'Failed to update payment.',
-      })
+      }),
     );
   });
 });


### PR DESCRIPTION
## Summary
- add sandbox page to test HTML filter rules and show diffs
- document risks and mitigations on the page
- fix payments API test to pass leaseId

## Testing
- `cd client && npm test --silent >/tmp/test.log 2>&1 && tail -n 5 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68b11e25aa4c8328b5af3c380423b819