### PR TITLE
Add share button with Web Share API fallback

### DIFF
--- a/client/src/app/(nondashboard)/search/[id]/property-overview.tsx
+++ b/client/src/app/(nondashboard)/search/[id]/property-overview.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import { useGetPropertyQuery } from "@/state/api";
 import { MapPin, Star } from "lucide-react";
 import React from "react";
+import ShareButton from "@/components/share-button";
 
 const PropertyOverview = ({ propertyId }: PropertyOverviewProps) => {
   const {
@@ -31,13 +34,14 @@ const PropertyOverview = ({ propertyId }: PropertyOverviewProps) => {
             {property.location?.city}, {property.location?.state},{" "}
             {property.location?.country}
           </span>
-          <div className="flex justify-between items-center gap-3">
+          <div className="flex items-center gap-3">
             <span className="flex items-center text-yellow-500">
               <Star className="w-4 h-4 mr-1 fill-current" />
               {property.averageRating.toFixed(1)} ({property.numberOfReviews}{" "}
               Reviews)
             </span>
             <span className="text-green-600">Verified Listing</span>
+            <ShareButton title={property.name} />
           </div>
         </div>
       </div>

--- a/client/src/components/share-button.tsx
+++ b/client/src/components/share-button.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Share2 } from "lucide-react";
+import { toast } from "sonner";
+
+interface ShareButtonProps {
+  /**
+   * Title of the resource being shared. Used for both the
+   * Web Share API and X fallbacks.
+   */
+  title: string;
+  /**
+   * Optional text description for the share payload. If not provided,
+   * the title will be reused.
+   */
+  text?: string;
+}
+
+/**
+ * A reusable button that attempts to share the current page using the
+ * [Web Share API](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share).
+ * If the API is unavailable, the page URL is copied to the clipboard and the
+ * X share dialog is opened as a fallback.
+ */
+const ShareButton = ({ title, text }: ShareButtonProps) => {
+  const handleShare = async () => {
+    const url = typeof window !== "undefined" ? window.location.href : "";
+    const shareText = text || title;
+
+    const shareData = { title, text: shareText, url };
+
+    if (navigator.share) {
+      try {
+        await navigator.share(shareData);
+        return;
+      } catch (err) {
+        // fall through to clipboard/X fallback if share is aborted or fails
+        console.error("Share failed", err);
+      }
+    }
+
+    try {
+      await navigator.clipboard.writeText(url);
+      toast("Link copied to clipboard");
+    } catch (err) {
+      console.error("Clipboard copy failed", err);
+    }
+
+    const xUrl = `https://x.com/intent/post?text=${encodeURIComponent(
+      shareText
+    )}&url=${encodeURIComponent(url)}`;
+    window.open(xUrl, "_blank");
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="icon"
+      aria-label="share"
+      onClick={handleShare}
+    >
+      <Share2 className="h-4 w-4" />
+    </Button>
+  );
+};
+
+export default ShareButton;
+

--- a/client/tests/payments-api.test.ts
+++ b/client/tests/payments-api.test.ts
@@ -76,7 +76,9 @@ describe('payment mutations', () => {
     };
 
     const result = await store
-      .dispatch(api.endpoints.createPayment.initiate({ id: 1, ...body }))
+      .dispatch(
+        api.endpoints.createPayment.initiate({ leaseId: 1, ...body })
+      )
       .unwrap();
 
     const req = fetchMock.mock.calls[0][0] as any;


### PR DESCRIPTION
## Summary
- implement reusable ShareButton that uses Web Share API, falling back to clipboard copy and X share link
- include ShareButton on property overview page for easy listing sharing
- fix payments API test to pass leaseId correctly

## Testing
- `npm test`
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b11df53c608328a83fcf0fab7163be