### PR TITLE
feat: add OPFS utilities

### DIFF
--- a/client/src/hooks/use-opfs.ts
+++ b/client/src/hooks/use-opfs.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useState } from "react";
+import { deleteFile, getRoot, readFile, writeFile } from "../services/opfs";
+
+export function useOPFS() {
+  const [root, setRoot] = useState<FileSystemDirectoryHandle | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    if (typeof navigator === "undefined" || !navigator.storage) return;
+    getRoot()
+      .then((dir) => {
+        if (mounted) setRoot(dir);
+      })
+      .catch(() => {
+        /* ignore */
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const read = useCallback(
+    (path: string) => {
+      if (!root) throw new Error("OPFS not ready");
+      return readFile(root, path);
+    },
+    [root]
+  );
+
+  const write = useCallback(
+    (path: string, data: Blob | string) => {
+      if (!root) throw new Error("OPFS not ready");
+      return writeFile(root, path, data);
+    },
+    [root]
+  );
+
+  const remove = useCallback(
+    (path: string) => {
+      if (!root) throw new Error("OPFS not ready");
+      return deleteFile(root, path);
+    },
+    [root]
+  );
+
+  return { root, read, write, remove };
+}

--- a/client/src/services/opfs.ts
+++ b/client/src/services/opfs.ts
@@ -1,0 +1,55 @@
+/*
+ * Basic file operations using the Origin Private File System (OPFS).
+ */
+
+// getDirectory is not yet in TypeScript lib definitions
+// so we cast to any to access it at runtime.
+export async function getRoot(): Promise<FileSystemDirectoryHandle> {
+  return await (navigator.storage as any).getDirectory();
+}
+
+async function getFileHandle(
+  root: FileSystemDirectoryHandle,
+  path: string,
+  create = false
+): Promise<FileSystemFileHandle> {
+  const parts = path.split("/").filter(Boolean);
+  let dir = root;
+  for (let i = 0; i < parts.length - 1; i++) {
+    dir = await dir.getDirectoryHandle(parts[i], { create });
+  }
+  const fileName = parts[parts.length - 1];
+  return await dir.getFileHandle(fileName, { create });
+}
+
+export async function readFile(
+  root: FileSystemDirectoryHandle,
+  path: string
+): Promise<string> {
+  const handle = await getFileHandle(root, path);
+  const file = await handle.getFile();
+  return await file.text();
+}
+
+export async function writeFile(
+  root: FileSystemDirectoryHandle,
+  path: string,
+  data: Blob | string
+): Promise<void> {
+  const handle = await getFileHandle(root, path, true);
+  const writable = await handle.createWritable();
+  await writable.write(data);
+  await writable.close();
+}
+
+export async function deleteFile(
+  root: FileSystemDirectoryHandle,
+  path: string
+): Promise<void> {
+  const parts = path.split("/").filter(Boolean);
+  let dir = root;
+  for (let i = 0; i < parts.length - 1; i++) {
+    dir = await dir.getDirectoryHandle(parts[i]);
+  }
+  await dir.removeEntry(parts[parts.length - 1]);
+}

--- a/client/tests/payments-api.test.ts
+++ b/client/tests/payments-api.test.ts
@@ -76,7 +76,7 @@ describe('payment mutations', () => {
     };
 
     const result = await store
-      .dispatch(api.endpoints.createPayment.initiate({ id: 1, ...body }))
+      .dispatch(api.endpoints.createPayment.initiate({ leaseId: 1, ...body }))
       .unwrap();
 
     const req = fetchMock.mock.calls[0][0] as any;


### PR DESCRIPTION
## Summary
- add OPFS service for async file access
- add useOPFS hook to provide read/write/remove helpers
- fix payment API test parameter

## Testing
- `cd client && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b11da2f64c8328a2ca35fc6a3f0e22