### PR TITLE
feat: add accessibility preferences and tokens

### DIFF
--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -90,6 +90,30 @@ body,
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
   }
+
+  :root[data-high-contrast='true'] {
+    --background: 0 0% 0%;
+    --foreground: 0 0% 100%;
+    --primary: 60 100% 50%;
+    --primary-foreground: 0 0% 0%;
+  }
+
+  :root[data-large-targets='true'] {
+    --target-size: 44px;
+  }
+
+  :root[data-large-targets='true'] button,
+  :root[data-large-targets='true'] input,
+  :root[data-large-targets='true'] select {
+    min-height: var(--target-size);
+    min-width: var(--target-size);
+  }
+
+  :root[data-reduce-motion='true'] * {
+    transition-duration: 0ms !important;
+    animation-duration: 0ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
 .dashboard-container {
@@ -177,14 +201,12 @@ body,
 /* Amplify UI Overrides */
 [data-amplify-authenticator] {
   --amplify-components-button-primary-background-color: var(--primary);
-  --amplify-components-button-primary-hover-background-color: hsl(
-    var(--primary) / 0.9
-  );
+  --amplify-components-button-primary-hover-background-color: hsl(var(--primary) / 0.9);
   --amplify-components-button-border-radius: var(--radius);
   --amplify-components-fieldcontrol-border-radius: var(--radius);
 }
 
-[data-amplify-authenticator][data-variation="default"] {
+[data-amplify-authenticator][data-variation='default'] {
   height: 100%;
   padding: 2rem !important;
 }
@@ -254,6 +276,6 @@ body,
 }
 
 /* Sonner Toast Styles */
-[data-close-button="true"] {
+[data-close-button='true'] {
   @apply bg-background border-border text-foreground hover:bg-muted;
 }

--- a/client/src/app/preferences-provider.tsx
+++ b/client/src/app/preferences-provider.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import { useAppDispatch, useAppSelector } from '@/state/redux';
+import { setPreferences } from '@/state/preferences';
+
+const PreferencesProvider = ({ children }: { children: React.ReactNode }) => {
+  const dispatch = useAppDispatch();
+  const prefs = useAppSelector((state) => state.preferences);
+
+  useEffect(() => {
+    const stored = typeof window !== 'undefined' ? localStorage.getItem('preferences') : null;
+    if (stored) {
+      dispatch(setPreferences(JSON.parse(stored)));
+    } else {
+      const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      dispatch(setPreferences({ reduceMotion: prefersReduced }));
+    }
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem('preferences', JSON.stringify(prefs));
+    const root = document.documentElement;
+    root.dataset.highContrast = String(prefs.highContrast);
+    root.dataset.largeTargets = String(prefs.largeTargets);
+    root.dataset.reduceMotion = String(prefs.reduceMotion);
+  }, [prefs]);
+
+  return <>{children}</>;
+};
+
+export default PreferencesProvider;

--- a/client/src/app/providers.tsx
+++ b/client/src/app/providers.tsx
@@ -1,17 +1,20 @@
-"use client";
+'use client';
 
-import StoreProvider from "@/state/redux";
-import { Authenticator } from "@aws-amplify/ui-react";
-import Auth from "./(auth)/auth-provider";
-import { ThemeProvider } from "next-themes";
+import StoreProvider from '@/state/redux';
+import PreferencesProvider from './preferences-provider';
+import { Authenticator } from '@aws-amplify/ui-react';
+import Auth from './(auth)/auth-provider';
+import { ThemeProvider } from 'next-themes';
 
 const Providers = ({ children }: { children: React.ReactNode }) => {
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
       <StoreProvider>
-        <Authenticator.Provider>
-          <Auth>{children}</Auth>
-        </Authenticator.Provider>
+        <PreferencesProvider>
+          <Authenticator.Provider>
+            <Auth>{children}</Auth>
+          </Authenticator.Provider>
+        </PreferencesProvider>
       </StoreProvider>
     </ThemeProvider>
   );

--- a/client/src/components/settings-form.tsx
+++ b/client/src/components/settings-form.tsx
@@ -1,21 +1,23 @@
-import { SettingsFormData, settingsSchema } from "@/lib/schemas";
-import { zodResolver } from "@hookform/resolvers/zod";
-import React, { useState } from "react";
-import { useForm } from "react-hook-form";
-import { Form } from "./ui/form";
-import { CustomFormField } from "./form-field";
-import { Button } from "./ui/button";
+import { SettingsFormData, settingsSchema } from '@/lib/schemas';
+import { zodResolver } from '@hookform/resolvers/zod';
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { Form } from './ui/form';
+import { CustomFormField } from './form-field';
+import { Button } from './ui/button';
+import { Switch } from './ui/switch';
+import { Label } from './ui/label';
+import { useAppDispatch, useAppSelector } from '@/state/redux';
+import { toggleHighContrast, toggleLargeTargets, toggleReduceMotion } from '@/state/preferences';
 
-const SettingsForm = ({
-  initialData,
-  onSubmit,
-  userType,
-}: SettingsFormProps) => {
+const SettingsForm = ({ initialData, onSubmit, userType }: SettingsFormProps) => {
   const [editMode, setEditMode] = useState(false);
   const form = useForm<SettingsFormData>({
     resolver: zodResolver(settingsSchema),
     defaultValues: initialData,
   });
+  const dispatch = useAppDispatch();
+  const prefs = useAppSelector((state) => state.preferences);
 
   const toggleEditMode = () => {
     setEditMode(!editMode);
@@ -41,22 +43,10 @@ const SettingsForm = ({
       </div>
       <div className="bg-white rounded-xl p-6">
         <Form {...form}>
-          <form
-            onSubmit={form.handleSubmit(handleSubmit)}
-            className="space-y-6"
-          >
+          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
             <CustomFormField name="name" label="Name" disabled={!editMode} />
-            <CustomFormField
-              name="email"
-              label="Email"
-              type="email"
-              disabled={!editMode}
-            />
-            <CustomFormField
-              name="phoneNumber"
-              label="Phone Number"
-              disabled={!editMode}
-            />
+            <CustomFormField name="email" label="Email" type="email" disabled={!editMode} />
+            <CustomFormField name="phoneNumber" label="Phone Number" disabled={!editMode} />
 
             <div className="pt-4 flex justify-between">
               <Button
@@ -64,19 +54,45 @@ const SettingsForm = ({
                 onClick={toggleEditMode}
                 className="bg-secondary-500 text-white hover:bg-secondary-600"
               >
-                {editMode ? "Cancel" : "Edit"}
+                {editMode ? 'Cancel' : 'Edit'}
               </Button>
               {editMode && (
-                <Button
-                  type="submit"
-                  className="bg-primary-700 text-white hover:bg-primary-800"
-                >
+                <Button type="submit" className="bg-primary-700 text-white hover:bg-primary-800">
                   Save Changes
                 </Button>
               )}
             </div>
           </form>
         </Form>
+        <div className="mt-8 border-t pt-4">
+          <h2 className="text-lg font-medium mb-4">Accessibility</h2>
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="high-contrast">High Contrast</Label>
+              <Switch
+                id="high-contrast"
+                checked={prefs.highContrast}
+                onCheckedChange={() => dispatch(toggleHighContrast())}
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <Label htmlFor="large-targets">Larger Targets</Label>
+              <Switch
+                id="large-targets"
+                checked={prefs.largeTargets}
+                onCheckedChange={() => dispatch(toggleLargeTargets())}
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <Label htmlFor="reduce-motion">Reduce Motion</Label>
+              <Switch
+                id="reduce-motion"
+                checked={prefs.reduceMotion}
+                onCheckedChange={() => dispatch(toggleReduceMotion())}
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/client/src/lib/__tests__/accessibility.test.ts
+++ b/client/src/lib/__tests__/accessibility.test.ts
@@ -1,0 +1,13 @@
+import { prefersReducedMotion } from '../accessibility';
+
+describe('motion preference', () => {
+  it('returns true when system prefers reduced motion', () => {
+    (window as any).matchMedia = () => ({
+      matches: true,
+      media: '(prefers-reduced-motion: reduce)',
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    });
+    expect(prefersReducedMotion()).toBe(true);
+  });
+});

--- a/client/src/lib/accessibility.ts
+++ b/client/src/lib/accessibility.ts
@@ -1,0 +1,4 @@
+export const prefersReducedMotion = () => {
+  if (typeof window === 'undefined') return false;
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+};

--- a/client/src/state/preferences.ts
+++ b/client/src/state/preferences.ts
@@ -1,0 +1,37 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export interface PreferencesState {
+  highContrast: boolean;
+  largeTargets: boolean;
+  reduceMotion: boolean;
+}
+
+const initialState: PreferencesState = {
+  highContrast: false,
+  largeTargets: false,
+  reduceMotion: false,
+};
+
+const preferencesSlice = createSlice({
+  name: 'preferences',
+  initialState,
+  reducers: {
+    toggleHighContrast(state) {
+      state.highContrast = !state.highContrast;
+    },
+    toggleLargeTargets(state) {
+      state.largeTargets = !state.largeTargets;
+    },
+    toggleReduceMotion(state) {
+      state.reduceMotion = !state.reduceMotion;
+    },
+    setPreferences(state, action: PayloadAction<Partial<PreferencesState>>) {
+      return { ...state, ...action.payload };
+    },
+  },
+});
+
+export const { toggleHighContrast, toggleLargeTargets, toggleReduceMotion, setPreferences } =
+  preferencesSlice.actions;
+
+export default preferencesSlice.reducer;

--- a/client/src/state/redux.tsx
+++ b/client/src/state/redux.tsx
@@ -1,40 +1,37 @@
-"use client";
+'use client';
 
-import { useRef } from "react";
-import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
-import { combineReducers, configureStore } from "@reduxjs/toolkit";
-import { Provider } from "react-redux";
-import { setupListeners } from "@reduxjs/toolkit/query";
-import globalReducer from "@/state";
-import { api } from "@/state/api";
+import { useRef } from 'react';
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
+import { setupListeners } from '@reduxjs/toolkit/query';
+import globalReducer from '@/state';
+import preferencesReducer from '@/state/preferences';
+import { api } from '@/state/api';
 
 /* REDUX STORE */
 const rootReducer = combineReducers({
   global: globalReducer,
+  preferences: preferencesReducer,
   [api.reducerPath]: api.reducer,
 });
 
 export const makeStore = () => {
   return configureStore({
     reducer: rootReducer,
-    middleware: (getDefaultMiddleware) =>
-      getDefaultMiddleware().concat(api.middleware),
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(api.middleware),
   });
 };
 
 /* REDUX TYPES */
 export type AppStore = ReturnType<typeof makeStore>;
-export type RootState = ReturnType<AppStore["getState"]>;
-export type AppDispatch = AppStore["dispatch"];
+export type RootState = ReturnType<AppStore['getState']>;
+export type AppDispatch = AppStore['dispatch'];
 export const useAppDispatch = () => useDispatch<AppDispatch>();
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 
 /* PROVIDER */
-export default function StoreProvider({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function StoreProvider({ children }: { children: React.ReactNode }) {
   const storeRef = useRef<AppStore | null>(null);
   if (!storeRef.current) {
     storeRef.current = makeStore();

--- a/client/src/theme/__tests__/tokens.test.ts
+++ b/client/src/theme/__tests__/tokens.test.ts
@@ -1,0 +1,20 @@
+import { highContrastTokens } from '../tokens';
+
+function luminance(hex: string) {
+  const rgb = [0, 1, 2].map((i) => {
+    const c = parseInt(hex.substr(1 + i * 2, 2), 16) / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2];
+}
+
+function contrast(hex1: string, hex2: string) {
+  const l1 = luminance(hex1);
+  const l2 = luminance(hex2);
+  return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+}
+
+test('high contrast tokens meet WCAG AAA contrast', () => {
+  const ratio = contrast(highContrastTokens.background, highContrastTokens.foreground);
+  expect(ratio).toBeGreaterThanOrEqual(7);
+});

--- a/client/src/theme/tokens.ts
+++ b/client/src/theme/tokens.ts
@@ -1,0 +1,18 @@
+export const highContrastTokens = {
+  background: '#000000',
+  foreground: '#ffffff',
+  primary: '#ffff00',
+  secondary: '#00ffff',
+};
+
+export const largeTargetTokens = {
+  targetSize: 44, // minimum size in pixels
+};
+
+export type AccessibilityTokens = {
+  background: string;
+  foreground: string;
+  primary: string;
+  secondary: string;
+  targetSize: number;
+};


### PR DESCRIPTION
## Summary
- add high-contrast and large-target theme tokens
- persist accessibility preferences and apply through provider
- expose accessibility toggles in Settings and validate contrast & motion

## Testing
- `npm test src/theme/__tests__/tokens.test.ts src/lib/__tests__/accessibility.test.ts`
- `npm test` *(fails: payment mutations: Expected: "http://localhost:3001/leases/1/payments" Received: "http://localhost:3001/leases/undefined/payments")*
- `npm test` (server)
- `npm run lint` *(fails: Code style issues found in 105 files. Run Prettier with --write to fix.)*


------
https://chatgpt.com/codex/tasks/task_e_68b11e1741b483289b087f2be60d843f