### PR TITLE
feat: add gamepad mapping with OPFS profiles

### DIFF
--- a/client/src/app/gamepad-mapping/page.tsx
+++ b/client/src/app/gamepad-mapping/page.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { GamepadProfile, saveGamepadProfile, loadGamepadProfile } from "@/lib/gamepad";
+
+export default function GamepadMappingPage() {
+  const [gamepad, setGamepad] = useState<Gamepad | null>(null);
+  const [gameId, setGameId] = useState("default");
+  const [profile, setProfile] = useState<GamepadProfile>({ buttons: {}, axes: {} });
+
+  useEffect(() => {
+    const update = () => {
+      const pads = navigator.getGamepads?.();
+      for (const gp of pads) {
+        if (gp) {
+          setGamepad(gp);
+          break;
+        }
+      }
+    };
+    window.addEventListener("gamepadconnected", update);
+    window.addEventListener("gamepaddisconnected", update);
+    update();
+    return () => {
+      window.removeEventListener("gamepadconnected", update);
+      window.removeEventListener("gamepaddisconnected", update);
+    };
+  }, []);
+
+  useEffect(() => {
+    loadGamepadProfile(gameId).then((p) => {
+      if (p) setProfile(p);
+    });
+  }, [gameId]);
+
+  const handleSave = async () => {
+    await saveGamepadProfile(gameId, profile);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Gamepad Mapping</h1>
+      <label className="block">
+        <span className="mr-2">Game ID:</span>
+        <input
+          value={gameId}
+          onChange={(e) => setGameId(e.target.value)}
+          className="border px-2 py-1"
+        />
+      </label>
+      {gamepad ? (
+        <div className="space-y-4">
+          <div>
+            <h2 className="text-xl font-semibold">Buttons</h2>
+            {gamepad.buttons.map((_, idx) => (
+              <div key={idx} className="flex items-center gap-2 my-1">
+                <span className="w-24">Button {idx}</span>
+                <input
+                  value={profile.buttons[idx] || ""}
+                  onChange={(e) =>
+                    setProfile((prev) => ({
+                      ...prev,
+                      buttons: { ...prev.buttons, [idx]: e.target.value },
+                    }))
+                  }
+                  className="border px-2 py-1 flex-1"
+                />
+              </div>
+            ))}
+          </div>
+          <div>
+            <h2 className="text-xl font-semibold">Axes</h2>
+            {gamepad.axes.map((_, idx) => (
+              <div key={idx} className="flex items-center gap-2 my-1">
+                <span className="w-24">Axis {idx}</span>
+                <input
+                  value={profile.axes[idx] || ""}
+                  onChange={(e) =>
+                    setProfile((prev) => ({
+                      ...prev,
+                      axes: { ...prev.axes, [idx]: e.target.value },
+                    }))
+                  }
+                  className="border px-2 py-1 flex-1"
+                />
+              </div>
+            ))}
+          </div>
+          <button onClick={handleSave} className="px-3 py-1 bg-blue-500 text-white">
+            Save Profile
+          </button>
+        </div>
+      ) : (
+        <p>No gamepad detected.</p>
+      )}
+    </div>
+  );
+}

--- a/client/src/app/games/[gameId]/page.tsx
+++ b/client/src/app/games/[gameId]/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useEffect } from "react";
+import { loadGamepadProfile } from "@/lib/gamepad";
+
+export default function GamePage({ params }: { params: { gameId: string } }) {
+  useEffect(() => {
+    loadGamepadProfile(params.gameId).then((profile) => {
+      console.log("Loaded profile", profile);
+    });
+  }, [params.gameId]);
+
+  return <div className="p-4">Launching game {params.gameId}...</div>;
+}

--- a/client/src/lib/gamepad.ts
+++ b/client/src/lib/gamepad.ts
@@ -1,0 +1,29 @@
+export interface GamepadProfile {
+  buttons: Record<number, string>;
+  axes: Record<number, string>;
+}
+
+const DIR_NAME = "gamepad-profiles";
+
+export async function saveGamepadProfile(gameId: string, profile: GamepadProfile) {
+  if (typeof navigator === "undefined" || !navigator.storage?.getDirectory) return;
+  const root = await navigator.storage.getDirectory();
+  const dir = await root.getDirectoryHandle(DIR_NAME, { create: true });
+  const file = await dir.getFileHandle(`${gameId}.json`, { create: true });
+  const writable = await file.createWritable();
+  await writable.write(JSON.stringify(profile));
+  await writable.close();
+}
+
+export async function loadGamepadProfile(gameId: string): Promise<GamepadProfile | null> {
+  if (typeof navigator === "undefined" || !navigator.storage?.getDirectory) return null;
+  try {
+    const root = await navigator.storage.getDirectory();
+    const dir = await root.getDirectoryHandle(DIR_NAME, { create: true });
+    const file = await dir.getFileHandle(`${gameId}.json`);
+    const data = await (await file.getFile()).text();
+    return JSON.parse(data) as GamepadProfile;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add gamepad mapping UI listing buttons and axes
- persist per-game gamepad profiles to OPFS
- load stored mappings when launching games

## Testing
- `npm test` (failed: payment mutations › creates a payment via POST)
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b11e1a4de8832893af69814c84d0e7