### PR TITLE
Add web worker code utilities and sandbox demo

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -20,6 +20,10 @@ You can start editing the page by modifying `src/app/page.tsx`. The page auto-up
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Web Worker Demo
+
+Navigate to `/web-worker-demo` to try the sample project that formats code with Prettier, lints with ESLint and executes JavaScript inside a sandboxed web worker. Console output appears in the output panel.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/client/src/app/web-worker-demo/page.tsx
+++ b/client/src/app/web-worker-demo/page.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+export default function WebWorkerDemo() {
+  const [code, setCode] = useState(
+    "function hello(name) {\n  console.log('Hello, ' + name);\n}\nhello('sandbox');"
+  );
+  const [logs, setLogs] = useState<string[]>([]);
+
+  const prettierWorker = useRef<Worker>();
+  const eslintWorker = useRef<Worker>();
+  const runnerWorker = useRef<Worker>();
+
+  useEffect(() => {
+    prettierWorker.current = new Worker(new URL('../../workers/prettierWorker.ts', import.meta.url));
+    eslintWorker.current = new Worker(new URL('../../workers/eslintWorker.ts', import.meta.url));
+    runnerWorker.current = new Worker(new URL('../../workers/runnerWorker.ts', import.meta.url));
+
+    prettierWorker.current.onmessage = (e) => {
+      if (e.data.formatted) setCode(e.data.formatted);
+      if (e.data.error) setLogs((l) => [...l, `prettier: ${e.data.error}`]);
+    };
+
+    eslintWorker.current.onmessage = (e) => {
+      if (e.data.messages) {
+        setLogs((l) => [
+          ...l,
+          ...e.data.messages.map((m: any) => `eslint: ${m.message}`),
+        ]);
+      }
+      if (e.data.error) setLogs((l) => [...l, `eslint: ${e.data.error}`]);
+    };
+
+    runnerWorker.current.onmessage = (e) => {
+      if (e.data.type === 'log') setLogs((l) => [...l, e.data.message]);
+      if (e.data.type === 'error') setLogs((l) => [...l, `error: ${e.data.error}`]);
+    };
+
+    return () => {
+      prettierWorker.current?.terminate();
+      eslintWorker.current?.terminate();
+      runnerWorker.current?.terminate();
+    };
+  }, []);
+
+  const runPrettier = () => prettierWorker.current?.postMessage({ code });
+  const runESLint = () => {
+    setLogs([]);
+    eslintWorker.current?.postMessage({ code });
+  };
+  const runCode = () => {
+    setLogs([]);
+    runnerWorker.current?.postMessage({ code });
+  };
+
+  return (
+    <div className="p-4 space-y-2">
+      <textarea
+        value={code}
+        onChange={(e) => setCode(e.target.value)}
+        className="w-full h-48 border p-2 font-mono"
+      />
+      <div className="space-x-2">
+        <button className="px-2 py-1 bg-blue-500 text-white" onClick={runPrettier}>
+          Prettier
+        </button>
+        <button className="px-2 py-1 bg-green-600 text-white" onClick={runESLint}>
+          ESLint
+        </button>
+        <button className="px-2 py-1 bg-purple-600 text-white" onClick={runCode}>
+          Run
+        </button>
+      </div>
+      <div className="bg-gray-100 h-32 overflow-auto p-2 font-mono">
+        {logs.map((l, i) => (
+          <div key={i}>{l}</div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client/src/workers/eslintWorker.ts
+++ b/client/src/workers/eslintWorker.ts
@@ -1,0 +1,17 @@
+export {};
+/// <reference lib="webworker" />
+
+declare const eslint: any;
+
+importScripts('https://unpkg.com/eslint4b@7.32.0/dist/eslint4b.js');
+
+const linter = new eslint.Linter();
+
+self.onmessage = (event: MessageEvent<{ code: string }>) => {
+  try {
+    const messages = linter.verify(event.data.code, { rules: { semi: 2 } });
+    (self as DedicatedWorkerGlobalScope).postMessage({ messages });
+  } catch (error: any) {
+    (self as DedicatedWorkerGlobalScope).postMessage({ error: (error as Error).message });
+  }
+};

--- a/client/src/workers/prettierWorker.ts
+++ b/client/src/workers/prettierWorker.ts
@@ -1,0 +1,20 @@
+export {};
+/// <reference lib="webworker" />
+
+declare const prettier: any;
+declare const prettierPlugins: any;
+
+importScripts('https://unpkg.com/prettier@2.8.8/standalone.js');
+importScripts('https://unpkg.com/prettier@2.8.8/parser-babel.js');
+
+self.onmessage = (event: MessageEvent<{ code: string }>) => {
+  try {
+    const formatted = prettier.format(event.data.code, {
+      parser: 'babel',
+      plugins: [prettierPlugins.babel],
+    });
+    (self as DedicatedWorkerGlobalScope).postMessage({ formatted });
+  } catch (error: any) {
+    (self as DedicatedWorkerGlobalScope).postMessage({ error: (error as Error).message });
+  }
+};

--- a/client/src/workers/runnerWorker.ts
+++ b/client/src/workers/runnerWorker.ts
@@ -1,0 +1,20 @@
+export {};
+/// <reference lib="webworker" />
+
+(self as any).console = {
+  log: (...args: unknown[]) => {
+    (self as DedicatedWorkerGlobalScope).postMessage({ type: 'log', message: args.map(a => String(a)).join(' ') });
+  },
+};
+
+self.onmessage = (event: MessageEvent<{ code: string }>) => {
+  try {
+    // eslint-disable-next-line no-eval
+    const result = eval(event.data.code);
+    if (result !== undefined) {
+      (self as DedicatedWorkerGlobalScope).postMessage({ type: 'log', message: String(result) });
+    }
+  } catch (error: any) {
+    (self as DedicatedWorkerGlobalScope).postMessage({ type: 'error', error: (error as Error).message });
+  }
+};


### PR DESCRIPTION
## Summary
- add web worker wrappers to run Prettier, ESLint and sandboxed JS
- expose `/web-worker-demo` page with action bar and output panel
- document the web worker demo in client README

## Testing
- `npm test` *(fails: payment mutations › creates a payment via POST)*

------
https://chatgpt.com/codex/tasks/task_e_68b11dec272083289296e834082394fe