### PR TITLE
feat: add printable timeline with skills

### DIFF
--- a/client/src/apps/about/Timeline.tsx
+++ b/client/src/apps/about/Timeline.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import React from 'react';
+
+interface Cert {
+  name: string;
+  badge: string;
+}
+
+interface Milestone {
+  year: string;
+  title: string;
+  description: string;
+  certs?: Cert[];
+}
+
+const milestones: Milestone[] = [
+  {
+    year: '2018',
+    title: 'Started Engineering Program',
+    description: 'Began studies in computer engineering focusing on software development.',
+  },
+  {
+    year: '2021',
+    title: 'Cloud Certification',
+    description: 'Achieved professional cloud certification and led migration project.',
+    certs: [
+      {
+        name: 'AWS Certified Cloud Practitioner',
+        badge: 'https://img.shields.io/badge/AWS-Cloud%20Practitioner-orange',
+      },
+    ],
+  },
+  {
+    year: '2024',
+    title: 'Senior Developer',
+    description: 'Promoted to senior developer leading a small team.',
+  },
+];
+
+const skills = [
+  { name: 'React', level: 5 },
+  { name: 'Node.js', level: 4 },
+  { name: 'TypeScript', level: 4 },
+  { name: 'GraphQL', level: 3 },
+  { name: 'AWS', level: 4 },
+];
+
+export default function Timeline() {
+  return (
+    <div className="timeline p-4 print:p-0">
+      <ol className="relative border-l border-gray-200 print:border-black">
+        {milestones.map((item) => (
+          <li key={item.year} className="mb-10 ml-4">
+            <div className="absolute w-3 h-3 bg-primary-500 rounded-full -left-1.5 border border-white print:border-black" />
+            <time className="mb-1 text-sm leading-none text-gray-400 print:text-black">{item.year}</time>
+            <h3 className="text-lg font-semibold text-gray-900 print:text-black">{item.title}</h3>
+            <p className="mb-4 text-base font-normal text-gray-500 print:text-black">{item.description}</p>
+            {item.certs && (
+              <div className="flex gap-2 flex-wrap">
+                {item.certs.map((cert) => (
+                  <img key={cert.name} src={cert.badge} alt={cert.name} className="h-8 w-auto print:h-6" />
+                ))}
+              </div>
+            )}
+          </li>
+        ))}
+      </ol>
+      <section className="mt-8">
+        <h3 className="text-lg font-semibold mb-2 print:text-black">Skill Heatmap</h3>
+        <div className="grid grid-cols-5 gap-4">
+          {skills.map((skill) => (
+            <div key={skill.name} className="text-center">
+              <div
+                className="w-8 h-8 mx-auto rounded-sm bg-primary-500"
+                style={{ opacity: skill.level / 5 }}
+              />
+              <div className="text-xs mt-1 text-gray-700 print:text-black">{skill.name}</div>
+            </div>
+          ))}
+        </div>
+      </section>
+      <style
+        dangerouslySetInnerHTML={{
+          __html: `@media print {\n  .timeline {\n    font-size: 12px;\n    width: 100%;\n  }\n  li {\n    page-break-inside: avoid;\n    break-inside: avoid;\n  }\n}`,
+        }}
+      />
+    </div>
+  );
+}

--- a/client/src/apps/about/__tests__/Timeline.test.tsx
+++ b/client/src/apps/about/__tests__/Timeline.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Timeline from '../Timeline';
+
+describe('Timeline component', () => {
+  it('renders milestone titles', () => {
+    render(React.createElement(Timeline));
+    expect(screen.getByText('Started Engineering Program')).toBeTruthy();
+    expect(screen.getByText('Cloud Certification')).toBeTruthy();
+  });
+
+  it('renders certification badges', () => {
+    render(React.createElement(Timeline));
+    expect(
+      screen.getByAltText('AWS Certified Cloud Practitioner')
+    ).toBeTruthy();
+  });
+
+  it('renders skill heatmap', () => {
+    render(React.createElement(Timeline));
+    expect(screen.getByText('React')).toBeTruthy();
+  });
+});

--- a/client/tailwind.config.ts
+++ b/client/tailwind.config.ts
@@ -7,6 +7,7 @@ const config: Config = {
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/apps/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
   	extend: {

--- a/client/tsconfig.jest.json
+++ b/client/tsconfig.jest.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
-    "types": ["jest"]
+    "types": ["jest"],
+    "jsx": "react-jsx"
   }
 }


### PR DESCRIPTION
## Summary
- add about timeline with milestones, cert badges, and skill heatmap
- enable Tailwind and Jest configs for new apps modules

## Testing
- `npm test`
- `npm test src/apps/about/__tests__/Timeline.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b11e0776988328957d678aeaa64791