### PR TITLE
Add OPFS trash management and Settings UI

### DIFF
--- a/client/src/__tests__/opfs.test.ts
+++ b/client/src/__tests__/opfs.test.ts
@@ -1,0 +1,13 @@
+import { isExpired, DEFAULT_MAX_AGE_MS } from "@/lib/opfs";
+
+interface Entry { path: string; deletedAt: number }
+
+describe("isExpired", () => {
+  it("flags entries older than max age", () => {
+    const now = Date.now();
+    const old: Entry = { path: "old", deletedAt: now - DEFAULT_MAX_AGE_MS - 1000 };
+    const fresh: Entry = { path: "fresh", deletedAt: now - 1000 };
+    expect(isExpired(old, now)).toBe(true);
+    expect(isExpired(fresh, now)).toBe(false);
+  });
+});

--- a/client/src/app/settings/page.tsx
+++ b/client/src/app/settings/page.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+
+export default function SettingsPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Settings</h1>
+      <ul className="list-disc pl-4">
+        <li>
+          <Link href="/settings/trash" className="text-blue-600 underline">
+            Trash
+          </Link>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/client/src/app/settings/trash/page.tsx
+++ b/client/src/app/settings/trash/page.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { listTrash, restoreFromTrash, TrashEntry, purgeOldTrash } from "@/lib/opfs";
+
+export default function TrashPage() {
+  const [items, setItems] = useState<TrashEntry[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      await purgeOldTrash();
+      const entries = await listTrash();
+      setItems(entries);
+    }
+    load();
+  }, []);
+
+  async function handleRestore(path: string) {
+    await restoreFromTrash(path);
+    setItems(await listTrash());
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Trash</h1>
+      {items.length === 0 ? (
+        <p>No items in trash.</p>
+      ) : (
+        <ul>
+          {items.map((item) => (
+            <li key={item.path} className="mb-2 flex justify-between">
+              <span>{item.path}</span>
+              <button
+                onClick={() => handleRestore(item.path)}
+                className="text-blue-600 underline"
+              >
+                Restore
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/client/src/lib/opfs.ts
+++ b/client/src/lib/opfs.ts
@@ -1,0 +1,106 @@
+const TRASH_DIR = "trash";
+const METADATA_FILE = "index.json";
+export const DEFAULT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+export interface TrashEntry {
+  path: string;
+  deletedAt: number;
+}
+
+function hasOPFS(): boolean {
+  return typeof navigator !== "undefined" && !!(navigator as any).storage?.getDirectory;
+}
+
+async function getTrashDir(create = true): Promise<FileSystemDirectoryHandle | undefined> {
+  if (!hasOPFS()) return undefined;
+  const root = await (navigator as any).storage.getDirectory();
+  try {
+    return await root.getDirectoryHandle(TRASH_DIR, { create });
+  } catch {
+    return undefined;
+  }
+}
+
+async function readMetadata(dir: FileSystemDirectoryHandle): Promise<TrashEntry[]> {
+  try {
+    const fileHandle = await dir.getFileHandle(METADATA_FILE, { create: true });
+    const file = await fileHandle.getFile();
+    const text = await file.text();
+    return text ? (JSON.parse(text) as TrashEntry[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeMetadata(dir: FileSystemDirectoryHandle, entries: TrashEntry[]): Promise<void> {
+  const fileHandle = await dir.getFileHandle(METADATA_FILE, { create: true });
+  const writable = await fileHandle.createWritable();
+  await writable.write(JSON.stringify(entries));
+  await writable.close();
+}
+
+export function isExpired(entry: TrashEntry, now: number = Date.now(), maxAgeMs: number = DEFAULT_MAX_AGE_MS): boolean {
+  return now - entry.deletedAt > maxAgeMs;
+}
+
+export async function moveToTrash(path: string): Promise<void> {
+  const dir = await getTrashDir(true);
+  if (!dir || !hasOPFS()) return;
+  const root = await (navigator as any).storage.getDirectory();
+  const fileName = path.split("/").pop() as string;
+  const source = await root.getFileHandle(path);
+  const dest = await dir.getFileHandle(fileName, { create: true });
+  const file = await source.getFile();
+  const writable = await dest.createWritable();
+  await writable.write(file);
+  await writable.close();
+  await root.removeEntry(path);
+  const entries = await readMetadata(dir);
+  entries.push({ path, deletedAt: Date.now() });
+  await writeMetadata(dir, entries);
+}
+
+export async function listTrash(): Promise<TrashEntry[]> {
+  const dir = await getTrashDir(false);
+  if (!dir) return [];
+  await purgeOldTrash();
+  return readMetadata(dir);
+}
+
+export async function restoreFromTrash(path: string): Promise<void> {
+  const dir = await getTrashDir(false);
+  if (!dir || !hasOPFS()) return;
+  const root = await (navigator as any).storage.getDirectory();
+  const fileName = path.split("/").pop() as string;
+  const source = await dir.getFileHandle(fileName);
+  const dest = await root.getFileHandle(path, { create: true });
+  const file = await source.getFile();
+  const writable = await dest.createWritable();
+  await writable.write(file);
+  await writable.close();
+  await dir.removeEntry(fileName);
+  const entries = (await readMetadata(dir)).filter((e) => e.path !== path);
+  await writeMetadata(dir, entries);
+}
+
+export async function purgeOldTrash(maxAgeMs: number = DEFAULT_MAX_AGE_MS): Promise<void> {
+  const dir = await getTrashDir(false);
+  if (!dir) return;
+  const now = Date.now();
+  const entries = await readMetadata(dir);
+  const remaining: TrashEntry[] = [];
+  for (const entry of entries) {
+    if (isExpired(entry, now, maxAgeMs)) {
+      try {
+        const fileName = entry.path.split("/").pop() as string;
+        await dir.removeEntry(fileName);
+      } catch {
+        // ignore missing files
+      }
+    } else {
+      remaining.push(entry);
+    }
+  }
+  await writeMetadata(dir, remaining);
+}
+

--- a/client/tests/payments-api.test.ts
+++ b/client/tests/payments-api.test.ts
@@ -76,7 +76,7 @@ describe('payment mutations', () => {
     };
 
     const result = await store
-      .dispatch(api.endpoints.createPayment.initiate({ id: 1, ...body }))
+      .dispatch(api.endpoints.createPayment.initiate({ leaseId: 1, ...body }))
       .unwrap();
 
     const req = fetchMock.mock.calls[0][0] as any;


### PR DESCRIPTION
## Summary
- add OPFS utilities to move files to `trash/`, restore, and purge items older than 30 days
- introduce Settings → Trash page to list and restore deleted items
- cover trash expiration logic with a unit test and fix payment API test parameter

## Testing
- `cd client && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b11e7a07a08328baed097d62625af0