### PR TITLE
feat(calc): add multi-base calculator with tape history

### DIFF
--- a/apps/calc/logic.ts
+++ b/apps/calc/logic.ts
@@ -1,0 +1,70 @@
+export type Mode = "dec" | "bin" | "hex";
+export type Operation = "+" | "-" | "*" | "/" | "AND" | "OR" | "XOR" | "NOT";
+
+const parse = (value: string, mode: Mode): number => {
+  switch (mode) {
+    case "bin":
+      return parseInt(value, 2);
+    case "hex":
+      return parseInt(value, 16);
+    default:
+      return parseInt(value, 10);
+  }
+};
+
+const format = (value: number, mode: Mode): string => {
+  switch (mode) {
+    case "bin":
+      return (value >>> 0).toString(2);
+    case "hex":
+      return (value >>> 0).toString(16).toUpperCase();
+    default:
+      return value.toString(10);
+  }
+};
+
+export const calculate = (
+  aStr: string,
+  bStr: string | null,
+  op: Operation,
+  mode: Mode
+): string => {
+  const a = parse(aStr, mode);
+  const b = bStr !== null ? parse(bStr, mode) : null;
+  let result: number;
+
+  switch (op) {
+    case "+":
+      result = a + (b ?? 0);
+      break;
+    case "-":
+      result = a - (b ?? 0);
+      break;
+    case "*":
+      result = a * (b ?? 0);
+      break;
+    case "/":
+      result = b === 0 || b === null ? NaN : a / b;
+      break;
+    case "AND":
+      result = a & (b ?? 0);
+      break;
+    case "OR":
+      result = a | (b ?? 0);
+      break;
+    case "XOR":
+      result = a ^ (b ?? 0);
+      break;
+    case "NOT":
+      result = ~a;
+      break;
+    default:
+      throw new Error(`Unsupported operation ${op}`);
+  }
+
+  if (!isFinite(result)) {
+    return "NaN";
+  }
+
+  return format(result, mode);
+};

--- a/client/src/app/calc/page.tsx
+++ b/client/src/app/calc/page.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState } from "react";
+import { calculate, Mode, Operation } from "../../../../apps/calc/logic";
+
+interface TapeEntry {
+  expression: string;
+  result: string;
+  mode: Mode;
+}
+
+const CalcPage = () => {
+  const [mode, setMode] = useState<Mode>("dec");
+  const [op, setOp] = useState<Operation>("+");
+  const [a, setA] = useState("");
+  const [b, setB] = useState("");
+  const [result, setResult] = useState("");
+  const [tape, setTape] = useState<TapeEntry[]>([]);
+  const [search, setSearch] = useState("");
+
+  const handleCalculate = () => {
+    const res = calculate(a, op === "NOT" ? null : b, op, mode);
+    setResult(res);
+    const expression = op === "NOT" ? `${op} ${a}` : `${a} ${op} ${b}`;
+    setTape([...tape, { expression, result: res, mode }]);
+  };
+
+  const filteredTape = tape.filter(
+    (t) =>
+      t.expression.toLowerCase().includes(search.toLowerCase()) ||
+      t.result.toLowerCase().includes(search.toLowerCase())
+  );
+
+  const downloadTape = () => {
+    const content = tape
+      .map((t) => `${t.expression} = ${t.result}`)
+      .join("\n");
+    const blob = new Blob([content], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "tape.txt";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex items-center gap-2">
+        <label htmlFor="mode">Mode:</label>
+        <select
+          id="mode"
+          className="border p-1"
+          value={mode}
+          onChange={(e) => setMode(e.target.value as Mode)}
+        >
+          <option value="dec">DEC</option>
+          <option value="bin">BIN</option>
+          <option value="hex">HEX</option>
+        </select>
+      </div>
+      <div className="flex items-center gap-2">
+        <input
+          className="border p-1 w-24"
+          value={a}
+          onChange={(e) => setA(e.target.value)}
+        />
+        {op !== "NOT" && (
+          <input
+            className="border p-1 w-24"
+            value={b}
+            onChange={(e) => setB(e.target.value)}
+          />
+        )}
+        <select
+          className="border p-1"
+          value={op}
+          onChange={(e) => setOp(e.target.value as Operation)}
+        >
+          <option value="+">+</option>
+          <option value="-">-</option>
+          <option value="*">*</option>
+          <option value="/">/</option>
+          <option value="AND">AND</option>
+          <option value="OR">OR</option>
+          <option value="XOR">XOR</option>
+          <option value="NOT">NOT</option>
+        </select>
+        <button
+          className="bg-blue-500 text-white px-3 py-1"
+          onClick={handleCalculate}
+        >
+          =
+        </button>
+        <span className="ml-2">{result}</span>
+      </div>
+      <div>
+        <div className="flex items-center gap-2 mb-2">
+          <input
+            className="border p-1 flex-1"
+            placeholder="Search tape"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <button
+            className="bg-green-500 text-white px-3 py-1"
+            onClick={downloadTape}
+          >
+            Download
+          </button>
+        </div>
+        <div className="border p-2 max-h-64 overflow-auto">
+          {filteredTape.map((t, i) => (
+            <div key={i}>{`${t.expression} = ${t.result}`}</div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CalcPage;

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -28,7 +28,8 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    "../shared/**/*.ts"
+    "../shared/**/*.ts",
+    "../apps/**/*.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary
- add calculator logic supporting decimal, binary, and hex plus bitwise ops
- add calc page with mode toggle and operation tape with search/download
- include shared logic in client tsconfig

## Testing
- `npm test` *(fails: payment mutations › creates a payment via POST)*

------
https://chatgpt.com/codex/tasks/task_e_68b11dcb59b483288a02561ba8c238fa