### PR TITLE
feat: cache bluetooth profiles in OPFS

### DIFF
--- a/client/src/app/devices/page.tsx
+++ b/client/src/app/devices/page.tsx
@@ -1,0 +1,9 @@
+import SavedDevicesManager from '../../components/saved-devices-manager';
+
+export default function DevicesPage() {
+  return (
+    <main className="p-4">
+      <SavedDevicesManager />
+    </main>
+  );
+}

--- a/client/src/components/navbar.tsx
+++ b/client/src/components/navbar.tsx
@@ -101,6 +101,12 @@ const Navbar = () => {
         )}
         <div className="flex items-center gap-5">
           <ThemeToggle />
+          <Link
+            href="/devices"
+            className="text-primary-200 hover:text-primary-400 hidden md:block"
+          >
+            Devices
+          </Link>
           {authUser ? (
             <>
               <div className="relative hidden md:block">

--- a/client/src/components/saved-devices-manager.tsx
+++ b/client/src/components/saved-devices-manager.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { DeviceProfile, listDeviceProfiles, removeDeviceProfile } from '../lib/bluetooth-storage';
+
+export default function SavedDevicesManager() {
+  const [devices, setDevices] = useState<DeviceProfile[]>([]);
+
+  const refresh = async () => {
+    const list = await listDeviceProfiles();
+    setDevices(list);
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const handleRemove = async (id: string) => {
+    await removeDeviceProfile(id);
+    await refresh();
+  };
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">Saved Devices</h2>
+      {devices.length === 0 && <p>No saved devices.</p>}
+      <ul className="space-y-2">
+        {devices.map((d) => (
+          <li key={d.id} className="flex items-center justify-between rounded border p-2">
+            <span>{d.name || d.id}</span>
+            <button
+              onClick={() => handleRemove(d.id)}
+              className="text-sm text-red-600 hover:underline"
+            >
+              Remove
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/client/src/lib/bluetooth-storage.ts
+++ b/client/src/lib/bluetooth-storage.ts
@@ -1,0 +1,65 @@
+export interface DeviceProfile {
+  id: string;
+  name?: string;
+  services: { uuid: string; characteristics: string[] }[];
+}
+
+const ROOT_DIR = 'bluetooth-profiles';
+
+async function getRootDir() {
+  const storage: any = navigator.storage;
+  if (!storage?.getDirectory) {
+    throw new Error('OPFS is not supported in this browser');
+  }
+  return storage.getDirectory();
+}
+
+export async function saveDeviceProfile(profile: DeviceProfile) {
+  const root = await getRootDir();
+  const dir = await root.getDirectoryHandle(ROOT_DIR, { create: true });
+  const file = await dir.getFileHandle(`${profile.id}.json`, { create: true });
+  const writable = await file.createWritable();
+  await writable.write(JSON.stringify(profile));
+  await writable.close();
+}
+
+export async function loadDeviceProfile(id: string): Promise<DeviceProfile | null> {
+  try {
+    const root = await getRootDir();
+    const dir = await root.getDirectoryHandle(ROOT_DIR);
+    const file = await dir.getFileHandle(`${id}.json`);
+    const blob = await file.getFile();
+    const text = await blob.text();
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+export async function removeDeviceProfile(id: string) {
+  try {
+    const root = await getRootDir();
+    const dir = await root.getDirectoryHandle(ROOT_DIR);
+    await dir.removeEntry(`${id}.json`);
+  } catch {
+    // ignore
+  }
+}
+
+export async function listDeviceProfiles(): Promise<DeviceProfile[]> {
+  const profiles: DeviceProfile[] = [];
+  try {
+    const root = await getRootDir();
+    const dir = await root.getDirectoryHandle(ROOT_DIR);
+    for await (const [name, handle] of (dir as any).entries()) {
+      if (handle.kind === 'file' && name.endsWith('.json')) {
+        const file = await handle.getFile();
+        const text = await file.text();
+        profiles.push(JSON.parse(text));
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return profiles;
+}

--- a/client/src/lib/bluetooth.ts
+++ b/client/src/lib/bluetooth.ts
@@ -1,0 +1,39 @@
+import { DeviceProfile, loadDeviceProfile, saveDeviceProfile } from './bluetooth-storage';
+
+export interface ConnectedDevice {
+  device: BluetoothDevice;
+  server: BluetoothRemoteGATTServer;
+  profile: DeviceProfile;
+}
+
+export async function connectToDevice(): Promise<ConnectedDevice> {
+  const device = await navigator.bluetooth.requestDevice({
+    acceptAllDevices: true,
+  });
+  const server = await device.gatt!.connect();
+
+  let profile = await loadDeviceProfile(device.id);
+  if (!profile) {
+    const services = await server.getPrimaryServices();
+    const profileServices = [] as DeviceProfile['services'];
+    for (const service of services) {
+      const chars = await service.getCharacteristics();
+      profileServices.push({
+        uuid: service.uuid,
+        characteristics: chars.map((c) => c.uuid),
+      });
+    }
+    profile = { id: device.id, name: device.name || undefined, services: profileServices };
+    await saveDeviceProfile(profile);
+  } else {
+    // Skip rediscovery by directly accessing known services/characteristics
+    for (const svc of profile.services) {
+      const service = await server.getPrimaryService(svc.uuid);
+      for (const charUUID of svc.characteristics) {
+        await service.getCharacteristic(charUUID);
+      }
+    }
+  }
+
+  return { device, server, profile };
+}


### PR DESCRIPTION
## Summary
- cache discovered bluetooth services and characteristics per device in OPFS
- reuse saved profiles on reconnect to skip rediscovery
- add UI and navigation to manage saved devices

## Testing
- `npm test` *(fails: Expected "http://localhost:3001/leases/1/payments" to be "http://localhost:3001/leases/undefined/payments")*

------
https://chatgpt.com/codex/tasks/task_e_68b11e2f2b848328a5afc0db54d880b4