### PR TITLE
feat: add document PiP hook and pin control

### DIFF
--- a/client/src/components/window/Header.tsx
+++ b/client/src/components/window/Header.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import React from "react";
+import { Pin } from "lucide-react";
+import useDocumentPiP from "@/hooks/use-document-pip";
+
+const Header = () => {
+  const { open } = useDocumentPiP();
+
+  return (
+    <div className="flex items-center justify-end border-b p-2">
+      <button
+        type="button"
+        onClick={open}
+        aria-label="Pin window"
+        className="rounded p-1 hover:bg-muted"
+      >
+        <Pin className="h-4 w-4" />
+      </button>
+    </div>
+  );
+};
+
+export default Header;

--- a/client/src/hooks/use-document-pip.ts
+++ b/client/src/hooks/use-document-pip.ts
@@ -1,0 +1,37 @@
+import { useCallback, useState } from "react";
+
+/**
+ * Hook to open the current document in a Picture-in-Picture window.
+ * Moves the app's body content into the PiP window and returns it when closed.
+ * Also syncs focus events between the PiP window and the main window.
+ */
+export function useDocumentPiP() {
+  const [pipWindow, setPipWindow] = useState<Window | null>(null);
+
+  const open = useCallback(async () => {
+    if (pipWindow || typeof window === "undefined") return;
+    // Document Picture-in-Picture is experimental and not typed in TS yet.
+    const dpip = (window as any).documentPictureInPicture;
+    if (!dpip?.requestWindow) return;
+
+    const pip = await dpip.requestWindow();
+    const elements = Array.from(document.body.children);
+    elements.forEach((el) => pip.document.body.appendChild(el));
+
+    pip.addEventListener(
+      "pagehide",
+      () => {
+        elements.forEach((el) => document.body.appendChild(el));
+        setPipWindow(null);
+      },
+      { once: true }
+    );
+
+    pip.addEventListener("focus", () => window.focus());
+    setPipWindow(pip);
+  }, [pipWindow]);
+
+  return { pipWindow, open };
+}
+
+export default useDocumentPiP;


### PR DESCRIPTION
## Summary
- add `useDocumentPiP` hook to open Document Picture-in-Picture windows and sync focus/close
- add `Pin` control in window header to trigger Document PiP

## Testing
- `npm test` *(fails: Expected 'http://localhost:3001/leases/1/payments', Received 'http://localhost:3001/leases/undefined/payments')*
- `npm run lint` *(fails: Code style issues found in 103 files)*

------
https://chatgpt.com/codex/tasks/task_e_68b11da1c6c883288133f9cdea9cb4ca