### PR TITLE
feat: add gamepad input and hook

### DIFF
--- a/client/src/hooks/use-gamepad.ts
+++ b/client/src/hooks/use-gamepad.ts
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { GamepadInput, GamepadProfile, DEFAULT_PROFILE } from '../input/gamepad';
+
+const STORAGE_KEY = (gameId: string) => `gamepad.profile.${gameId}`;
+
+export function useGamepad(gameId: string, initialProfile: GamepadProfile = DEFAULT_PROFILE) {
+  const [profile, setProfile] = useState<GamepadProfile>(initialProfile);
+  const gpRef = useRef<GamepadInput>();
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem(STORAGE_KEY(gameId));
+    if (stored) {
+      try {
+        setProfile(JSON.parse(stored));
+      } catch {
+        /* ignore */
+      }
+    }
+  }, [gameId]);
+
+  useEffect(() => {
+    const gp = new GamepadInput(profile);
+    gp.start();
+    gpRef.current = gp;
+    return () => gp.stop();
+  }, [profile]);
+
+  const remap = useCallback(
+    (newProfile: GamepadProfile) => {
+      setProfile(newProfile);
+      window.localStorage.setItem(STORAGE_KEY(gameId), JSON.stringify(newProfile));
+      gpRef.current?.remap(newProfile);
+    },
+    [gameId],
+  );
+
+  const on = useCallback((action: string, handler: EventListener) => {
+    gpRef.current?.on(action, handler);
+  }, []);
+
+  const off = useCallback((action: string, handler: EventListener) => {
+    gpRef.current?.off(action, handler);
+  }, []);
+
+  return { on, off, remap, profile };
+}

--- a/client/src/input/gamepad.ts
+++ b/client/src/input/gamepad.ts
@@ -1,0 +1,84 @@
+export type GamepadProfile = Record<number, string>;
+
+export const DEFAULT_PROFILE: GamepadProfile = {
+  0: 'buttonA',
+  1: 'buttonB',
+  2: 'buttonX',
+  3: 'buttonY',
+  4: 'bumperLeft',
+  5: 'bumperRight',
+  6: 'triggerLeft',
+  7: 'triggerRight',
+  8: 'select',
+  9: 'start',
+  10: 'stickLeft',
+  11: 'stickRight',
+  12: 'dpadUp',
+  13: 'dpadDown',
+  14: 'dpadLeft',
+  15: 'dpadRight',
+  16: 'home',
+};
+
+export class GamepadInput {
+  private emitter = new EventTarget();
+  private profile: GamepadProfile;
+  private prevButtons: Record<number, boolean> = {};
+  private rafId?: number;
+
+  constructor(profile: GamepadProfile = DEFAULT_PROFILE) {
+    this.profile = profile;
+  }
+
+  start() {
+    const loop = () => {
+      const pads = navigator.getGamepads();
+      for (const pad of pads) {
+        if (!pad) continue;
+        pad.buttons.forEach((btn, idx) => {
+          const pressed = btn.pressed;
+          const prev = this.prevButtons[idx];
+          if (pressed && !prev) {
+            const action = this.profile[idx];
+            if (action) {
+              this.emitter.dispatchEvent(new Event(action));
+              if (pad.vibrationActuator) {
+                void pad.vibrationActuator.playEffect('dual-rumble', {
+                  duration: 50,
+                  strongMagnitude: 1.0,
+                  weakMagnitude: 1.0,
+                });
+              }
+            }
+          }
+          this.prevButtons[idx] = pressed;
+        });
+      }
+      this.rafId = window.requestAnimationFrame(loop);
+    };
+    this.rafId = window.requestAnimationFrame(loop);
+  }
+
+  stop() {
+    if (this.rafId !== undefined) {
+      cancelAnimationFrame(this.rafId);
+      this.rafId = undefined;
+    }
+  }
+
+  on(action: string, handler: EventListener) {
+    this.emitter.addEventListener(action, handler);
+  }
+
+  off(action: string, handler: EventListener) {
+    this.emitter.removeEventListener(action, handler);
+  }
+
+  remap(profile: GamepadProfile) {
+    this.profile = profile;
+  }
+
+  getProfile() {
+    return this.profile;
+  }
+}

--- a/docs/gamepad.md
+++ b/docs/gamepad.md
@@ -1,0 +1,29 @@
+# Gamepad Mapping
+
+The client exposes basic support for the browser [Gamepad API](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad_API). Buttons are translated into named events and a short rumble is triggered when a mapped button is pressed.
+
+## Default Button Mapping
+
+| Index | Button            | Event name     |
+| ----- | ----------------- | -------------- |
+| 0     | A / Cross         | `buttonA`      |
+| 1     | B / Circle        | `buttonB`      |
+| 2     | X / Square        | `buttonX`      |
+| 3     | Y / Triangle      | `buttonY`      |
+| 4     | Left bumper       | `bumperLeft`   |
+| 5     | Right bumper      | `bumperRight`  |
+| 6     | Left trigger      | `triggerLeft`  |
+| 7     | Right trigger     | `triggerRight` |
+| 8     | Select / Back     | `select`       |
+| 9     | Start             | `start`        |
+| 10    | Left stick press  | `stickLeft`    |
+| 11    | Right stick press | `stickRight`   |
+| 12    | D-pad up          | `dpadUp`       |
+| 13    | D-pad down        | `dpadDown`     |
+| 14    | D-pad left        | `dpadLeft`     |
+| 15    | D-pad right       | `dpadRight`    |
+| 16    | Home / Guide      | `home`         |
+
+## Remapping
+
+Use the `useGamepad(gameId)` hook to listen for actions and remap button indices per game. Profiles are stored in `localStorage` under `gamepad.profile.<gameId>`.


### PR DESCRIPTION
## Summary
- map browser Gamepad API button presses to named events and rumble
- provide `useGamepad` hook with per-game profile remapping stored in localStorage
- document default controller button mapping

## Testing
- `npm test` (fails: Expected "http://localhost:3001/leases/1/payments" Received "http://localhost:3001/leases/undefined/payments")
- `npm run lint` (fails: Code style issues found in 102 files. Run Prettier with --write to fix.)

------
https://chatgpt.com/codex/tasks/task_e_68b11da475188328aa2ab89ea6ae19f2