### PR TITLE
feat: add document PiP pin control

### DIFF
--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import Providers from "./providers";
 import { Toaster } from "@/components/ui/sonner";
 import ErrorBoundary from "@/components/error-boundary";
+import WindowHeader from "@/components/window/Header";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -55,6 +56,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <ErrorBoundary>
+          <WindowHeader />
           <Providers>{children}</Providers>
           <Toaster closeButton />
         </ErrorBoundary>

--- a/client/src/components/window/Header.tsx
+++ b/client/src/components/window/Header.tsx
@@ -1,0 +1,21 @@
+import { Pin } from "lucide-react";
+import { useDocumentPiP } from "@/hooks/use-document-pip";
+import React from "react";
+
+const WindowHeader = () => {
+  const { togglePiP } = useDocumentPiP();
+
+  return (
+    <div className="flex justify-end p-2 border-b bg-white">
+      <button
+        aria-label="Pin window"
+        onClick={togglePiP}
+        className="p-1 rounded hover:bg-gray-100"
+      >
+        <Pin className="h-4 w-4" />
+      </button>
+    </div>
+  );
+};
+
+export default WindowHeader;

--- a/client/src/hooks/use-document-pip.ts
+++ b/client/src/hooks/use-document-pip.ts
@@ -1,0 +1,69 @@
+import { useCallback, useRef, useEffect } from "react";
+
+export function useDocumentPiP() {
+  const pipWindowRef = useRef<Window | null>(null);
+  const appRootRef = useRef<HTMLElement | null>(null);
+
+  const openPiP = useCallback(async () => {
+    if (pipWindowRef.current) {
+      pipWindowRef.current.focus();
+      return;
+    }
+
+    const api = (window as any).documentPictureInPicture;
+    if (!api || typeof api.requestWindow !== "function") {
+      return;
+    }
+
+    const pipWindow: Window = await api.requestWindow();
+    pipWindowRef.current = pipWindow;
+
+    appRootRef.current = document.getElementById("__next");
+    if (appRootRef.current) {
+      pipWindow.document.body.append(appRootRef.current);
+    }
+
+    const handleClose = () => {
+      if (appRootRef.current) {
+        document.body.append(appRootRef.current);
+      }
+      pipWindow.removeEventListener("pagehide", handleClose);
+      pipWindow.removeEventListener("focus", handleFocus);
+      pipWindowRef.current = null;
+    };
+
+    const handleFocus = () => {
+      window.focus();
+    };
+
+    pipWindow.addEventListener("pagehide", handleClose);
+    pipWindow.addEventListener("focus", handleFocus);
+  }, []);
+
+  const closePiP = useCallback(() => {
+    pipWindowRef.current?.close();
+  }, []);
+
+  const togglePiP = useCallback(() => {
+    if (pipWindowRef.current) {
+      closePiP();
+    } else {
+      openPiP();
+    }
+  }, [openPiP, closePiP]);
+
+  useEffect(() => {
+    return () => {
+      if (pipWindowRef.current) {
+        pipWindowRef.current.close();
+      }
+      if (appRootRef.current) {
+        document.body.append(appRootRef.current);
+      }
+    };
+  }, []);
+
+  return { pipWindow: pipWindowRef.current, openPiP, closePiP, togglePiP };
+}
+
+export default useDocumentPiP;


### PR DESCRIPTION
## Summary
- add `useDocumentPiP` hook to open Document Picture-in-Picture and sync events
- add window `Header` component with Pin control
- mount window header in global layout

## Testing
- `npm test` *(fails: payment mutations › creates a payment via POST)*

------
https://chatgpt.com/codex/tasks/task_e_68b11d9edc808328b9a92894e657dd6d