### PR TITLE
feat: add custom mood playlists

### DIFF
--- a/client/src/app/moods/page.tsx
+++ b/client/src/app/moods/page.tsx
@@ -1,0 +1,10 @@
+import MoodManager from "@/components/mood-manager";
+
+export default function MoodPage() {
+  return (
+    <main className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Moods</h1>
+      <MoodManager />
+    </main>
+  );
+}

--- a/client/src/components/mood-manager.tsx
+++ b/client/src/components/mood-manager.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { loadMoods, saveMoods, reorder } from "@/lib/moods";
+
+const MoodManager = () => {
+  const [moods, setMoods] = useState<string[]>([]);
+  const [newMood, setNewMood] = useState("");
+
+  useEffect(() => {
+    loadMoods().then(setMoods);
+  }, []);
+
+  const addMood = async () => {
+    const trimmed = newMood.trim();
+    if (!trimmed) return;
+    const updated = [...moods, trimmed];
+    setMoods(updated);
+    setNewMood("");
+    await saveMoods(updated);
+  };
+
+  const moveMood = async (index: number, direction: number) => {
+    const target = index + direction;
+    if (target < 0 || target >= moods.length) return;
+    const updated = reorder(moods, index, target);
+    setMoods(updated);
+    await saveMoods(updated);
+  };
+
+  return (
+    <div className="space-y-4">
+      <ul className="space-y-2">
+        {moods.map((mood, idx) => (
+          <li key={mood} className="flex items-center space-x-2">
+            <span className="flex-1">{mood}</span>
+            <button
+              type="button"
+              aria-label="move up"
+              onClick={() => moveMood(idx, -1)}
+              className="px-2 border rounded"
+            >
+              ↑
+            </button>
+            <button
+              type="button"
+              aria-label="move down"
+              onClick={() => moveMood(idx, 1)}
+              className="px-2 border rounded"
+            >
+              ↓
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div className="flex space-x-2">
+        <input
+          value={newMood}
+          onChange={(e) => setNewMood(e.target.value)}
+          placeholder="Add mood"
+          className="flex-1 border p-2 rounded"
+        />
+        <button type="button" onClick={addMood} className="px-4 py-2 border rounded">
+          Add
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default MoodManager;

--- a/client/src/lib/__tests__/playlist.test.ts
+++ b/client/src/lib/__tests__/playlist.test.ts
@@ -1,0 +1,16 @@
+import { getPlaylistForMood } from "../playlist";
+import { loadMoods } from "../moods";
+
+jest.mock("../moods", () => ({
+  loadMoods: jest.fn(),
+}));
+
+const mockedLoad = loadMoods as jest.MockedFunction<typeof loadMoods>;
+
+describe("getPlaylistForMood", () => {
+  it("uses custom moods when mood not found", async () => {
+    mockedLoad.mockResolvedValue(["Happy", "Energetic"]);
+    const playlist = await getPlaylistForMood("Unknown");
+    expect(playlist).toEqual(["happy-song-1", "happy-song-2"]);
+  });
+});

--- a/client/src/lib/moods.ts
+++ b/client/src/lib/moods.ts
@@ -1,0 +1,32 @@
+import { readOPFSFile, writeOPFSFile } from "./opfs";
+
+export type Mood = string;
+
+const MOODS_FILE = "moods.json";
+export const DEFAULT_MOODS: Mood[] = ["Happy", "Relaxed", "Focused"];
+
+export async function loadMoods(): Promise<Mood[]> {
+  const text = await readOPFSFile(MOODS_FILE);
+  if (text) {
+    try {
+      const parsed = JSON.parse(text);
+      if (Array.isArray(parsed)) {
+        return parsed as Mood[];
+      }
+    } catch {
+      // ignore parse errors
+    }
+  }
+  return DEFAULT_MOODS;
+}
+
+export async function saveMoods(moods: Mood[]): Promise<void> {
+  await writeOPFSFile(MOODS_FILE, JSON.stringify(moods));
+}
+
+export function reorder<T>(items: T[], from: number, to: number): T[] {
+  const arr = [...items];
+  const [item] = arr.splice(from, 1);
+  arr.splice(to, 0, item);
+  return arr;
+}

--- a/client/src/lib/opfs.ts
+++ b/client/src/lib/opfs.ts
@@ -1,0 +1,34 @@
+export async function readOPFSFile(fileName: string): Promise<string | null> {
+  if (
+    typeof navigator === "undefined" ||
+    !("storage" in navigator) ||
+    !(navigator as any).storage.getDirectory
+  ) {
+    return null;
+  }
+
+  try {
+    const root = await (navigator as any).storage.getDirectory();
+    const handle = await root.getFileHandle(fileName);
+    const file = await handle.getFile();
+    return await file.text();
+  } catch {
+    return null;
+  }
+}
+
+export async function writeOPFSFile(fileName: string, contents: string): Promise<void> {
+  if (
+    typeof navigator === "undefined" ||
+    !("storage" in navigator) ||
+    !(navigator as any).storage.getDirectory
+  ) {
+    return;
+  }
+
+  const root = await (navigator as any).storage.getDirectory();
+  const handle = await root.getFileHandle(fileName, { create: true });
+  const writable = await handle.createWritable();
+  await writable.write(contents);
+  await writable.close();
+}

--- a/client/src/lib/playlist.ts
+++ b/client/src/lib/playlist.ts
@@ -1,0 +1,13 @@
+import { loadMoods } from "./moods";
+
+const playlists: Record<string, string[]> = {
+  Happy: ["happy-song-1", "happy-song-2"],
+  Relaxed: ["relaxed-song-1"],
+  Focused: ["focused-song-1"],
+};
+
+export async function getPlaylistForMood(mood: string): Promise<string[]> {
+  const moods = await loadMoods();
+  const chosen = moods.includes(mood) ? mood : moods[0];
+  return playlists[chosen] || [];
+}


### PR DESCRIPTION
## Summary
- load and save user mood categories via OPFS
- provide UI to add or reorder moods
- update playlist selection to honor custom moods

## Testing
- `cd client && npm test` *(fails: tests/payments-api.test.ts expected lease id 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b11df9626883289f4e243cb7276fa5