### PR TITLE
feat: add chrome tab UI with session persistence

### DIFF
--- a/apps.config.ts
+++ b/apps.config.ts
@@ -1,0 +1,9 @@
+export interface AppProfile {
+  id: string;
+  name: string;
+}
+
+export const profiles: AppProfile[] = [
+  { id: "default", name: "Default" },
+  { id: "work", name: "Work" },
+];

--- a/apps/chrome/TabStrip.tsx
+++ b/apps/chrome/TabStrip.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import React, { useState } from "react";
+
+export interface Tab {
+  id: string;
+  title: string;
+  url: string;
+  sandbox?: string;
+}
+
+interface TabStripProps {
+  tabs: Tab[];
+  activeTabId: string | null;
+  onSelect: (id: string) => void;
+  onClose: (id: string) => void;
+  onAdd: (tab: Tab) => void;
+}
+
+const DEFAULT_SANDBOX = "allow-scripts allow-same-origin";
+
+const TabStrip: React.FC<TabStripProps> = ({
+  tabs,
+  activeTabId,
+  onSelect,
+  onClose,
+  onAdd,
+}) => {
+  const [url, setUrl] = useState("");
+  const [sandbox, setSandbox] = useState(DEFAULT_SANDBOX);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!url) return;
+    const newTab: Tab = {
+      id: crypto.randomUUID(),
+      title: url,
+      url,
+      sandbox,
+    };
+    onAdd(newTab);
+    setUrl("");
+  };
+
+  return (
+    <div className="flex flex-col h-full w-full">
+      <div className="flex items-center gap-2 bg-gray-200 p-2 overflow-x-auto">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => onSelect(tab.id)}
+            className={`px-2 py-1 text-sm rounded-md whitespace-nowrap ${tab.id === activeTabId ? "bg-white" : "bg-gray-300"}`}
+          >
+            {tab.title}
+            <span
+              className="ml-2 cursor-pointer"
+              onClick={(e) => {
+                e.stopPropagation();
+                onClose(tab.id);
+              }}
+            >
+              ×
+            </span>
+          </button>
+        ))}
+        <form onSubmit={handleSubmit} className="flex items-center gap-1">
+          <input
+            type="text"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://example.com"
+            className="border px-1 py-0.5 text-sm rounded"
+          />
+          <input
+            type="text"
+            value={sandbox}
+            onChange={(e) => setSandbox(e.target.value)}
+            placeholder="sandbox flags"
+            className="border px-1 py-0.5 text-sm rounded"
+          />
+          <button
+            type="submit"
+            className="px-2 py-1 bg-blue-500 text-white text-sm rounded"
+          >
+            +
+          </button>
+        </form>
+      </div>
+      <div className="flex-1 relative">
+        {tabs.map((tab) => (
+          <iframe
+            key={tab.id}
+            src={tab.url}
+            sandbox={tab.sandbox}
+            style={{
+              display: tab.id === activeTabId ? "block" : "none",
+              width: "100%",
+              height: "100%",
+              border: "none",
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default TabStrip;

--- a/apps/chrome/index.tsx
+++ b/apps/chrome/index.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import TabStrip, { Tab } from "./TabStrip";
+import { profiles } from "../../apps.config";
+
+const SESSION_FILE = "tabs.json";
+
+async function getProfileDirectory(profile: string) {
+  const root = await (navigator as any).storage.getDirectory();
+  const profilesDir = await root.getDirectoryHandle("profiles", { create: true });
+  return profilesDir.getDirectoryHandle(profile, { create: true });
+}
+
+async function loadTabs(profile: string): Promise<Tab[]> {
+  try {
+    const dir = await getProfileDirectory(profile);
+    const fileHandle = await dir.getFileHandle(SESSION_FILE);
+    const file = await fileHandle.getFile();
+    const text = await file.text();
+    return JSON.parse(text);
+  } catch {
+    return [];
+  }
+}
+
+async function saveTabs(profile: string, tabs: Tab[]): Promise<void> {
+  const dir = await getProfileDirectory(profile);
+  const handle = await dir.getFileHandle(SESSION_FILE, { create: true });
+  const writable = await handle.createWritable();
+  await writable.write(JSON.stringify(tabs));
+  await writable.close();
+}
+
+const ChromeApp: React.FC = () => {
+  const [tabs, setTabs] = useState<Tab[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [profile, setProfile] = useState<string>(profiles[0]?.id ?? "default");
+
+  useEffect(() => {
+    loadTabs(profile).then((restored) => {
+      setTabs(restored);
+      setActiveId(restored[0]?.id ?? null);
+    });
+  }, [profile]);
+
+  useEffect(() => {
+    saveTabs(profile, tabs);
+  }, [tabs, profile]);
+
+  const handleAdd = (tab: Tab) => {
+    setTabs((prev) => [...prev, tab]);
+    setActiveId(tab.id);
+  };
+
+  const handleClose = (id: string) => {
+    setTabs((prev) => prev.filter((t) => t.id !== id));
+    if (activeId === id) {
+      const index = tabs.findIndex((t) => t.id === id);
+      const next = tabs[index + 1] || tabs[index - 1];
+      setActiveId(next ? next.id : null);
+    }
+  };
+
+  return (
+    <div className="h-screen flex flex-col">
+      <div className="p-2 bg-gray-100 flex items-center gap-2">
+        <label htmlFor="profile">Profile:</label>
+        <select
+          id="profile"
+          value={profile}
+          onChange={(e) => setProfile(e.target.value)}
+          className="border px-2 py-1 rounded"
+        >
+          {profiles.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <TabStrip
+        tabs={tabs}
+        activeTabId={activeId}
+        onSelect={setActiveId}
+        onClose={handleClose}
+        onAdd={handleAdd}
+      />
+    </div>
+  );
+};
+
+export default ChromeApp;


### PR DESCRIPTION
## Summary
- add TabStrip component supporting per-tab sandboxing
- persist tab sessions in OPFS and restore on load
- introduce profile configuration for session separation

## Testing
- `npm test` *(fails: Expected URL http://localhost:3001/leases/1/payments, got http://localhost:3001/leases/undefined/payments)*
- `npm run lint` *(fails: Code style issues found in 101 files)*

------
https://chatgpt.com/codex/tasks/task_e_68b11db531888328a654b08a8dcf54a8