### PR TITLE
feat: add compact gauge with doc pip pinning

### DIFF
--- a/client/src/components/__tests__/compact-gauge.test.tsx
+++ b/client/src/components/__tests__/compact-gauge.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { CompactGauge } from '../compact-gauge';
+
+jest.useFakeTimers();
+
+describe('CompactGauge', () => {
+  it('updates value at regular interval', () => {
+    let current = 0;
+    const getValue = jest.fn(() => ++current);
+    render(React.createElement(CompactGauge, { getValue }));
+    expect(screen.getByText('1')).toBeTruthy();
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    expect(screen.getByText('2')).toBeTruthy();
+  });
+
+  it('opens and closes Document PiP window', async () => {
+    const getValue = jest.fn(() => 50);
+    const pipWindow: any = {
+      document: {
+        write: jest.fn(),
+        close: jest.fn(),
+        getElementById: jest.fn(() => ({ textContent: '', value: 0 })),
+      },
+      addEventListener: jest.fn((evt, cb) => { pipWindow._close = cb; }),
+      removeEventListener: jest.fn(),
+      close: jest.fn(() => pipWindow._close && pipWindow._close()),
+      _close: null,
+    };
+    (window as any).documentPictureInPicture = {
+      requestWindow: jest.fn().mockResolvedValue(pipWindow),
+    };
+
+    render(React.createElement(CompactGauge, { getValue }));
+
+    const pinBtn = screen.getByRole('button', { name: /pin to pip/i });
+    await act(async () => {
+      fireEvent.click(pinBtn);
+    });
+    expect((window as any).documentPictureInPicture.requestWindow).toHaveBeenCalled();
+
+    // Simulate closing the PiP window
+    act(() => {
+      pipWindow._close();
+    });
+    expect(pinBtn.textContent).toBe('Pin');
+  });
+});

--- a/client/src/components/compact-gauge.tsx
+++ b/client/src/components/compact-gauge.tsx
@@ -1,0 +1,100 @@
+"use client";
+import React, { useEffect, useRef, useState } from "react";
+
+interface CompactGaugeProps {
+  /**
+   * Function returning current value for the gauge (0-100)
+   */
+  getValue: () => number;
+}
+
+interface DocumentPictureInPicture {
+  requestWindow: (options?: { width?: number; height?: number }) => Promise<Window>;
+}
+
+declare global {
+  interface Window {
+    documentPictureInPicture?: DocumentPictureInPicture;
+  }
+}
+
+/**
+ * Compact gauge component that updates its value every <200ms
+ * and can be pinned into a Document Picture-in-Picture window.
+ */
+export const CompactGauge: React.FC<CompactGaugeProps> = ({ getValue }) => {
+  const [value, setValue] = useState<number>(getValue());
+  const [pinned, setPinned] = useState(false);
+  const pipWindowRef = useRef<Window | null>(null);
+
+  // Update gauge value at a 200ms interval
+  useEffect(() => {
+    const id = setInterval(() => {
+      const v = getValue();
+      setValue(v);
+      // Reflect updates inside PiP window if open
+      if (pipWindowRef.current) {
+        const doc = pipWindowRef.current.document;
+        const valueEl = doc.getElementById("pip-gauge-value") as HTMLSpanElement | null;
+        const progressEl = doc.getElementById("pip-gauge-progress") as HTMLProgressElement | null;
+        if (valueEl) valueEl.textContent = v.toFixed(0);
+        if (progressEl) progressEl.value = v;
+      }
+    }, 200);
+    return () => clearInterval(id);
+  }, [getValue]);
+
+  const handlePiPClose = () => {
+    pipWindowRef.current = null;
+    setPinned(false);
+  };
+
+  // Open Document Picture-in-Picture window
+  const openPiP = async () => {
+    if (pipWindowRef.current || !window.documentPictureInPicture) return;
+    const pip = await window.documentPictureInPicture.requestWindow({ width: 160, height: 96 });
+    pip.document.write(
+      `<html><body style="margin:0;display:flex;align-items:center;justify-content:center;font-family:sans-serif;background:#fff;">
+        <div><progress id="pip-gauge-progress" max="100" value="${value}" style="width:100px;height:6px"></progress>
+        <div style="text-align:center;font-size:12px"><span id="pip-gauge-value">${value.toFixed(0)}</span></div></div>
+       </body></html>`
+    );
+    pip.document.close();
+    pip.addEventListener("pagehide", handlePiPClose);
+    pipWindowRef.current = pip;
+    setPinned(true);
+  };
+
+  // Close PiP window
+  const closePiP = () => {
+    if (pipWindowRef.current) {
+      pipWindowRef.current.removeEventListener("pagehide", handlePiPClose);
+      pipWindowRef.current.close();
+      pipWindowRef.current = null;
+    }
+    setPinned(false);
+  };
+
+  // Ensure PiP window is closed on unmount
+  useEffect(() => {
+    return () => closePiP();
+  }, []);
+
+  return (
+    <div className="compact-gauge flex items-center space-x-2">
+      <progress max={100} value={value} className="h-2 w-24" aria-label="gauge" />
+      <span className="text-sm">{value.toFixed(0)}</span>
+      {"documentPictureInPicture" in window && (
+        <button
+          onClick={pinned ? closePiP : openPiP}
+          aria-label="pin to pip"
+          className="ml-2 text-xs px-2 py-1 border rounded"
+        >
+          {pinned ? "Unpin" : "Pin"}
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default CompactGauge;

--- a/client/tsconfig.jest.json
+++ b/client/tsconfig.jest.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
-    "types": ["jest"]
+    "types": ["jest"],
+    "jsx": "react-jsx"
   }
 }


### PR DESCRIPTION
## Summary
- add compact gauge updating every 200ms
- support pinning gauge to Document Picture-in-Picture with close event sync
- enable JSX compilation for Jest

## Testing
- `npm test` *(fails: tests/payments-api.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b11e20f3a883289016c863566b18f4